### PR TITLE
Staging環境にデプロイされるようにする

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -2,6 +2,8 @@ name: deploy-production
 run-name: Deploy Production by @${{ github.actor }}
 on:
   push:
+    branches:
+      - main
 jobs:
   deploy-production:
     name: Deploy Production

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -2,8 +2,6 @@ name: deploy-production
 run-name: Deploy Production by @${{ github.actor }}
 on:
   push:
-    branches:
-      - main
 jobs:
   deploy-production:
     name: Deploy Production

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -10,4 +10,8 @@ jobs:
     uses: ./.github/workflows/workflow_deploy.yaml
     with:
       environment: production
-    secrets: inherit
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      GOOGLE_CREDENTIALS_KMS: ${{ secrets.GOOGLE_CREDENTIALS }}
+      # planner は staging用プロジェクトにデプロイする（無料枠に収めるため）
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS_STAGING }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -2,8 +2,6 @@ name: deploy-staging
 run-name: Deploy Staging by @${{ github.actor }}
 on:
   push:
-    branches:
-      - develop 
 jobs:
   deploy-staging:
     name: Deploy Staging

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -2,8 +2,6 @@ name: deploy-staging
 run-name: Deploy Staging by @${{ github.actor }}
 on:
   push:
-    branches:
-      - develop
 jobs:
   deploy-staging:
     name: Deploy Staging

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -10,4 +10,5 @@ jobs:
       environment: staging
     secrets:
       GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      GOOGLE_CREDENTIALS_KMS: ${{ secrets.GOOGLE_CREDENTIALS }}
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS_STAGING }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -10,4 +10,6 @@ jobs:
     uses: ./.github/workflows/workflow_deploy.yaml
     with:
       environment: staging
-    secrets: inherit
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS_STAGING }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -2,6 +2,8 @@ name: deploy-staging
 run-name: Deploy Staging by @${{ github.actor }}
 on:
   push:
+    branches:
+      - develop 
 jobs:
   deploy-staging:
     name: Deploy Staging

--- a/.github/workflows/workflow_deploy.yaml
+++ b/.github/workflows/workflow_deploy.yaml
@@ -10,6 +10,8 @@ on:
     secrets:
       GOOGLE_CREDENTIALS:
         required: true
+      GOOGLE_CREDENTIALS_KMS:
+        required: true
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
 jobs:
@@ -24,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/decrypt_secrets
         with:
-          google_credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          google_credentials_json: ${{ secrets.GOOGLE_CREDENTIALS_KMS }}
           gh_personal_access_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           environment: ${{ inputs.environment }}
       - name: Deploy Cloud Functions
@@ -43,9 +45,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/decrypt_secrets
         with:
-          google_credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          google_credentials_json: ${{ secrets.GOOGLE_CREDENTIALS_KMS }}
           gh_personal_access_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           environment: ${{ inputs.environment }}
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
       # SEE: https://github.com/google-github-actions/deploy-appengine#authorization
       - name: Deploy an App Engine app
         uses: google-github-actions/deploy-appengine@v1

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,4 @@
 runtime: go119
-service: planner
 
 main: ./cmd/server
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Stagingデプロイするときに、Stagingのプロジェクト（poroto-staging）にデプロイされるようにした
- また、Google App Engineの無料枠を利用するため、plannerのProductionデプロイはStagingプロジェクトに対して行う

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- Staging環境にデプロイされていることを確認
![image](https://github.com/poroto-app/planner/assets/55840281/b607e2be-98f9-480e-944b-7b35f890f448)

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```