### PR TITLE
Places APIの呼び出し件数を減らす

### DIFF
--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -132,7 +132,7 @@ func (r *queryResolver) AvailablePlacesForPlan(ctx context.Context, input model.
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	availablePlaces, err := s.FetchCandidatePlaces(ctx, input.Session)
+	availablePlaces, err := s.FetchCandidatePlaces(ctx, input.Session, 4)
 	if err != nil {
 		log.Println("error while fetching candidate places: ", err)
 		return nil, fmt.Errorf("internal server error")

--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -59,6 +59,7 @@ func (r *queryResolver) MatchInterests(ctx context.Context, input *model.MatchIn
 			Longitude: input.Longitude,
 		},
 		createPlanSessionId,
+		3,
 	)
 	if err != nil {
 		log.Printf("error while searching categories for session[%s]: %v", createPlanSessionId, err)
@@ -97,6 +98,7 @@ func (r *queryResolver) NearbyPlaceCategories(ctx context.Context, input model.N
 			Longitude: input.Longitude,
 		},
 		createPlanSessionId,
+		3,
 	)
 	if err != nil {
 		log.Printf("error while searching categories for session[%s]: %v", createPlanSessionId, err)

--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -54,12 +54,13 @@ func (r *queryResolver) MatchInterests(ctx context.Context, input *model.MatchIn
 
 	categoriesSearched, err := service.CategoriesNearLocation(
 		ctx,
-		models.GeoLocation{
-			Latitude:  input.Latitude,
-			Longitude: input.Longitude,
+		plancandidate.CategoryNearLocationParams{
+			Location: models.GeoLocation{
+				Latitude:  input.Latitude,
+				Longitude: input.Longitude,
+			},
+			CreatePlanSessionId: createPlanSessionId,
 		},
-		createPlanSessionId,
-		3,
 	)
 	if err != nil {
 		log.Printf("error while searching categories for session[%s]: %v", createPlanSessionId, err)
@@ -93,12 +94,13 @@ func (r *queryResolver) NearbyPlaceCategories(ctx context.Context, input model.N
 
 	categoriesSearched, err := service.CategoriesNearLocation(
 		ctx,
-		models.GeoLocation{
-			Latitude:  input.Latitude,
-			Longitude: input.Longitude,
+		plancandidate.CategoryNearLocationParams{
+			Location: models.GeoLocation{
+				Latitude:  input.Latitude,
+				Longitude: input.Longitude,
+			},
+			CreatePlanSessionId: createPlanSessionId,
 		},
-		createPlanSessionId,
-		3,
 	)
 	if err != nil {
 		log.Printf("error while searching categories for session[%s]: %v", createPlanSessionId, err)

--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -157,7 +157,7 @@ func (r *queryResolver) PlacesToAddForPlanCandidate(ctx context.Context, input m
 	}
 
 	// TODO: 指定されたプランIDが不正だった場合の対処をする
-	placesToAdd, err := s.FetchPlacesToAdd(ctx, input.PlanCandidateID, input.PlanID, 10)
+	placesToAdd, err := s.FetchPlacesToAdd(ctx, input.PlanCandidateID, input.PlanID, 4)
 	if err != nil {
 		log.Println("error while fetching places to add: ", err)
 		return nil, fmt.Errorf("internal server error")
@@ -181,7 +181,7 @@ func (r *queryResolver) PlacesToReplaceForPlanCandidate(ctx context.Context, inp
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	placesToReplace, err := s.FetchPlacesToReplace(ctx, input.PlanCandidateID, input.PlanID, input.PlaceID, 10)
+	placesToReplace, err := s.FetchPlacesToReplace(ctx, input.PlanCandidateID, input.PlanID, input.PlaceID, 4)
 	if err != nil {
 		log.Println("error while fetching places to replace: ", err)
 		return nil, fmt.Errorf("internal server error")

--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -28,6 +28,7 @@ func (s Service) FetchPlacesPhotos(ctx context.Context, places []models.GooglePl
 			photos, err := s.placesApi.FetchPlacePhotos(
 				ctx,
 				place.PlaceId,
+				1,
 				api.ImageSizeTypeSmall,
 				api.ImageSizeTypeLarge,
 			)

--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -17,7 +17,6 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, location models.GeoLoca
 		maps.PlaceTypeAquarium,
 		maps.PlaceTypeAmusementPark,
 		maps.PlaceTypeCafe,
-		maps.PlaceTypeMovieTheater,
 		maps.PlaceTypeMuseum,
 		maps.PlaceTypeRestaurant,
 		maps.PlaceTypeShoppingMall,

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -11,18 +11,32 @@ import (
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
 )
 
+const (
+	defaultMaxCategory          = 3
+	defaultMaxPlacesPerCategory = 1
+)
+
+type CategoryNearLocationParams struct {
+	Location             models.GeoLocation
+	CreatePlanSessionId  string
+	MaxCategory          int
+	MaxPlacesPerCategory int
+}
+
 // TODO: PlanGeneratorServiceに持っていく
 func (s Service) CategoriesNearLocation(
 	ctx context.Context,
-	location models.GeoLocation,
-	createPlanSessionId string,
-	nLimit int,
+	params CategoryNearLocationParams,
 ) ([]models.LocationCategoryWithPlaces, error) {
-	if nLimit <= 0 {
-		panic("nLimit must be greater than 0")
+	if params.MaxCategory <= 0 {
+		params.MaxCategory = defaultMaxCategory
 	}
 
-	placesSearched, err := s.placeService.SearchNearbyPlaces(ctx, location)
+	if params.MaxPlacesPerCategory <= 0 {
+		params.MaxPlacesPerCategory = defaultMaxPlacesPerCategory
+	}
+
+	placesSearched, err := s.placeService.SearchNearbyPlaces(ctx, params.Location)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places: %v\n", err)
 	}
@@ -32,7 +46,7 @@ func (s Service) CategoriesNearLocation(
 		places = append(places, factory.PlaceInPlanCandidateFromGooglePlace(uuid.New().String(), googlePlace))
 	}
 
-	if err := s.placeInPlanCandidateRepository.SavePlaces(ctx, createPlanSessionId, places); err != nil {
+	if err := s.placeInPlanCandidateRepository.SavePlaces(ctx, params.CreatePlanSessionId, places); err != nil {
 		return nil, fmt.Errorf("error while saving places to cache: %v\n", err)
 	}
 
@@ -54,7 +68,7 @@ func (s Service) CategoriesNearLocation(
 	categoriesWithPlaces := make([]models.LocationCategoryWithPlaces, 0)
 	for _, categoryPlaces := range placeCategoryGroups {
 		// 取得したカテゴリが上限に達したら終了
-		if len(categoriesWithPlaces) >= nLimit {
+		if len(categoriesWithPlaces) >= params.MaxCategory {
 			break
 		}
 
@@ -79,17 +93,17 @@ func (s Service) CategoriesNearLocation(
 			return true
 		})
 
-		// カテゴリと関連の強い場所の最初の5件の写真を取得する
+		// カテゴリと関連の強い場所の最初の1件の写真を取得する
 		placesSortedByCategoryIndex := placesNotUsedInOtherCategory
 		sort.Slice(placesSortedByCategoryIndex, func(i, j int) bool {
 			return placesSortedByCategoryIndex[i].Google.IndexOfCategory(*category) < placesSortedByCategoryIndex[j].Google.IndexOfCategory(*category)
 		})
-		if len(placesSortedByCategoryIndex) > 5 {
-			placesSortedByCategoryIndex = placesSortedByCategoryIndex[:5]
+		if len(placesSortedByCategoryIndex) > params.MaxPlacesPerCategory {
+			placesSortedByCategoryIndex = placesSortedByCategoryIndex[:params.MaxPlacesPerCategory]
 		}
 
 		// 場所の写真を取得する
-		placesWithPhotos := s.placeService.FetchPlacesInPlanCandidatePhotosAndSave(ctx, createPlanSessionId, placesSortedByCategoryIndex...)
+		placesWithPhotos := s.placeService.FetchPlacesInPlanCandidatePhotosAndSave(ctx, params.CreatePlanSessionId, placesSortedByCategoryIndex...)
 
 		places := make([]models.Place, 0)
 		for _, place := range placesWithPhotos {

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -16,7 +16,12 @@ func (s Service) CategoriesNearLocation(
 	ctx context.Context,
 	location models.GeoLocation,
 	createPlanSessionId string,
+	nLimit int,
 ) ([]models.LocationCategoryWithPlaces, error) {
+	if nLimit <= 0 {
+		panic("nLimit must be greater than 0")
+	}
+
 	placesSearched, err := s.placeService.SearchNearbyPlaces(ctx, location)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places: %v\n", err)
@@ -48,6 +53,11 @@ func (s Service) CategoriesNearLocation(
 	// 検索された場所のカテゴリとその写真を取得
 	categoriesWithPlaces := make([]models.LocationCategoryWithPlaces, 0)
 	for _, categoryPlaces := range placeCategoryGroups {
+		// 取得したカテゴリが上限に達したら終了
+		if len(categoriesWithPlaces) >= nLimit {
+			break
+		}
+
 		category := models.GetCategoryOfName(categoryPlaces.category)
 		if category == nil {
 			continue

--- a/internal/domain/services/plancandidate/place.go
+++ b/internal/domain/services/plancandidate/place.go
@@ -10,15 +10,16 @@ import (
 	googleplaces "poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
-const (
-	maxAddablePlaces = 10
-)
-
 // FetchCandidatePlaces はプランの候補となる場所を取得する
 func (s Service) FetchCandidatePlaces(
 	ctx context.Context,
 	createPlanSessionId string,
+	nLimit int,
 ) (*[]models.Place, error) {
+	if nLimit <= 0 {
+		panic("nLimit must be greater than 0")
+	}
+
 	placesSaved, err := s.placeInPlanCandidateRepository.FindByPlanCandidateId(ctx, createPlanSessionId)
 	if err != nil {
 		return nil, err
@@ -64,7 +65,7 @@ func (s Service) FetchCandidatePlaces(
 
 		placesToSuggest = append(placesToSuggest, place.ToPlace())
 
-		if len(placesToSuggest) >= maxAddablePlaces {
+		if len(placesToSuggest) >= nLimit {
 			break
 		}
 	}

--- a/internal/domain/services/plangen/create.go
+++ b/internal/domain/services/plangen/create.go
@@ -88,6 +88,7 @@ func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesPa
 	for _, place := range placesSorted {
 		// プランに含まれる場所の数が上限に達したら終了
 		if len(placesInPlan) >= params.maxPlace {
+			log.Printf("skip place %s because the number of places in plan is over\n", place.Google.Name)
 			break
 		}
 

--- a/internal/domain/services/plangen/create.go
+++ b/internal/domain/services/plangen/create.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	defaultMaxPlanDuration = 180
+	defaultMaxPlace        = 4
 )
 
 type CreatePlanPlacesParams struct {
@@ -23,10 +24,15 @@ type CreatePlanPlacesParams struct {
 	freeTime                     *int
 	createBasedOnCurrentLocation bool
 	shouldOpenWhileTraveling     bool
+	maxPlace                     int
 }
 
 // createPlanPlaces プランの候補地となる場所を作成する
 func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesParams) ([]models.PlaceInPlanCandidate, error) {
+	if params.maxPlace == 0 {
+		params.maxPlace = defaultMaxPlace
+	}
+
 	placesFiltered := params.places
 
 	// 現在、開いている場所のみに絞る
@@ -80,6 +86,11 @@ func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesPa
 	}
 
 	for _, place := range placesSorted {
+		// プランに含まれる場所の数が上限に達したら終了
+		if len(placesInPlan) >= params.maxPlace {
+			break
+		}
+
 		if place.Id == params.placeStart.Id {
 			continue
 		}

--- a/internal/domain/services/plangen/create_by_location.go
+++ b/internal/domain/services/plangen/create_by_location.go
@@ -178,7 +178,6 @@ func (s Service) findOrFetchPlaceById(
 		return place, true, nil
 	}
 
-	// TODO: キャッシュする
 	googlePlaceEntity, err := s.placesApi.FetchPlace(ctx, googleplaces.FetchPlaceRequest{
 		PlaceId:  googlePlaceId,
 		Language: "ja",

--- a/internal/infrastructure/api/google/places/details.go
+++ b/internal/infrastructure/api/google/places/details.go
@@ -2,6 +2,7 @@ package places
 
 import (
 	"context"
+	"log"
 
 	"googlemaps.github.io/maps"
 )
@@ -14,6 +15,8 @@ type FetchPlaceRequest struct {
 // FetchPlace は IDを指定することで、対応する場所の情報を取得する
 // 取得される内容は FindPlacesFromLocation と同じ
 func (r PlacesApi) FetchPlace(ctx context.Context, req FetchPlaceRequest) (*Place, error) {
+	log.Println("Places API Place Details: ", req)
+
 	resp, err := r.mapsClient.PlaceDetails(ctx, &maps.PlaceDetailsRequest{
 		PlaceID:  req.PlaceId,
 		Language: req.Language,

--- a/internal/infrastructure/api/google/places/nearbysearch.go
+++ b/internal/infrastructure/api/google/places/nearbysearch.go
@@ -3,6 +3,7 @@ package places
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"googlemaps.github.io/maps"
@@ -12,6 +13,7 @@ import (
 // https://developers.google.com/maps/documentation/places/web-service/search-nearby
 // pageCount は 1 以上の整数で、ページング処理を行う回数を指定する。
 func (r PlacesApi) nearBySearch(ctx context.Context, req *maps.NearbySearchRequest, pagesCount int) ([]maps.PlacesSearchResult, error) {
+	log.Printf("Places API Nearby Search: %+v\n", req)
 	if pagesCount < 1 {
 		pagesCount = 1
 	}

--- a/internal/infrastructure/api/google/places/opening.go
+++ b/internal/infrastructure/api/google/places/opening.go
@@ -14,7 +14,7 @@ type PlaceOpeningPeriod struct {
 }
 
 func (r PlacesApi) FetchPlaceOpeningPeriods(ctx context.Context, googlePlaceId string) ([]PlaceOpeningPeriod, error) {
-	log.Printf("Places API Fetch Place Opening Periods: %+v\n", googlePlaceId)
+	log.Printf("Places API Place Details for opening hours: %s\n", googlePlaceId)
 
 	resp, err := r.mapsClient.PlaceDetails(ctx, &maps.PlaceDetailsRequest{
 		PlaceID: googlePlaceId,

--- a/internal/infrastructure/api/google/places/opening.go
+++ b/internal/infrastructure/api/google/places/opening.go
@@ -2,6 +2,7 @@ package places
 
 import (
 	"context"
+	"log"
 
 	"googlemaps.github.io/maps"
 )
@@ -13,6 +14,8 @@ type PlaceOpeningPeriod struct {
 }
 
 func (r PlacesApi) FetchPlaceOpeningPeriods(ctx context.Context, googlePlaceId string) ([]PlaceOpeningPeriod, error) {
+	log.Printf("Places API Fetch Place Opening Periods: %+v\n", googlePlaceId)
+
 	resp, err := r.mapsClient.PlaceDetails(ctx, &maps.PlaceDetailsRequest{
 		PlaceID: googlePlaceId,
 		Fields: []maps.PlaceDetailsFieldMask{

--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -128,7 +128,9 @@ func (r PlacesApi) FetchPlacePhoto(photoReferences []string, imageSize ImageSize
 
 // FetchPlacePhotos は，指定された場所の写真を全件取得する
 // imageSizeTypes が指定されている場合は，高画質の写真を取得する
-func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, imageSizeTypes ...ImageSizeType) ([]PlacePhoto, error) {
+// 画像取得は呼び出し料金が高いため、複数の場所の写真を取得するときは注意
+// https://developers.google.com/maps/documentation/places/web-service/usage-and-billing?hl=ja#places-photo-new
+func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, maxPhotoCount int, imageSizeTypes ...ImageSizeType) ([]PlacePhoto, error) {
 	if len(imageSizeTypes) == 0 {
 		imageSizeTypes = []ImageSizeType{ImageSizeTypeLarge}
 	}
@@ -144,7 +146,11 @@ func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, imageSi
 	}
 
 	ch := make(chan *placePhotoWithSize, len(resp.Photos)*len(imageSizeTypes))
-	for _, photo := range resp.Photos {
+	for i, photo := range resp.Photos {
+		if i >= maxPhotoCount {
+			break
+		}
+
 		for _, imageSizeType := range imageSizeTypes {
 			go func(ctx context.Context, photo maps.Photo, imageSizeType ImageSizeType, ch chan<- *placePhotoWithSize) {
 				imageSize := imageSizeType.ImageSize()

--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -152,6 +152,7 @@ func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, maxPhot
 			go func(ctx context.Context, photoIndex int, photo maps.Photo, imageSizeType ImageSizeType, ch chan<- *placePhotoWithSize) {
 				if photoIndex >= maxPhotoCount {
 					ch <- nil
+					return
 				}
 
 				imageSize := imageSizeType.ImageSize()

--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -131,6 +131,8 @@ func (r PlacesApi) FetchPlacePhoto(photoReferences []string, imageSize ImageSize
 // 画像取得は呼び出し料金が高いため、複数の場所の写真を取得するときは注意
 // https://developers.google.com/maps/documentation/places/web-service/usage-and-billing?hl=ja#places-photo-new
 func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, maxPhotoCount int, imageSizeTypes ...ImageSizeType) ([]PlacePhoto, error) {
+	log.Printf("Places API Fetch Place Photos: %s\n", placeId)
+
 	if len(imageSizeTypes) == 0 {
 		imageSizeTypes = []ImageSizeType{ImageSizeTypeLarge}
 	}

--- a/internal/infrastructure/api/google/places/review.go
+++ b/internal/infrastructure/api/google/places/review.go
@@ -12,7 +12,7 @@ type FetchPlaceReviewRequest struct {
 }
 
 func (r PlacesApi) FetchPlaceReview(ctx context.Context, req FetchPlaceReviewRequest) (*[]maps.PlaceReview, error) {
-	log.Printf("Places API Fetch Place Review: %+v\n", req)
+	log.Printf("Places API Place Details for reviews: %s\n", req.PlaceId)
 
 	resp, err := r.mapsClient.PlaceDetails(ctx, &maps.PlaceDetailsRequest{
 		PlaceID:  req.PlaceId,

--- a/internal/infrastructure/api/google/places/review.go
+++ b/internal/infrastructure/api/google/places/review.go
@@ -3,6 +3,7 @@ package places
 import (
 	"context"
 	"googlemaps.github.io/maps"
+	"log"
 )
 
 type FetchPlaceReviewRequest struct {
@@ -11,6 +12,8 @@ type FetchPlaceReviewRequest struct {
 }
 
 func (r PlacesApi) FetchPlaceReview(ctx context.Context, req FetchPlaceReviewRequest) (*[]maps.PlaceReview, error) {
+	log.Printf("Places API Fetch Place Review: %+v\n", req)
+
 	resp, err := r.mapsClient.PlaceDetails(ctx, &maps.PlaceDetailsRequest{
 		PlaceID:  req.PlaceId,
 		Language: req.Language,


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Places APIが過度に呼び出されないように以下の修正を行った

|項目|before|after|
|---|---|---|
|場所ごとに取得される画像の数|10|1|
|興味選択時に提示される場所の数|x|3|
|カテゴリごとに例示される場所の数|5|1|
|プラン内に含まれる場所の上限|x|4|
|プランに場所を追加するときに提示する場所の数|x|4|
|プラン作成可能な場所として提示する場所の数|x|4|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #303 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- Places APIの過度な呼び出しをしないようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] `go run cmd/server/main.go &> app_log.txt`でプランを作成し、`cat app_log.txt | grep "Places API" | wc -l`としたときのAPI呼び出し数が60件近い値になることを確認（もとは280回）

```shell
# planner
export BRANCH_PLANNER=feature/reduce_places_api_call
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```