### PR TITLE
Places APIキーを環境ごとに分ける

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # dot env
 .env.local
+.env.*.local
 
 # secrets
 secrets

--- a/cmd/batch/delete_expired_plan_candidates/main.go
+++ b/cmd/batch/delete_expired_plan_candidates/main.go
@@ -3,26 +3,14 @@ package main
 import (
 	"context"
 	"log"
-	"os"
+	"poroto.app/poroto/planner/internal/env"
 	"time"
 
-	"github.com/joho/godotenv"
 	"poroto.app/poroto/planner/internal/domain/services/plancandidate"
 )
 
 func init() {
-	env := os.Getenv("ENV")
-	if "" == env {
-		env = "development"
-	}
-
-	if err := godotenv.Load(".env.local"); err != nil {
-		log.Fatalf("error while loading .env.local: %v", err)
-	}
-
-	if err := godotenv.Load(".env." + env); err != nil {
-		log.Fatalf("error while loading .env.%s: %v", env, err)
-	}
+	env.LoadEnv()
 }
 
 // 有効期限切れのプラン候補を削除する

--- a/cmd/cloudfunctions/main.go
+++ b/cmd/cloudfunctions/main.go
@@ -3,26 +3,15 @@ package main
 import (
 	"log"
 	"os"
+	"poroto.app/poroto/planner/internal/env"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
-	"github.com/joho/godotenv"
 	"poroto.app/poroto/planner/internal/interface/cloudfunctions"
 )
 
 func init() {
-	env := os.Getenv("ENV")
-	if "" == env {
-		env = "development"
-	}
-
-	if err := godotenv.Load(".env.local"); err != nil {
-		log.Fatalf("error while loading .env.local: %v", err)
-	}
-
-	if err := godotenv.Load(".env." + env); err != nil {
-		log.Fatalf("error while loading .env.%s: %v", env, err)
-	}
+	env.LoadEnv()
 
 	functions.HTTP("DeleteExpiredPlanCandidates", cloudfunctions.DeleteExpiredPlanCandidates)
 }

--- a/cmd/migrate/migrate_place_entity.go
+++ b/cmd/migrate/migrate_place_entity.go
@@ -3,27 +3,16 @@ package main
 import (
 	"cloud.google.com/go/firestore"
 	"context"
-	"github.com/joho/godotenv"
 	"google.golang.org/api/option"
 	"log"
 	"os"
 	"poroto.app/poroto/planner/internal/domain/utils"
+	"poroto.app/poroto/planner/internal/env"
 	"time"
 )
 
 func init() {
-	env := os.Getenv("ENV")
-	if "" == env {
-		env = "development"
-	}
-
-	if err := godotenv.Load(".env.local"); err != nil {
-		log.Fatalf("error while loading .env.local: %v", err)
-	}
-
-	if err := godotenv.Load(".env." + env); err != nil {
-		log.Fatalf("error while loading .env.%s: %v", env, err)
-	}
+	env.LoadEnv()
 }
 
 // PlanEntity 2023/10/4

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,24 +3,13 @@ package main
 import (
 	"log"
 	"os"
+	"poroto.app/poroto/planner/internal/env"
 
-	"github.com/joho/godotenv"
 	"poroto.app/poroto/planner/internal/interface/rest"
 )
 
 func init() {
-	env := os.Getenv("ENV")
-	if "" == env {
-		env = "development"
-	}
-
-	if err := godotenv.Load(".env.local"); err != nil {
-		log.Fatalf("error while loading .env.local: %v", err)
-	}
-
-	if err := godotenv.Load(".env." + env); err != nil {
-		log.Fatalf("error while loading .env.%s: %v", env, err)
-	}
+	env.LoadEnv()
 }
 
 func main() {

--- a/internal/env/load_env.go
+++ b/internal/env/load_env.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"fmt"
 	"github.com/joho/godotenv"
 	"log"
 	"os"
@@ -16,7 +17,11 @@ func LoadEnv() {
 		log.Fatalf("error while loading .env.local: %v", err)
 	}
 
-	if err := godotenv.Load(".env." + env); err != nil {
+	if err := godotenv.Load(fmt.Sprintf(".env.%s", env)); err != nil {
 		log.Fatalf("error while loading .env.%s: %v", env, err)
+	}
+
+	if err := godotenv.Load(fmt.Sprintf(".env.%s.local", env)); err != nil {
+		log.Fatalf("error while loading .env: %v", err)
 	}
 }

--- a/internal/env/load_env.go
+++ b/internal/env/load_env.go
@@ -1,0 +1,22 @@
+package env
+
+import (
+	"github.com/joho/godotenv"
+	"log"
+	"os"
+)
+
+func LoadEnv() {
+	env := os.Getenv("ENV")
+	if "" == env {
+		env = "development"
+	}
+
+	if err := godotenv.Load(".env.local"); err != nil {
+		log.Fatalf("error while loading .env.local: %v", err)
+	}
+
+	if err := godotenv.Load(".env." + env); err != nil {
+		log.Fatalf("error while loading .env.%s: %v", env, err)
+	}
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,3 +10,15 @@ bash scripts/decrypt.sh
 ```shell
 bash scripts/decrypt.sh production
 ```
+### encrypt.sh
+planner リポジトリのシークレットを暗号化するスクリプト
+
+開発環境で利用するシークレットを暗号化
+```shell
+bash scripts/encrypt.sh
+```
+
+プロダクション環境で利用するシークレットを暗号化
+```shell
+bash scripts/encrypt.sh production
+```

--- a/scripts/decrypt.sh
+++ b/scripts/decrypt.sh
@@ -36,13 +36,13 @@ fi
 
 case "$env" in
 "development")
-  secrets_variable=("secrets/google-credential.json")
+  secrets_variable=("secrets/google-credential.json" ".env.development.local")
   ;;
 "staging")
