### PR TITLE
GraphQlの不要なクエリを削除 & 非Null制約をつける

### DIFF
--- a/graphql/factory/place.go
+++ b/graphql/factory/place.go
@@ -3,7 +3,6 @@ package factory
 import (
 	graphql "poroto.app/poroto/planner/graphql/model"
 	"poroto.app/poroto/planner/internal/domain/models"
-	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
 func PlaceFromDomainModel(place *models.Place) *graphql.Place {
@@ -11,7 +10,6 @@ func PlaceFromDomainModel(place *models.Place) *graphql.Place {
 		return nil
 	}
 
-	// TODO: not nil な値にする
 	var images []*graphql.Image
 	if place.Google.Photos != nil {
 		for _, photo := range *place.Google.Photos {
@@ -23,10 +21,10 @@ func PlaceFromDomainModel(place *models.Place) *graphql.Place {
 			})
 		}
 	} else {
+		// not nil な値にする
 		images = make([]*graphql.Image, 0)
 	}
 
-	// TODO: not nil な値にする
 	var googlePlaceReviews []*graphql.GooglePlaceReview
 	if place.Google.PlaceDetail != nil && place.Google.PlaceDetail.Reviews != nil {
 		googlePlaceReviews = make([]*graphql.GooglePlaceReview, len(place.Google.PlaceDetail.Reviews))
@@ -34,6 +32,7 @@ func PlaceFromDomainModel(place *models.Place) *graphql.Place {
 			googlePlaceReviews[i] = GooglePlaceReviewFromDomainModel(review)
 		}
 	} else {
+		// not nil な値にする
 		googlePlaceReviews = make([]*graphql.GooglePlaceReview, 0)
 	}
 
@@ -47,7 +46,7 @@ func PlaceFromDomainModel(place *models.Place) *graphql.Place {
 
 	return &graphql.Place{
 		ID:            place.Id,
-		GooglePlaceID: utils.StrPointer(place.Google.PlaceId),
+		GooglePlaceID: place.Google.PlaceId,
 		Name:          place.Name,
 		Images:        images,
 		Location: &graphql.GeoLocation{

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -1142,12 +1142,12 @@ type Image {
 `, BuiltIn: false},
 	{Name: "../schema/place_type.graphqls", Input: `type Place {
     id: String!
-    googlePlaceId: String
+    googlePlaceId: String!
     name: String!
     location: GeoLocation!
     images: [Image!]!
     estimatedStayDuration: Int!
-    googleReviews: [GooglePlaceReview!]
+    googleReviews: [GooglePlaceReview!]!
     categories: [PlaceCategory!]!
     priceRange: PriceRange
 }
@@ -4158,11 +4158,14 @@ func (ec *executionContext) _Place_googlePlaceId(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Place_googlePlaceId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -4389,11 +4392,14 @@ func (ec *executionContext) _Place_googleReviews(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]*model.GooglePlaceReview)
 	fc.Result = res
-	return ec.marshalOGooglePlaceReview2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐGooglePlaceReviewᚄ(ctx, field.Selections, res)
+	return ec.marshalNGooglePlaceReview2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐGooglePlaceReviewᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Place_googleReviews(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9965,6 +9971,9 @@ func (ec *executionContext) _Place(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "googlePlaceId":
 			out.Values[i] = ec._Place_googlePlaceId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "name":
 			out.Values[i] = ec._Place_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -9987,6 +9996,9 @@ func (ec *executionContext) _Place(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "googleReviews":
 			out.Values[i] = ec._Place_googleReviews(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "categories":
 			out.Values[i] = ec._Place_categories(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -11313,6 +11325,50 @@ func (ec *executionContext) marshalNGeoLocation2ᚖporotoᚗappᚋporotoᚋplann
 	return ec._GeoLocation(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNGooglePlaceReview2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐGooglePlaceReviewᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.GooglePlaceReview) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGooglePlaceReview2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐGooglePlaceReview(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNGooglePlaceReview2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐGooglePlaceReview(ctx context.Context, sel ast.SelectionSet, v *model.GooglePlaceReview) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -12180,53 +12236,6 @@ func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalFloatContext(*v)
 	return graphql.WrapContextMarshaler(ctx, res)
-}
-
-func (ec *executionContext) marshalOGooglePlaceReview2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐGooglePlaceReviewᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.GooglePlaceReview) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGooglePlaceReview2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐGooglePlaceReview(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -104,11 +104,6 @@ type ComplexityRoot struct {
 		Small   func(childComplexity int) int
 	}
 
-	InterestCandidate struct {
-		Categories func(childComplexity int) int
-		Session    func(childComplexity int) int
-	}
-
 	LocationCategory struct {
 		DefaultPhotoURL func(childComplexity int) int
 		DisplayName     func(childComplexity int) int
@@ -195,7 +190,6 @@ type ComplexityRoot struct {
 		AvailablePlacesForPlan          func(childComplexity int, input model.AvailablePlacesForPlanInput) int
 		CachedCreatedPlans              func(childComplexity int, input model.CachedCreatedPlansInput) int
 		FirebaseUser                    func(childComplexity int, input *model.FirebaseUserInput) int
-		MatchInterests                  func(childComplexity int, input *model.MatchInterestsInput) int
 		NearbyPlaceCategories           func(childComplexity int, input model.NearbyPlaceCategoriesInput) int
 		PlacesToAddForPlanCandidate     func(childComplexity int, input model.PlacesToAddForPlanCandidateInput) int
 		PlacesToReplaceForPlanCandidate func(childComplexity int, input model.PlacesToReplaceForPlanCandidateInput) int
@@ -242,7 +236,6 @@ type MutationResolver interface {
 type QueryResolver interface {
 	Version(ctx context.Context) (string, error)
 	CachedCreatedPlans(ctx context.Context, input model.CachedCreatedPlansInput) (*model.CachedCreatedPlans, error)
-	MatchInterests(ctx context.Context, input *model.MatchInterestsInput) (*model.InterestCandidate, error)
 	NearbyPlaceCategories(ctx context.Context, input model.NearbyPlaceCategoriesInput) (*model.NearbyPlaceCategoryOutput, error)
 	AvailablePlacesForPlan(ctx context.Context, input model.AvailablePlacesForPlanInput) (*model.AvailablePlacesForPlan, error)
 	PlacesToAddForPlanCandidate(ctx context.Context, input model.PlacesToAddForPlanCandidateInput) (*model.PlacesToAddForPlanCandidateOutput, error)
@@ -457,20 +450,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Image.Small(childComplexity), true
-
-	case "InterestCandidate.categories":
-		if e.complexity.InterestCandidate.Categories == nil {
-			break
-		}
-
-		return e.complexity.InterestCandidate.Categories(childComplexity), true
-
-	case "InterestCandidate.session":
-		if e.complexity.InterestCandidate.Session == nil {
-			break
-		}
-
-		return e.complexity.InterestCandidate.Session(childComplexity), true
 
 	case "LocationCategory.defaultPhotoUrl":
 		if e.complexity.LocationCategory.DefaultPhotoURL == nil {
@@ -875,18 +854,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.FirebaseUser(childComplexity, args["input"].(*model.FirebaseUserInput)), true
 
-	case "Query.matchInterests":
-		if e.complexity.Query.MatchInterests == nil {
-			break
-		}
-
-		args, err := ec.field_Query_matchInterests_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.MatchInterests(childComplexity, args["input"].(*model.MatchInterestsInput)), true
-
 	case "Query.nearbyPlaceCategories":
 		if e.complexity.Query.NearbyPlaceCategories == nil {
 			break
@@ -1058,7 +1025,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeletePlaceFromPlanCandidateInput,
 		ec.unmarshalInputEditPlanTitleOfPlanCandidateInput,
 		ec.unmarshalInputFirebaseUserInput,
-		ec.unmarshalInputMatchInterestsInput,
 		ec.unmarshalInputNearbyPlaceCategoriesInput,
 		ec.unmarshalInputPlacesToAddForPlanCandidateInput,
 		ec.unmarshalInputPlacesToReplaceForPlanCandidateInput,
@@ -1334,10 +1300,6 @@ type EditPlanTitleOfPlanCandidateOutput {
     # キャッシュされたプラン一覧を取得する
     cachedCreatedPlans(input: CachedCreatedPlansInput!): CachedCreatedPlans!
 
-    # TODO: Delete
-    # TODO: NearByPlaceCategories等のアプリケーションに依存しない名前にする
-    matchInterests(input: MatchInterestsInput): InterestCandidate!
-
     nearbyPlaceCategories(input: NearbyPlaceCategoriesInput!): NearbyPlaceCategoryOutput!
 
     # プランを作成可能な他の場所を取得する
@@ -1367,16 +1329,6 @@ input AvailablePlacesForPlanInput {
 
 type AvailablePlacesForPlan {
     places: [Place!]!
-}
-
-type InterestCandidate {
-    session: String!
-    categories: [LocationCategory!]!
-}
-
-input MatchInterestsInput {
-    latitude: Float!
-    longitude: Float!
 }
 
 input NearbyPlaceCategoriesInput {
@@ -1688,21 +1640,6 @@ func (ec *executionContext) field_Query_firebaseUser_args(ctx context.Context, r
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalOFirebaseUserInput2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐFirebaseUserInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_matchInterests_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 *model.MatchInterestsInput
-	if tmp, ok := rawArgs["input"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalOMatchInterestsInput2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐMatchInterestsInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -3145,104 +3082,6 @@ func (ec *executionContext) fieldContext_Image_large(ctx context.Context, field 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _InterestCandidate_session(ctx context.Context, field graphql.CollectedField, obj *model.InterestCandidate) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_InterestCandidate_session(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Session, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_InterestCandidate_session(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "InterestCandidate",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _InterestCandidate_categories(ctx context.Context, field graphql.CollectedField, obj *model.InterestCandidate) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_InterestCandidate_categories(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Categories, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.LocationCategory)
-	fc.Result = res
-	return ec.marshalNLocationCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐLocationCategoryᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_InterestCandidate_categories(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "InterestCandidate",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "name":
-				return ec.fieldContext_LocationCategory_name(ctx, field)
-			case "displayName":
-				return ec.fieldContext_LocationCategory_displayName(ctx, field)
-			case "photo":
-				return ec.fieldContext_LocationCategory_photo(ctx, field)
-			case "defaultPhotoUrl":
-				return ec.fieldContext_LocationCategory_defaultPhotoUrl(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type LocationCategory", field.Name)
 		},
 	}
 	return fc, nil
@@ -5677,67 +5516,6 @@ func (ec *executionContext) fieldContext_Query_cachedCreatedPlans(ctx context.Co
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_cachedCreatedPlans_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_matchInterests(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_matchInterests(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().MatchInterests(rctx, fc.Args["input"].(*model.MatchInterestsInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.InterestCandidate)
-	fc.Result = res
-	return ec.marshalNInterestCandidate2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐInterestCandidate(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_matchInterests(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "session":
-				return ec.fieldContext_InterestCandidate_session(ctx, field)
-			case "categories":
-				return ec.fieldContext_InterestCandidate_categories(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type InterestCandidate", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_matchInterests_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9111,44 +8889,6 @@ func (ec *executionContext) unmarshalInputFirebaseUserInput(ctx context.Context,
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputMatchInterestsInput(ctx context.Context, obj interface{}) (model.MatchInterestsInput, error) {
-	var it model.MatchInterestsInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"latitude", "longitude"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "latitude":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("latitude"))
-			data, err := ec.unmarshalNFloat2float64(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Latitude = data
-		case "longitude":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("longitude"))
-			data, err := ec.unmarshalNFloat2float64(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Longitude = data
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputNearbyPlaceCategoriesInput(ctx context.Context, obj interface{}) (model.NearbyPlaceCategoriesInput, error) {
 	var it model.NearbyPlaceCategoriesInput
 	asMap := map[string]interface{}{}
@@ -9953,50 +9693,6 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 	return out
 }
 
-var interestCandidateImplementors = []string{"InterestCandidate"}
-
-func (ec *executionContext) _InterestCandidate(ctx context.Context, sel ast.SelectionSet, obj *model.InterestCandidate) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, interestCandidateImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("InterestCandidate")
-		case "session":
-			out.Values[i] = ec._InterestCandidate_session(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "categories":
-			out.Values[i] = ec._InterestCandidate_categories(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
 var locationCategoryImplementors = []string{"LocationCategory"}
 
 func (ec *executionContext) _LocationCategory(ctx context.Context, sel ast.SelectionSet, obj *model.LocationCategory) graphql.Marshaler {
@@ -10691,28 +10387,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_cachedCreatedPlans(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "matchInterests":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_matchInterests(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11733,74 +11407,6 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
-func (ec *executionContext) marshalNInterestCandidate2porotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐInterestCandidate(ctx context.Context, sel ast.SelectionSet, v model.InterestCandidate) graphql.Marshaler {
-	return ec._InterestCandidate(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNInterestCandidate2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐInterestCandidate(ctx context.Context, sel ast.SelectionSet, v *model.InterestCandidate) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._InterestCandidate(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNLocationCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐLocationCategoryᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.LocationCategory) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNLocationCategory2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐLocationCategory(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalNLocationCategory2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐLocationCategory(ctx context.Context, sel ast.SelectionSet, v *model.LocationCategory) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._LocationCategory(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNNearbyLocationCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐNearbyLocationCategoryᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.NearbyLocationCategory) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -12637,14 +12243,6 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 	}
 	res := graphql.MarshalInt(*v)
 	return res
-}
-
-func (ec *executionContext) unmarshalOMatchInterestsInput2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐMatchInterestsInput(ctx context.Context, v interface{}) (*model.MatchInterestsInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputMatchInterestsInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOPlace2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐPlace(ctx context.Context, sel ast.SelectionSet, v *model.Place) graphql.Marshaler {

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -1314,7 +1314,7 @@ type EditPlanTitleOfPlanCandidateOutput {
 }
 
 type CachedCreatedPlans {
-    plans: [Plan!]
+    plans: [Plan!]!
     createdBasedOnCurrentLocation: Boolean!
 }
 
@@ -1980,11 +1980,14 @@ func (ec *executionContext) _CachedCreatedPlans_plans(ctx context.Context, field
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]*model.Plan)
 	fc.Result = res
-	return ec.marshalOPlan2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐPlanᚄ(ctx, field.Selections, res)
+	return ec.marshalNPlan2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐPlanᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CachedCreatedPlans_plans(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9310,6 +9313,9 @@ func (ec *executionContext) _CachedCreatedPlans(ctx context.Context, sel ast.Sel
 			out.Values[i] = graphql.MarshalString("CachedCreatedPlans")
 		case "plans":
 			out.Values[i] = ec._CachedCreatedPlans_plans(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createdBasedOnCurrentLocation":
 			out.Values[i] = ec._CachedCreatedPlans_createdBasedOnCurrentLocation(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12259,53 +12265,6 @@ func (ec *executionContext) marshalOPlace2ᚖporotoᚗappᚋporotoᚋplannerᚋg
 		return graphql.Null
 	}
 	return ec._Place(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOPlan2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐPlanᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Plan) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNPlan2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐPlan(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalOPlan2ᚖporotoᚗappᚋporotoᚋplannerᚋgraphqlᚋmodelᚐPlan(ctx context.Context, sel ast.SelectionSet, v *model.Plan) graphql.Marshaler {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -150,12 +150,12 @@ type NearbyPlaceCategoryOutput struct {
 
 type Place struct {
 	ID                    string               `json:"id"`
-	GooglePlaceID         *string              `json:"googlePlaceId,omitempty"`
+	GooglePlaceID         string               `json:"googlePlaceId"`
 	Name                  string               `json:"name"`
 	Location              *GeoLocation         `json:"location"`
 	Images                []*Image             `json:"images"`
 	EstimatedStayDuration int                  `json:"estimatedStayDuration"`
-	GoogleReviews         []*GooglePlaceReview `json:"googleReviews,omitempty"`
+	GoogleReviews         []*GooglePlaceReview `json:"googleReviews"`
 	Categories            []*PlaceCategory     `json:"categories"`
 	PriceRange            *PriceRange          `json:"priceRange,omitempty"`
 }

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -124,21 +124,11 @@ type Image struct {
 	Large   *string `json:"large,omitempty"`
 }
 
-type InterestCandidate struct {
-	Session    string              `json:"session"`
-	Categories []*LocationCategory `json:"categories"`
-}
-
 type LocationCategory struct {
 	Name            string  `json:"name"`
 	DisplayName     string  `json:"displayName"`
 	Photo           *string `json:"photo,omitempty"`
 	DefaultPhotoURL string  `json:"defaultPhotoUrl"`
-}
-
-type MatchInterestsInput struct {
-	Latitude  float64 `json:"latitude"`
-	Longitude float64 `json:"longitude"`
 }
 
 type NearbyLocationCategory struct {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -29,7 +29,7 @@ type AvailablePlacesForPlanInput struct {
 }
 
 type CachedCreatedPlans struct {
-	Plans                         []*Plan `json:"plans,omitempty"`
+	Plans                         []*Plan `json:"plans"`
 	CreatedBasedOnCurrentLocation bool    `json:"createdBasedOnCurrentLocation"`
 }
 

--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -42,46 +42,6 @@ func (r *queryResolver) CachedCreatedPlans(ctx context.Context, input model.Cach
 	}, nil
 }
 
-// MatchInterests is the resolver for the matchInterests field.
-func (r *queryResolver) MatchInterests(ctx context.Context, input *model.MatchInterestsInput) (*model.InterestCandidate, error) {
-	service, err := plancandidate.NewService(ctx)
-	if err != nil {
-		log.Println("error while initializing plan candidate service: ", err)
-		return nil, fmt.Errorf("internal server error")
-	}
-
-	createPlanSessionId := uuid.New().String()
-
-	categoriesSearched, err := service.CategoriesNearLocation(
-		ctx,
-		plancandidate.CategoryNearLocationParams{
-			Location: models.GeoLocation{
-				Latitude:  input.Latitude,
-				Longitude: input.Longitude,
-			},
-			CreatePlanSessionId: createPlanSessionId,
-		},
-	)
-	if err != nil {
-		log.Printf("error while searching categories for session[%s]: %v", createPlanSessionId, err)
-		return nil, fmt.Errorf("internal server error")
-	}
-
-	var categories = []*model.LocationCategory{}
-	for _, categorySearched := range categoriesSearched {
-		categories = append(categories, &model.LocationCategory{
-			Name:            categorySearched.Category.Name,
-			DisplayName:     categorySearched.Category.DisplayName,
-			DefaultPhotoURL: categorySearched.Category.DefaultPhoto,
-		})
-	}
-
-	return &model.InterestCandidate{
-		Session:    createPlanSessionId,
-		Categories: categories,
-	}, nil
-}
-
 // NearbyPlaceCategories is the resolver for the nearbyPlaceCategories field.
 func (r *queryResolver) NearbyPlaceCategories(ctx context.Context, input model.NearbyPlaceCategoriesInput) (*model.NearbyPlaceCategoryOutput, error) {
 	service, err := plancandidate.NewService(ctx)

--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -127,7 +127,6 @@ func (r *queryResolver) PlacesToAddForPlanCandidate(ctx context.Context, input m
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	// TODO: レスポンスの型を []models.Place にする
 	var places []*model.Place
 	for _, place := range placesToAdd {
 		p := factory.PlaceFromDomainModel(&place)
@@ -155,7 +154,6 @@ func (r *queryResolver) PlacesToReplaceForPlanCandidate(ctx context.Context, inp
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	// TODO: レスポンスの型を []models.Place にする
 	var places []*model.Place
 	for _, place := range placesToReplace {
 		p := factory.PlaceFromDomainModel(&place)

--- a/graphql/schema/place_type.graphqls
+++ b/graphql/schema/place_type.graphqls
@@ -1,11 +1,11 @@
 type Place {
     id: String!
-    googlePlaceId: String
+    googlePlaceId: String!
     name: String!
     location: GeoLocation!
     images: [Image!]!
     estimatedStayDuration: Int!
-    googleReviews: [GooglePlaceReview!]
+    googleReviews: [GooglePlaceReview!]!
     categories: [PlaceCategory!]!
     priceRange: PriceRange
 }

--- a/graphql/schema/plan_candidate_query.graphqls
+++ b/graphql/schema/plan_candidate_query.graphqls
@@ -3,10 +3,6 @@ extend type Query {
     # キャッシュされたプラン一覧を取得する
     cachedCreatedPlans(input: CachedCreatedPlansInput!): CachedCreatedPlans!
 
-    # TODO: Delete
-    # TODO: NearByPlaceCategories等のアプリケーションに依存しない名前にする
-    matchInterests(input: MatchInterestsInput): InterestCandidate!
-
     nearbyPlaceCategories(input: NearbyPlaceCategoriesInput!): NearbyPlaceCategoryOutput!
 
     # プランを作成可能な他の場所を取得する
@@ -36,16 +32,6 @@ input AvailablePlacesForPlanInput {
 
 type AvailablePlacesForPlan {
     places: [Place!]!
-}
-
-type InterestCandidate {
-    session: String!
-    categories: [LocationCategory!]!
-}
-
-input MatchInterestsInput {
-    latitude: Float!
-    longitude: Float!
 }
 
 input NearbyPlaceCategoriesInput {

--- a/graphql/schema/plan_candidate_query.graphqls
+++ b/graphql/schema/plan_candidate_query.graphqls
@@ -17,7 +17,7 @@ extend type Query {
 }
 
 type CachedCreatedPlans {
-    plans: [Plan!]
+    plans: [Plan!]!
     createdBasedOnCurrentLocation: Boolean!
 }
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- `MatchInterest`など利用していないクエリを削除した
- また、返り値がNullにならないようにスキーマを変更した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- porotoでnilハンドリングをしなくてもいいようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```