### PR TITLE
検索結果のキャッシュを利用してNearbySearchを行うカテゴリ数を減らす

### DIFF
--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -114,6 +114,11 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 		placesSearched = append(placesSearched, *searchResults...)
 	}
 
+	// 検索された場所に加えて、キャッシュされた場所を追加
+	for _, place := range placesSaved {
+		placesSearched = append(placesSearched, place.Google)
+	}
+
 	// 重複した場所を削除
 	var placesSearchedFiltered []models.GooglePlace
 	for _, place := range placesSearched {

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/services/place"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
 	"sort"
 )
@@ -39,7 +40,7 @@ func (s Service) CategoriesNearLocation(
 	}
 
 	// 付近の場所を検索
-	placesSearched, err := s.placeService.SearchNearbyPlaces(ctx, params.Location)
+	placesSearched, err := s.placeService.SearchNearbyPlaces(ctx, params.Location, place.NearbySearchRadius)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places: %v\n", err)
 	}

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -40,7 +40,7 @@ func (s Service) CategoriesNearLocation(
 	}
 
 	// 付近の場所を検索
-	placesSearched, err := s.placeService.SearchNearbyPlaces(ctx, params.Location, place.NearbySearchRadius)
+	placesSearched, err := s.placeService.SearchNearbyPlaces(ctx, place.SearchNearbyPlacesInput{Location: params.Location})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places: %v\n", err)
 	}

--- a/internal/domain/services/plangen/create_by_location.go
+++ b/internal/domain/services/plangen/create_by_location.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/services/place"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
 )
 
@@ -36,7 +37,7 @@ func (s Service) CreatePlanByLocation(
 
 	// 検索を行っていない場合は検索を行う
 	if places == nil {
-		googlePlaces, err := s.placeService.SearchNearbyPlaces(ctx, locationStart)
+		googlePlaces, err := s.placeService.SearchNearbyPlaces(ctx, locationStart, place.NearbySearchRadius)
 		if err != nil {
 			return nil, fmt.Errorf("error while fetching google places: %v\n", err)
 		}

--- a/internal/domain/services/plangen/create_by_location.go
+++ b/internal/domain/services/plangen/create_by_location.go
@@ -37,7 +37,7 @@ func (s Service) CreatePlanByLocation(
 
 	// 検索を行っていない場合は検索を行う
 	if places == nil {
-		googlePlaces, err := s.placeService.SearchNearbyPlaces(ctx, locationStart, place.NearbySearchRadius)
+		googlePlaces, err := s.placeService.SearchNearbyPlaces(ctx, place.SearchNearbyPlacesInput{Location: locationStart})
 		if err != nil {
 			return nil, fmt.Errorf("error while fetching google places: %v\n", err)
 		}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 特定のカテゴリ（カフェや温泉）に対して、過去に検索された内容を取得し、それが十分あればNearbySearchを行わないように修正した。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #321 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 料金の高いNearbySearchの呼び出し回数を減らすため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 検索結果が再利用され、NearbySearchが行われなくなっていることを確認

![image](https://github.com/poroto-app/planner/assets/55840281/6aca20a9-076b-41f0-9e79-ef63468d7c50)


```shell
# planner
export BRANCH_PLANNER=feature/reuse_nearby_search
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```