### PR TITLE
移動経路が最短になるように並び替えられるようにする

### DIFF
--- a/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -284,5 +284,29 @@ func (r *mutationResolver) EditPlanTitleOfPlanCandidate(ctx context.Context, inp
 
 // AutoReorderPlacesInPlanCandidate is the resolver for the autoReorderPlacesInPlanCandidate field.
 func (r *mutationResolver) AutoReorderPlacesInPlanCandidate(ctx context.Context, input model.AutoReorderPlacesInPlanCandidateInput) (*model.AutoReorderPlacesInPlanCandidateOutput, error) {
-	panic(fmt.Errorf("not implemented: AutoReorderPlacesInPlanCandidate - autoReorderPlacesInPlanCandidate"))
+	planCandidateService, err := plancandidate.NewService(ctx)
+	if err != nil {
+		log.Println(fmt.Errorf("error while initizalizing PlanService: %v", err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	planUpdated, err := planCandidateService.AutoReorderPlaces(ctx, plancandidate.AutoReorderPlacesInput{
+		PlanCandidateId: input.PlanCandidateID,
+		PlanId:          input.PlanID,
+	})
+	if err != nil {
+		log.Println(fmt.Errorf("error while auto reordering places in plan candidate: %v", err))
+		return nil, fmt.Errorf("could not auto reorder places in plan candidate")
+	}
+
+	graphqlPlanInPlanCandidate, err := factory.PlanFromDomainModel(*planUpdated, nil)
+	if err != nil {
+		log.Printf("error while converting plan to graphql model: %v", err)
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	return &model.AutoReorderPlacesInPlanCandidateOutput{
+		PlanCandidateID: input.PlanCandidateID,
+		Plan:            graphqlPlanInPlanCandidate,
+	}, nil
 }

--- a/internal/domain/models/place_test.go
+++ b/internal/domain/models/place_test.go
@@ -99,3 +99,50 @@ func TestPlace_EstimatedStayDuration(t *testing.T) {
 		})
 	}
 }
+
+// ==============================================================
+// Mocks
+// ==============================================================
+func NewMockPlaceShinjukuStation() Place {
+	return Place{
+		Id:   "sinjuku-station",
+		Name: "新宿駅",
+		Location: GeoLocation{
+			Latitude:  35.6899573,
+			Longitude: 139.7005071,
+		},
+	}
+}
+
+func NewMockPlaceIsetan() Place {
+	return Place{
+		Id:   "isetan",
+		Name: "伊勢丹 新宿店",
+		Location: GeoLocation{
+			Latitude:  35.6916532,
+			Longitude: 139.7046449,
+		},
+	}
+}
+
+func NewMockPlaceShinjukuGyoen() Place {
+	return Place{
+		Id:   "shinjuku-gyoen",
+		Name: "新宿御苑",
+		Location: GeoLocation{
+			Latitude:  35.6867668,
+			Longitude: 139.7123842,
+		},
+	}
+}
+
+func NewMockPlaceTakashimaya() Place {
+	return Place{
+		Id:   "takashimaya",
+		Name: "新宿高島屋",
+		Location: GeoLocation{
+			Latitude:  35.6875312,
+			Longitude: 139.7022521,
+		},
+	}
+}

--- a/internal/domain/models/plan.go
+++ b/internal/domain/models/plan.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+	"sort"
+)
+
 type Plan struct {
 	Id       string  `json:"id"`
 	Name     string  `json:"name"`
@@ -15,6 +19,50 @@ func (p Plan) GetPlace(placeId string) *Place {
 		}
 	}
 	return nil
+}
+
+// PlacesReorderedToMinimizeDistance は、スタート地点から移動が少なくなるように場所を並び替える
+func (p Plan) PlacesReorderedToMinimizeDistance() []Place {
+	if len(p.Places) == 0 {
+		panic("Plan has no places")
+	}
+
+	placesReordered := make([]Place, len(p.Places))
+
+	// 最初の場所をスタート地点とする
+	startPlace := p.Places[0]
+	placesReordered[0] = startPlace
+
+	for i := 1; i < len(p.Places); i++ {
+		// 一つ前の場所から近い順に並び替える
+		placesSortedByDistanceToPrevLocation := make([]Place, len(p.Places))
+		copy(placesSortedByDistanceToPrevLocation, p.Places)
+		sort.Slice(placesSortedByDistanceToPrevLocation, func(a, b int) bool {
+			prevLocation := placesReordered[i-1].Location
+			return placesSortedByDistanceToPrevLocation[a].Location.DistanceInMeter(prevLocation) < placesSortedByDistanceToPrevLocation[b].Location.DistanceInMeter(prevLocation)
+		})
+
+		//　一つ前の場所から最も近い場所を選択する
+		for _, place := range placesSortedByDistanceToPrevLocation {
+			// すでに並び替えた場所は除外する
+			var isAlreadyAdded bool
+			for _, placeReordered := range placesReordered {
+				if placeReordered.Id == place.Id {
+					isAlreadyAdded = true
+					break
+				}
+			}
+
+			if isAlreadyAdded {
+				continue
+			}
+
+			placesReordered[i] = place
+			break
+		}
+	}
+
+	return placesReordered
 }
 
 func (p Plan) Transitions(startLocation *GeoLocation) []Transition {

--- a/internal/domain/models/plan_test.go
+++ b/internal/domain/models/plan_test.go
@@ -49,3 +49,57 @@ func TestGetPlace(t *testing.T) {
 		})
 	}
 }