-  secrets_variable=("secrets/google-credential.json")
+  secrets_variable=("secrets/google-credential.json" ".env.staging.local")
   ;;
 "production")
-  secrets_variable=("secrets/google-credential.json")
+  secrets_variable=("secrets/google-credential.json" ".env.production.local")
   ;;
 esac
 

--- a/scripts/encrypt.sh
+++ b/scripts/encrypt.sh
@@ -3,9 +3,44 @@
 #   - planner
 #   - infrastructure
 
-gcloud kms encrypt \
-  --location "asia-northeast1" \
-  --keyring "planner_api_key_ring" \
-  --key "planner_api_crypt_key" \
-  --plaintext-file ./.env.local \
-  --ciphertext-file ../infrastructure/roles/app/planner/production/.env.local.enc
+function encrypt() {
+  environment=$1
+  file=$2
+
+  echo "[${environment}] Encrypting ${file} ..."
+  gcloud kms encrypt \
+    --location "asia-northeast1" \
+    --keyring "planner_api_key_ring" \
+    --key "planner_api_crypt_key" \
+    --plaintext-file "${file}" \
+    --ciphertext-file "../infrastructure/roles/app/planner/${environment}/${file}.enc" || exit 1
+  echo ">> [${environment}] Encrypted ${file}!"
+}
+
+# 環境設定（デフォルトはdevelopment）
+env=$1
+if [ -z "${env}" ]; then
+  env="development"
+fi
+
+# 共通のシークレットを復号化
+secrets=(".env.local")
+for file in "${secrets[@]}"; do
+  encrypt "production" "${file}"
+done
+
+case "$env" in
+"development")
+  secrets_variable=(".env.development.local")
+  ;;
+"staging")
+  secrets_variable=(".env.staging.local")
+  ;;
+"production")
+  secrets_variable=(".env.production.local")
+  ;;
+esac
+
+for file in "${secrets_variable[@]}"; do
+  encrypt "${env}" "${file}"
+done


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Places APIキーを環境ごとに分けるために、環境ごとの`.env.*.local`を作成し、それを読み込むようにした


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- API呼び出しの利用を環境ごとに管理できるようにするため

### どのようにテストされているか
- [ ] ~~プラン作成できることを確認~~
- [ ] ~~プランを保存できることを確認~~
- [ ] ~~porotoで問題なく動作できることを確認~~
- [x] `go run cmd/server/main.go`を実行できることを確認

※ Places APIの過度な呼び出しを防ぐために、プラン作成は行っていない

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```