### PR TITLE
[Places API呼び出し改善] 画像IDを取得するためにPlaceDetail APIを重複して呼ばないようにする

### DIFF
--- a/doc/google_places_api.md
+++ b/doc/google_places_api.md
@@ -19,6 +19,7 @@ sequenceDiagram
     participant P as planner
     participant NS as Nearby Search
     participant PD as Place Details
+    participant PP as Place Photos
     P ->> NS: 周辺検索（10カテゴリ検索）
     NS ->> P: 周辺の場所（60件程度）
     alt ユーザーが場所を指定してプランを作成した場合
@@ -27,4 +28,5 @@ sequenceDiagram
     end
     P ->> PD: 場所の詳細情報（プランに含まれる12件程度）
     PD ->> P: 場所の詳細情報
+    P -->> PP: 場所の写真（Place DetailでPhoto Referenceを取得後でないと呼び出せない）
 ```

--- a/doc/google_places_api.md
+++ b/doc/google_places_api.md
@@ -1,0 +1,30 @@
+# Google Places API
+
+### 料金体系
+
+https://developers.google.com/maps/documentation/places/web-service/usage-and-billing?hl=ja
+
+- [Places APIはリクエストに含まれるフィールド内で最上位のSKUに基づいて課金される](https://developers.google.com/maps/documentation/places/web-service/usage-and-billing?hl=ja)
+
+### Place Detail APIの呼び出し方
+
+- プラン作成時には複数回、Place Detailによる情報が必要な場面がある（開店時刻、写真、レビュー等）
+- これらのリクエストを別々に行ってしまうと、`SKU料金*リクエスト回数`の料金が発生してしまう
+- したがって、planner では、Place Detailによる情報を一度に取得するようにしている
+
+### リクエストのフロー
+
+```mermaid
+sequenceDiagram
+    participant P as planner
+    participant NS as Nearby Search
+    participant PD as Place Details
+    P ->> NS: 周辺検索（10カテゴリ検索）
+    NS ->> P: 周辺の場所（60件程度）
+    alt ユーザーが場所を指定してプランを作成した場合
+        P ->> PD: ユーザーが指定した場所を検索
+        PD ->> P: 場所の詳細情報
+    end
+    P ->> PD: 場所の詳細情報（プランに含まれる12件程度）
+    PD ->> P: 場所の詳細情報
+```

--- a/internal/domain/factory/google_place_detail.go
+++ b/internal/domain/factory/google_place_detail.go
@@ -7,11 +7,12 @@ import (
 
 func GooglePlaceDetailFromPlaceDetailEntity(placeDetail places.PlaceDetail) models.GooglePlaceDetail {
 	reviews := GooglePlaceReviewsFromPlaceDetail(placeDetail)
-
+	photos := GooglePlacePhotosFromPlaceDetail(placeDetail)
 	openingPeriods := GooglePlaceOpeningPeriodsFromPlaceDetail(placeDetail)
 
 	return models.GooglePlaceDetail{
 		Reviews:      reviews,
+		Photos:       photos,
 		OpeningHours: &openingPeriods,
 	}
 }

--- a/internal/domain/factory/google_place_photo.go
+++ b/internal/domain/factory/google_place_photo.go
@@ -1,0 +1,20 @@
+package factory
+
+import (
+	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/infrastructure/api/google/places"
+)
+
+func GooglePlacePhotosFromPlaceDetail(placeDetail places.PlaceDetail) []models.GooglePlacePhoto {
+	var photos []models.GooglePlacePhoto
+	for _, photo := range placeDetail.Photos {
+		photos = append(photos, models.GooglePlacePhoto{
+			PhotoReference:   photo.PhotoReference,
+			Width:            photo.Width,
+			Height:           photo.Height,
+			HTMLAttributions: photo.HTMLAttributions,
+		})
+	}
+
+	return photos
+}

--- a/internal/domain/models/google_place_detail.go
+++ b/internal/domain/models/google_place_detail.go
@@ -3,4 +3,5 @@ package models
 type GooglePlaceDetail struct {
 	OpeningHours *[]GooglePlaceOpeningPeriod
 	Reviews      []GooglePlaceReview
+	Photos       []GooglePlacePhoto
 }

--- a/internal/domain/models/google_place_photo.go
+++ b/internal/domain/models/google_place_photo.go
@@ -1,0 +1,8 @@
+package models
+
+type GooglePlacePhoto struct {
+	PhotoReference   string
+	Width            int
+	Height           int
+	HTMLAttributions []string
+}

--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -25,9 +25,14 @@ func (s Service) FetchPlacesPhotos(ctx context.Context, places []models.GooglePl
 				return
 			}
 
+			photoReferences := make([]string, len(place.PlaceDetail.Photos))
+			for i, photo := range place.PlaceDetail.Photos {
+				photoReferences[i] = photo.PhotoReference
+			}
+
 			photos, err := s.placesApi.FetchPlacePhotos(
 				ctx,
-				place.PlaceId,
+				photoReferences,
 				1,
 				api.ImageSizeTypeSmall,
 				api.ImageSizeTypeLarge,

--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -75,6 +75,7 @@ func (s Service) FetchPlacesPhotos(ctx context.Context, places []models.GooglePl
 }
 
 // FetchPlacesPhotosAndSave は，指定された場所の写真を一括で取得し，保存する
+// 事前に FetchPlaceDetail で models.GooglePlaceDetail を取得しておく必要がある
 func (s Service) FetchPlacesPhotosAndSave(ctx context.Context, planCandidateId string, places ...models.GooglePlace) []models.GooglePlace {
 	// 写真が取得されていない場所のみ、画像が保存されるようにする
 	var googlePlaceIdsAlreadyHasImages []string

--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -77,10 +77,10 @@ func (s Service) FetchPlacesPhotos(ctx context.Context, places []models.GooglePl
 // FetchPlacesPhotosAndSave は，指定された場所の写真を一括で取得し，保存する
 func (s Service) FetchPlacesPhotosAndSave(ctx context.Context, planCandidateId string, places ...models.GooglePlace) []models.GooglePlace {
 	// 写真が取得されていない場所のみ、画像が保存されるようにする
-	var googlePlaceIdsWithPhotos []string
+	var googlePlaceIdsAlreadyHasImages []string
 	for _, place := range places {
 		if place.Images != nil && len(*place.Images) > 0 {
-			googlePlaceIdsWithPhotos = append(googlePlaceIdsWithPhotos, place.PlaceId)
+			googlePlaceIdsAlreadyHasImages = append(googlePlaceIdsAlreadyHasImages, place.PlaceId)
 		}
 	}
 
@@ -90,7 +90,8 @@ func (s Service) FetchPlacesPhotosAndSave(ctx context.Context, planCandidateId s
 	// 画像を保存
 	for _, place := range places {
 		// すでに写真が取得済みの場合は何もしない
-		if array.IsContain(googlePlaceIdsWithPhotos, place.PlaceId) {
+		alreadyHasImages := array.IsContain(googlePlaceIdsAlreadyHasImages, place.PlaceId)
+		if alreadyHasImages {
 			continue
 		}
 

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -113,8 +113,8 @@ func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId strin
 		googlePlaces = append(googlePlaces, place.Google)
 	}
 
-	googlePlaces = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, googlePlaces...)
 	googlePlaces = s.placeService.FetchPlacesDetail(ctx, googlePlaces)
+	googlePlaces = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, googlePlaces...)
 
 	placeIdToPlaceDetail := make(map[string]placeDetail)
 	for _, place := range places {

--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -17,8 +17,9 @@ type ImageSize struct {
 type ImageSizeType int
 
 type PlacePhoto struct {
-	Small *string
-	Large *string
+	PhotoReference string
+	Small          *string
+	Large          *string
 }
 
 type placePhotoWithSize struct {
@@ -180,6 +181,8 @@ func (r PlacesApi) FetchPlacePhotos(ctx context.Context, photoReferences []strin
 	var placePhotos []PlacePhoto
 	for _, photoReference := range photoReferences {
 		var placePhoto PlacePhoto
+		placePhoto.PhotoReference = photoReference
+
 		for _, placePhotoWithSize := range placePhotoWithSizes {
 			if placePhotoWithSize.photoReference != photoReference {
 				continue

--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-
-	"googlemaps.github.io/maps"
 )
 
 type ImageSize struct {
@@ -130,26 +128,15 @@ func (r PlacesApi) FetchPlacePhoto(photoReferences []string, imageSize ImageSize
 // imageSizeTypes が指定されている場合は，高画質の写真を取得する
 // 画像取得は呼び出し料金が高いため、複数の場所の写真を取得するときは注意
 // https://developers.google.com/maps/documentation/places/web-service/usage-and-billing?hl=ja#places-photo-new
-func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, maxPhotoCount int, imageSizeTypes ...ImageSizeType) ([]PlacePhoto, error) {
+func (r PlacesApi) FetchPlacePhotos(ctx context.Context, photoReferences []string, maxPhotoCount int, imageSizeTypes ...ImageSizeType) ([]PlacePhoto, error) {
 	if len(imageSizeTypes) == 0 {
 		imageSizeTypes = []ImageSizeType{ImageSizeTypeLarge}
 	}
 
-	log.Printf("Places API Place Details for Photo: %s\n", placeId)
-	resp, err := r.mapsClient.PlaceDetails(ctx, &maps.PlaceDetailsRequest{
-		PlaceID: placeId,
-		Fields: []maps.PlaceDetailsFieldMask{
-			maps.PlaceDetailsFieldMaskPhotos,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	ch := make(chan *placePhotoWithSize, len(resp.Photos)*len(imageSizeTypes))
-	for iPhoto, photo := range resp.Photos {
+	ch := make(chan *placePhotoWithSize, len(photoReferences)*len(imageSizeTypes))
+	for iPhoto, photoReference := range photoReferences {
 		for _, imageSizeType := range imageSizeTypes {
-			go func(ctx context.Context, photoIndex int, photo maps.Photo, imageSizeType ImageSizeType, ch chan<- *placePhotoWithSize) {
+			go func(ctx context.Context, photoIndex int, photoReference string, imageSizeType ImageSizeType, ch chan<- *placePhotoWithSize) {
 				if photoIndex >= maxPhotoCount {
 					ch <- nil
 					return
@@ -157,32 +144,32 @@ func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, maxPhot
 
 				imageSize := imageSizeType.ImageSize()
 
-				imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photo.PhotoReference, r.apiKey)
+				imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photoReference, r.apiKey)
 				if err != nil {
-					log.Printf("skipping photo because of error while building image url: %v", err)
+					log.Printf("skipping photoReference because of error while building image url: %v", err)
 					ch <- nil
 					return
 				}
 
-				log.Printf("Places API Fetch Place Photo: %s\n", photo.PhotoReference)
+				log.Printf("Places API Fetch Place Photo: %s\n", photoReference)
 				publicImageUrl, err := fetchPublicImageUrl(imgUrl)
 				if err != nil {
-					log.Printf("skipping photo because of error while fetching public image url: %v", err)
+					log.Printf("skipping photoReference because of error while fetching public image url: %v", err)
 					ch <- nil
 					return
 				}
 
 				ch <- &placePhotoWithSize{
-					photoReference: photo.PhotoReference,
+					photoReference: photoReference,
 					imageUrl:       *publicImageUrl,
 					size:           imageSizeType,
 				}
-			}(ctx, iPhoto, photo, imageSizeType, ch)
+			}(ctx, iPhoto, photoReference, imageSizeType, ch)
 		}
 	}
 
 	var placePhotoWithSizes []*placePhotoWithSize
-	for i := 0; i < len(resp.Photos)*len(imageSizeTypes); i++ {
+	for i := 0; i < len(photoReferences)*len(imageSizeTypes); i++ {
 		placePhotoWithSize := <-ch
 		if placePhotoWithSize == nil {
 			continue
@@ -191,10 +178,10 @@ func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, maxPhot
 	}
 
 	var placePhotos []PlacePhoto
-	for _, photo := range resp.Photos {
+	for _, photoReference := range photoReferences {
 		var placePhoto PlacePhoto
 		for _, placePhotoWithSize := range placePhotoWithSizes {
-			if placePhotoWithSize.photoReference != photo.PhotoReference {
+			if placePhotoWithSize.photoReference != photoReference {
 				continue
 			}
 
@@ -216,7 +203,7 @@ func (r PlacesApi) FetchPlacePhotos(ctx context.Context, placeId string, maxPhot
 	}
 
 	// すべての写真の取得に失敗した場合は、エラーを返す
-	if len(resp.Photos) > 0 && len(placePhotos) == 0 {
+	if len(photoReferences) > 0 && len(placePhotos) == 0 {
 		return nil, fmt.Errorf("could not fetch any photos")
 	}
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Places APIを利用して画像を取得するためには`Nearby Search`や`Place Detail`によって画像のIDを事前に取得する必要がある。
- これまでは、画像を取得する関数のなかでPlaceDetailを呼び出して、その情報をもちいて画像を取得していた。
- これを、PlaceDetailで画像の他に開店時間やレビューを取得する処理と、それを用いて画像を取得する処理に分けた。
- これにより、PlaceDetailが重複して呼ばれることがなくなるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- Place Detail APIの呼び出しを減らすため

### どのようにテストされているか
現段階では機能として完成していないのでテストは行わない