+
+func TestPlan_PlacesReorderedToMinimizeDistance(t *testing.T) {
+	cases := []struct {
+		name     string
+		plan     Plan
+		expected []Place
+	}{
+		{
+			name: "should start with first place",
+			plan: Plan{
+				Places: []Place{
+					NewMockPlaceShinjukuStation(),
+				},
+			},
+			expected: []Place{
+				NewMockPlaceShinjukuStation(),
+			},
+		},
+		{
+			name: "should return places reordered to minimize distance from first place",
+			plan: Plan{
+				Places: []Place{
+					// 新宿駅
+					NewMockPlaceShinjukuStation(),
+					// 伊勢丹
+					NewMockPlaceIsetan(),
+					// 新宿御苑
+					NewMockPlaceShinjukuGyoen(),
+					// 高島屋
+					NewMockPlaceTakashimaya(),
+				},
+			},
+			expected: []Place{
+				// 新宿駅
+				NewMockPlaceShinjukuStation(),
+				// 高島屋
+				NewMockPlaceTakashimaya(),
+				// 伊勢丹
+				NewMockPlaceIsetan(),
+				// 新宿御苑
+				NewMockPlaceShinjukuGyoen(),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := c.plan.PlacesReorderedToMinimizeDistance()
+			if diff := cmp.Diff(c.expected, actual); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/domain/repository/plan_candidate.go
+++ b/internal/domain/repository/plan_candidate.go
@@ -14,6 +14,8 @@ type PlanCandidateRepository interface {
 
 	Find(ctx context.Context, planCandidateId string) (*models.PlanCandidate, error)
 
+	FindPlan(ctx context.Context, planCandidateId string, planId string) (*models.Plan, error)
+
 	FindExpiredBefore(ctx context.Context, expiresAt time.Time) (*[]string, error)
 
 	// AddSearchedPlacesForPlanCandidate は models.PlanCandidate を作成するために検索した場所を保存する

--- a/internal/domain/repository/plan_candidate.go
+++ b/internal/domain/repository/plan_candidate.go
@@ -29,6 +29,7 @@ type PlanCandidateRepository interface {
 
 	RemovePlaceFromPlan(ctx context.Context, planCandidateId string, planId string, placeId string) error
 
+	// TODO: errorだけを返すようにする
 	UpdatePlacesOrder(ctx context.Context, planId string, planCandidate string, placeIdsOrdered []string) (*models.Plan, error)
 
 	UpdatePlanCandidateMetaData(ctx context.Context, planCandidateId string, meta models.PlanCandidateMetaData) error

--- a/internal/domain/services/plancandidate/auto_reorder_places.go
+++ b/internal/domain/services/plancandidate/auto_reorder_places.go
@@ -1,0 +1,38 @@
+package plancandidate
+
+import (
+	"context"
+	"fmt"
+	"poroto.app/poroto/planner/internal/domain/models"
+)
+
+type AutoReorderPlacesInput struct {
+	PlanCandidateId string
+	PlanId          string
+}
+
+// AutoReorderPlaces はプラン候補の場所をスタート地点からの移動が最小になるように並び替える
+func (s *Service) AutoReorderPlaces(ctx context.Context, input AutoReorderPlacesInput) (*models.Plan, error) {
+	plan, err := s.planCandidateRepository.FindPlan(ctx, input.PlanCandidateId, input.PlanId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find plan: %w", err)
+	}
+
+	if plan == nil {
+		return nil, fmt.Errorf("plan not found")
+	}
+
+	placesReordered := plan.PlacesReorderedToMinimizeDistance()
+	plan.Places = placesReordered
+
+	var placeIdsOrdered []string
+	for _, place := range placesReordered {
+		placeIdsOrdered = append(placeIdsOrdered, place.Id)
+	}
+
+	if _, err := s.planCandidateRepository.UpdatePlacesOrder(ctx, input.PlanId, input.PlanCandidateId, placeIdsOrdered); err != nil {
+		return nil, fmt.Errorf("failed to update places order: %v", err)
+	}
+
+	return plan, nil
+}

--- a/internal/infrastructure/firestore/entity/plan_candidate.go
+++ b/internal/infrastructure/firestore/entity/plan_candidate.go
@@ -32,12 +32,12 @@ func ToPlanCandidateEntity(planCandidate models.PlanCandidate) PlanCandidateEnti
 func FromPlanCandidateEntity(entity PlanCandidateEntity, metaData PlanCandidateMetaDataV1Entity, planEntities []PlanInCandidateEntity, places []models.Place) models.PlanCandidate {
 	var plans []models.Plan
 	for _, planId := range entity.PlanIds {
-		for _, place := range planEntities {
-			if place.Id != planId {
+		for _, planEntity := range planEntities {
+			if planEntity.Id != planId {
 				continue
 			}
 
-			plan, err := FromPlanInCandidateEntity(planId, place.Name, places, place.PlaceIdsOrdered)
+			plan, err := planEntity.ToPlan(places)
 			if err != nil {
 				log.Printf("error while converting entity.PlanCandidateEntity to models.PlanCandidate: %v", err)
 

--- a/internal/infrastructure/firestore/entity/plan_in_candidate.go
+++ b/internal/infrastructure/firestore/entity/plan_in_candidate.go
@@ -31,14 +31,9 @@ func ToPlanInCandidateEntity(plan models.Plan) PlanInCandidateEntity {
 	}
 }
 
-func FromPlanInCandidateEntity(
-	id string,
-	name string,
-	places []models.Place,
-	placeIdsOrdered []string,
-) (*models.Plan, error) {
-	placesOrdered := make([]models.Place, len(placeIdsOrdered))
-	for i, placeIdOrdered := range placeIdsOrdered {
+func (p PlanInCandidateEntity) ToPlan(places []models.Place) (*models.Plan, error) {
+	placesOrdered := make([]models.Place, len(p.PlaceIdsOrdered))
+	for i, placeIdOrdered := range p.PlaceIdsOrdered {
 		for _, place := range places {
 			if place.Id == placeIdOrdered {
 				placesOrdered[i] = place
@@ -47,13 +42,13 @@ func FromPlanInCandidateEntity(
 	}
 
 	// 整合性の確認
-	if err := validatePlaceEntity(placesOrdered, placeIdsOrdered); err != nil {
+	if err := validatePlaceEntity(placesOrdered, p.PlaceIdsOrdered); err != nil {
 		return nil, fmt.Errorf("places in plan candidate is invalid: %w", err)
 	}
 
 	return &models.Plan{
-		Id:     id,
-		Name:   name,
+		Id:     p.Id,
+		Name:   p.Name,
 		Places: placesOrdered,
 	}, nil
 }

--- a/internal/infrastructure/firestore/entity/plan_in_candidate_test.go
+++ b/internal/infrastructure/firestore/entity/plan_in_candidate_test.go
@@ -67,12 +67,7 @@ func TestFromPlanInCandidateEntity(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result, _ := FromPlanInCandidateEntity(
-				c.entity.Id,
-				c.entity.Name,
-				c.places,
-				c.entity.PlaceIdsOrdered,
-			)
+			result, _ := c.entity.ToPlan(c.places)
 			if diff := cmp.Diff(c.expected, result); diff != "" {
 				t.Errorf("FromPlanInCandidateEntity() mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/infrastructure/mock/plan_candidate.go
+++ b/internal/infrastructure/mock/plan_candidate.go
@@ -27,6 +27,11 @@ func (p PlanRepository) Find(ctx context.Context, planCandidateId string) (*mode
 	panic("implement me")
 }
 
+func (p PlanRepository) FindPlan(ctx context.Context, planCandidateId string, planId string) (*models.Plan, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p PlanRepository) FindExpiredBefore(ctx context.Context, expiresAt time.Time) (*[]string, error) {
 	var values []string
 	for _, value := range p.Data {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 作成されたプランに含まれる場所を、移動が最小になるように並び替える処理を作成した

|並び替え後の経路|
|---|
|![image](https://github.com/poroto-app/planner/assets/55840281/ecf5cf0f-ef0d-447e-aeb2-4804c74545b1)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 編集機能で経路を気にせず追加した場所を、自動的に並び替えられるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 自動的に並び変わることを確認（Postmanを用いて実行 & porotoで更新をチェック）

```shell
# planner
export BRANCH_PLANNER=feature/place_auto_reorder
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```