### PR TITLE
[PlaceRepository] Placeモデルに不要なプロパティを持たせない

### DIFF
--- a/internal/domain/models/category_with_places.go
+++ b/internal/domain/models/category_with_places.go
@@ -9,7 +9,7 @@ func NewLocationCategoryWithPlaces(category LocationCategory, places []Place) Lo
 	var placesToAdd []Place
 	for _, place := range places {
 		// 画像がない場合は追加しない
-		if len(place.Images) == 0 {
+		if place.Google.Photos == nil || len(*place.Google.Photos) == 0 {
 			continue
 		}
 

--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -3,6 +3,7 @@ package models
 // Place 場所の情報
 type Place struct {
 	Id                 string               `json:"id"`
+	Google             GooglePlace          `json:"google"`
 	GooglePlaceId      *string              `json:"google_place_id"`
 	Name               string               `json:"name"`
 	Location           GeoLocation          `json:"location"`
@@ -10,6 +11,15 @@ type Place struct {
 	Categories         []LocationCategory   `json:"categories"`
 	GooglePlaceReviews *[]GooglePlaceReview `json:"google_place_reviews"`
 	PriceLevel         int                  `json:"price_level"`
+}
+
+func NewPlaceFromGooglePlace(placeId string, googlePlace GooglePlace) Place {
+	return Place{
+		Id:       placeId,
+		Google:   googlePlace,
+		Name:     googlePlace.Name,
+		Location: googlePlace.Location,
+	}
 }
 
 func (p Place) MainCategory() *LocationCategory {

--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -2,15 +2,11 @@ package models
 
 // Place 場所の情報
 type Place struct {
-	Id                 string               `json:"id"`
-	Google             GooglePlace          `json:"google"`
-	GooglePlaceId      *string              `json:"google_place_id"`
-	Name               string               `json:"name"`
-	Location           GeoLocation          `json:"location"`
-	Images             []Image              `json:"images"`
-	Categories         []LocationCategory   `json:"categories"`
-	GooglePlaceReviews *[]GooglePlaceReview `json:"google_place_reviews"`
-	PriceLevel         int                  `json:"price_level"`
+	Id            string      `json:"id"`
+	Google        GooglePlace `json:"google"`
+	GooglePlaceId *string     `json:"google_place_id"`
+	Name          string      `json:"name"`
+	Location      GeoLocation `json:"location"`
 }
 
 func NewPlaceFromGooglePlace(placeId string, googlePlace GooglePlace) Place {
@@ -22,11 +18,15 @@ func NewPlaceFromGooglePlace(placeId string, googlePlace GooglePlace) Place {
 	}
 }
 
+func (p Place) Categories() []LocationCategory {
+	return GetCategoriesFromSubCategories(p.Google.Types)
+}
+
 func (p Place) MainCategory() *LocationCategory {
-	if len(p.Categories) == 0 {
+	if len(p.Categories()) == 0 {
 		return nil
 	}
-	return &p.Categories[0]
+	return &p.Categories()[0]
 }
 
 func (p Place) EstimatedStayDuration() uint {

--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -40,5 +40,5 @@ func (p Place) EstimatedStayDuration() uint {
 // EstimatedPriceRange 価格帯を推定する
 func (p Place) EstimatedPriceRange() (priceRange *PriceRange) {
 	// TODO: 飲食店でprice_levelが0の場合は、価格帯が不明なので、nilを返す
-	return PriceRangeFromGooglePriceLevel(p.PriceLevel)
+	return PriceRangeFromGooglePriceLevel(p.Google.PriceLevel)
 }

--- a/internal/domain/models/place_in_plan_candidate.go
+++ b/internal/domain/models/place_in_plan_candidate.go
@@ -34,19 +34,5 @@ func (p PlaceInPlanCandidate) IsSameCategoryPlace(other PlaceInPlanCandidate) bo
 }
 
 func (p PlaceInPlanCandidate) ToPlace() Place {
-	var googlePlaceReviews *[]GooglePlaceReview
-	if p.Google.PlaceDetail != nil {
-		googlePlaceReviews = &p.Google.PlaceDetail.Reviews
-	}
-
-	return Place{
-		Id:                 p.Id,
-		GooglePlaceId:      utils.StrOmitEmpty(p.Google.PlaceId),
-		Name:               p.Google.Name,
-		Location:           p.Google.Location,
-		Images:             p.Google.Images(),
-		Categories:         GetCategoriesFromSubCategories(p.Google.Types),
-		GooglePlaceReviews: googlePlaceReviews,
-		PriceLevel:         p.Google.PriceLevel,
-	}
+	return NewPlaceFromGooglePlace(p.Id, p.Google)
 }

--- a/internal/domain/models/place_in_plan_candidate.go
+++ b/internal/domain/models/place_in_plan_candidate.go
@@ -1,7 +1,5 @@
 package models
 
-import "poroto.app/poroto/planner/internal/domain/utils"
-
 type PlaceInPlanCandidate struct {
 	Id     string
 	Google GooglePlace

--- a/internal/domain/models/place_test.go
+++ b/internal/domain/models/place_test.go
@@ -5,50 +5,6 @@ import (
 	"testing"
 )
 
-func TestPlace_MainCategory(t *testing.T) {
-	cases := []struct {
-		name     string
-		place    Place
-		expected *LocationCategory
-	}{
-		{
-			name: "place has no category",
-			place: Place{
-				Categories: []LocationCategory{},
-			},
-			expected: nil,
-		},
-		{
-			name: "place has one category",
-			place: Place{
-				Categories: []LocationCategory{
-					CategoryAmusements,
-				},
-			},
-			expected: &CategoryAmusements,
-		},
-		{
-			name: "place has two categories and the first one is main category",
-			place: Place{
-				Categories: []LocationCategory{
-					CategoryAmusements,
-					CategoryBookStore,
-				},
-			},
-			expected: &CategoryAmusements,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			actual := c.place.MainCategory()
-			if diff := cmp.Diff(c.expected, actual); diff != "" {
-				t.Errorf("MainCategory() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestPlace_EstimatedStayDuration(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -58,28 +14,32 @@ func TestPlace_EstimatedStayDuration(t *testing.T) {
 		{
 			name: "place has no category",
 			place: Place{
-				Categories: []LocationCategory{},
+				Google: GooglePlace{
+					Types: []string{},
+				},
 			},
 			expected: 0,
 		},
 		{
 			name: "place has one category",
 			place: Place{
-				Categories: []LocationCategory{
-					{EstimatedStayDuration: 10},
+				Google: GooglePlace{
+					Types: []string{CategoryAmusements.SubCategories[0]},
 				},
 			},
-			expected: 10,
+			expected: CategoryAmusements.EstimatedStayDuration,
 		},
 		{
 			name: "place has two categories and return the estimated stay duration of the first one",
 			place: Place{
-				Categories: []LocationCategory{
-					{EstimatedStayDuration: 10},
-					{EstimatedStayDuration: 20},
+				Google: GooglePlace{
+					Types: []string{
+						CategoryBookStore.SubCategories[0],
+						CategoryAmusements.SubCategories[1],
+					},
 				},
 			},
-			expected: 10,
+			expected: CategoryBookStore.EstimatedStayDuration,
 		},
 	}
 

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -69,7 +69,7 @@ func (s Service) FetchPlacesToReplace(
 	})
 
 	// 指定された場所と同じカテゴリの場所を選択
-	placesFiltered = placefilter.FilterByCategory(placesFiltered, placeToReplace.Categories, true)
+	placesFiltered = placefilter.FilterByCategory(placesFiltered, placeToReplace.Categories(), true)
 
 	// レビューの高い順でソート
 	sort.SliceStable(placesFiltered, func(i, j int) bool {

--- a/internal/infrastructure/firestore/entity/place.go
+++ b/internal/infrastructure/firestore/entity/place.go
@@ -17,33 +17,10 @@ type PlaceEntity struct {
 }
 
 func ToPlaceEntity(place models.Place) PlaceEntity {
-	var googlePlaceReviews *[]GooglePlaceReviewEntity
-	if place.GooglePlaceReviews != nil {
-		googlePlaceReviews = new([]GooglePlaceReviewEntity)
-		for _, review := range *place.GooglePlaceReviews {
-			*googlePlaceReviews = append(*googlePlaceReviews, GooglePlaceReviewEntityFromGooglePlaceReview(review, *place.GooglePlaceId))
-		}
-	}
-
-	var images []ImageEntity
-	for _, image := range place.Images {
-		images = append(images, ToImageEntity(*place.GooglePlaceId, image))
-	}
-
-	var categories []string
-	for _, category := range place.Categories {
-		categories = append(categories, category.Name)
-	}
-
 	return PlaceEntity{
-		Id:                 place.Id,
-		GooglePlaceId:      place.GooglePlaceId,
-		Name:               place.Name,
-		Location:           ToGeoLocationEntity(place.Location),
-		Images:             images,
-		GooglePlaceReviews: googlePlaceReviews,
-		Categories:         categories,
-		PriceLevel:         place.PriceLevel,
+		Id:       place.Id,
+		Name:     place.Name,
+		Location: ToGeoLocationEntity(place.Location),
 	}
 }
 
@@ -70,13 +47,8 @@ func FromPlaceEntity(entity PlaceEntity) models.Place {
 	}
 
 	return models.Place{
-		Id:                 entity.Id,
-		GooglePlaceId:      entity.GooglePlaceId,
-		Name:               entity.Name,
-		Location:           FromGeoLocationEntity(entity.Location),
-		Images:             images,
-		GooglePlaceReviews: googlePlaceReviews,
-		Categories:         categories,
-		PriceLevel:         entity.PriceLevel,
+		Id:       entity.Id,
+		Name:     entity.Name,
+		Location: FromGeoLocationEntity(entity.Location),
 	}
 }

--- a/internal/infrastructure/firestore/entity/place.go
+++ b/internal/infrastructure/firestore/entity/place.go
@@ -20,13 +20,13 @@ func NewPlaceEntityFromPlace(place models.Place) PlaceEntity {
 	}
 }
 
-func FromPlaceEntity(entity PlaceEntity) models.Place {
+func (p PlaceEntity) ToPlace() models.Place {
 	return models.Place{
-		Id:   entity.Id,
-		Name: entity.Name,
+		Id:   p.Id,
+		Name: p.Name,
 		Location: models.GeoLocation{
-			Latitude:  entity.Latitude,
-			Longitude: entity.Longitude,
+			Latitude:  p.Latitude,
+			Longitude: p.Longitude,
 		},
 	}
 }

--- a/internal/infrastructure/firestore/entity/place.go
+++ b/internal/infrastructure/firestore/entity/place.go
@@ -4,51 +4,29 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-// PlaceEntity
 type PlaceEntity struct {
-	Id                 string                     `firestore:"id"`
-	GooglePlaceId      *string                    `firestore:"google_place_id"`
-	Name               string                     `firestore:"name"`
-	Location           GeoLocationEntity          `firestore:"location"`
-	Images             []ImageEntity              `firestore:"images"`
-	GooglePlaceReviews *[]GooglePlaceReviewEntity `firestore:"google_place_reviews,omitempty"`
-	Categories         []string                   `firestore:"categories"`
-	PriceLevel         int                        `firestore:"price_level"`
+	Id        string  `firestore:"id"`
+	Name      string  `firestore:"name"`
+	Latitude  float64 `firestore:"latitude"`
+	Longitude float64 `firestore:"longitude"`
 }
 
 func ToPlaceEntity(place models.Place) PlaceEntity {
 	return PlaceEntity{
-		Id:       place.Id,
-		Name:     place.Name,
-		Location: ToGeoLocationEntity(place.Location),
+		Id:        place.Id,
+		Name:      place.Name,
+		Latitude:  place.Location.Latitude,
+		Longitude: place.Location.Longitude,
 	}
 }
 
 func FromPlaceEntity(entity PlaceEntity) models.Place {
-	var googlePlaceReviews *[]models.GooglePlaceReview
-	if entity.GooglePlaceReviews != nil {
-		googlePlaceReviews = new([]models.GooglePlaceReview)
-		for _, review := range *entity.GooglePlaceReviews {
-			*googlePlaceReviews = append(*googlePlaceReviews, review.ToGooglePlaceReview())
-		}
-	}
-
-	var images []models.Image
-	for _, image := range entity.Images {
-		images = append(images, FromImageEntity(image))
-	}
-
-	var categories []models.LocationCategory
-	for _, category := range entity.Categories {
-		c := models.GetCategoryOfName(category)
-		if c != nil {
-			categories = append(categories, *c)
-		}
-	}
-
 	return models.Place{
-		Id:       entity.Id,
-		Name:     entity.Name,
-		Location: FromGeoLocationEntity(entity.Location),
+		Id:   entity.Id,
+		Name: entity.Name,
+		Location: models.GeoLocation{
+			Latitude:  entity.Latitude,
+			Longitude: entity.Longitude,
+		},
 	}
 }

--- a/internal/infrastructure/firestore/entity/place.go
+++ b/internal/infrastructure/firestore/entity/place.go
@@ -11,7 +11,7 @@ type PlaceEntity struct {
 	Longitude float64 `firestore:"longitude"`
 }
 
-func ToPlaceEntity(place models.Place) PlaceEntity {
+func NewPlaceEntityFromPlace(place models.Place) PlaceEntity {
 	return PlaceEntity{
 		Id:        place.Id,
 		Name:      place.Name,

--- a/internal/infrastructure/firestore/entity/plan.go
+++ b/internal/infrastructure/firestore/entity/plan.go
@@ -42,8 +42,8 @@ func ToPlanEntity(plan models.Plan) PlanEntity {
 
 func FromPlanEntity(entity PlanEntity) models.Plan {
 	ps := make([]models.Place, len(entity.Places))
-	for i, place := range entity.Places {
-		ps[i] = FromPlaceEntity(place)
+	for i, placeEntity := range entity.Places {
+		ps[i] = placeEntity.ToPlace()
 	}
 
 	return models.Plan{

--- a/internal/infrastructure/firestore/entity/plan.go
+++ b/internal/infrastructure/firestore/entity/plan.go
@@ -21,7 +21,7 @@ type PlanEntity struct {
 func ToPlanEntity(plan models.Plan) PlanEntity {
 	places := make([]PlaceEntity, len(plan.Places))
 	for i, place := range plan.Places {
-		places[i] = ToPlaceEntity(place)
+		places[i] = NewPlaceEntityFromPlace(place)
 	}
 
 	var geohash *string

--- a/internal/infrastructure/firestore/entity/plan_in_candidate.go
+++ b/internal/infrastructure/firestore/entity/plan_in_candidate.go
@@ -20,7 +20,7 @@ func ToPlanInCandidateEntity(plan models.Plan) PlanInCandidateEntity {
 	placeIdsOrdered := make([]string, len(plan.Places))
 
 	for i, place := range plan.Places {
-		ps[i] = ToPlaceEntity(place)
+		ps[i] = NewPlaceEntityFromPlace(place)
 		placeIdsOrdered[i] = place.Id
 	}
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- PlaceはGooglePlaceが持つ`Review`や`Rating`の情報を持っていた。
- 今回の修正では`Place `に`GooglePlace`を持たせることで、これらのPlaces APIから取得した値をPlaceの値として持たないようにした。
- 今後、porotoにレビューなどのデータがアップロードされた場合はそれらをPlaceのフィールドとしてもたせる

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [x] 破壊的な修正 (既存の機能を修正する必要があるもの)
  - Firestoreに保存されるPlaceのスキーマを変更したため、過去のデータを読み込めなくなった
  - 過去のデータを利用するためにはマイングレーションが必要
  - 今後の修正でPlaceRepositoryをすべてのプランで共通化し、そこに場所の情報が入るため、マイングレーションを行うとしたらそのPRのあと
  - （おそらく、コストとメリットを比較してマイングレーションは行わないと予想している）
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- `PlaceRepository`として共通の場所の情報を保存するデータベースを作るため

### どのようにテストされているか
- このPRではデータ構造の変更がわかりやすくなるように、機能としては完成していない状態でPRを出している
- そのためテストをすることはできない。