### PR TITLE
NearbySearchで取得した画像や住所の情報が保存されるようにする

### DIFF
--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -18,6 +18,12 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		for _, photo := range *photos {
 			photoReferences = append(photoReferences, photo.ToPhotoReference())
 		}
+	} else if place.PhotoReferences != nil && len(place.PhotoReferences) > 0 {
+		// Nearby Search で取得した場合は PhotoReference がある
+		photoReferences = make([]models.GooglePlacePhotoReference, len(place.PhotoReferences))
+		for _, photo := range place.PhotoReferences {
+			photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
+		}
 	}
 
 	return models.GooglePlace{

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -25,6 +25,8 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		Rating:           place.Rating,
 		UserRatingsTotal: place.UserRatingsTotal,
 		PriceLevel:       place.PriceLevel,
+		FormattedAddress: place.FormattedAddress,
+		Vicinity:         place.Vicinity,
 		Photos:           photos,
 		PlaceDetail:      placeDetail,
 	}

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -22,9 +22,6 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		// Nearby Search で取得した場合は PhotoReference がある
 		photoReferences = make([]models.GooglePlacePhotoReference, len(place.PhotoReferences))
 		for i, photo := range place.PhotoReferences {
-			if photo.PhotoReference == "" {
-				continue
-			}
 			photoReferences[i] = GooglePlacePhotoReferenceFromPhoto(photo)
 		}
 	}

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -12,6 +12,14 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		placeDetail = &d
 	}
 
+	var photoReferences []models.GooglePlacePhotoReference
+	if photos != nil {
+		photoReferences = make([]models.GooglePlacePhotoReference, len(*photos))
+		for _, photo := range *photos {
+			photoReferences = append(photoReferences, photo.ToPhotoReference())
+		}
+	}
+
 	return models.GooglePlace{
 		PlaceId: place.PlaceID,
 		Name:    place.Name,
@@ -20,7 +28,7 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 			Latitude:  place.Location.Latitude,
 			Longitude: place.Location.Longitude,
 		},
-		PhotoReferences:  place.PhotoReferences,
+		PhotoReferences:  photoReferences,
 		OpenNow:          place.OpenNow,
 		Rating:           place.Rating,
 		UserRatingsTotal: place.UserRatingsTotal,

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -15,14 +15,17 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 	var photoReferences []models.GooglePlacePhotoReference
 	if photos != nil {
 		photoReferences = make([]models.GooglePlacePhotoReference, len(*photos))
-		for _, photo := range *photos {
-			photoReferences = append(photoReferences, photo.ToPhotoReference())
+		for i, photo := range *photos {
+			photoReferences[i] = photo.ToPhotoReference()
 		}
 	} else if place.PhotoReferences != nil && len(place.PhotoReferences) > 0 {
 		// Nearby Search で取得した場合は PhotoReference がある
 		photoReferences = make([]models.GooglePlacePhotoReference, len(place.PhotoReferences))
-		for _, photo := range place.PhotoReferences {
-			photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
+		for i, photo := range place.PhotoReferences {
+			if photo.PhotoReference == "" {
+				continue
+			}
+			photoReferences[i] = GooglePlacePhotoReferenceFromPhoto(photo)
 		}
 	}
 

--- a/internal/domain/factory/google_place_photo.go
+++ b/internal/domain/factory/google_place_photo.go
@@ -1,20 +1,25 @@
 package factory
 
 import (
+	"googlemaps.github.io/maps"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
 func GooglePlacePhotoReferencesFromPlaceDetail(placeDetail places.PlaceDetail) []models.GooglePlacePhotoReference {
 	var photoReferences []models.GooglePlacePhotoReference
-	for _, photoReference := range placeDetail.Photos {
-		photoReferences = append(photoReferences, models.GooglePlacePhotoReference{
-			PhotoReference:   photoReference.PhotoReference,
-			Width:            photoReference.Width,
-			Height:           photoReference.Height,
-			HTMLAttributions: photoReference.HTMLAttributions,
-		})
+	for _, photo := range placeDetail.Photos {
+		photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
 	}
 
 	return photoReferences
+}
+
+func GooglePlacePhotoReferenceFromPhoto(photo maps.Photo) models.GooglePlacePhotoReference {
+	return models.GooglePlacePhotoReference{
+		PhotoReference:   photo.PhotoReference,
+		Width:            photo.Width,
+		Height:           photo.Height,
+		HTMLAttributions: photo.HTMLAttributions,
+	}
 }

--- a/internal/domain/factory/google_place_photo.go
+++ b/internal/domain/factory/google_place_photo.go
@@ -7,9 +7,9 @@ import (
 )
 
 func GooglePlacePhotoReferencesFromPlaceDetail(placeDetail places.PlaceDetail) []models.GooglePlacePhotoReference {
-	var photoReferences []models.GooglePlacePhotoReference
-	for _, photo := range placeDetail.Photos {
-		photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
+	photoReferences := make([]models.GooglePlacePhotoReference, len(placeDetail.Photos))
+	for i, photo := range placeDetail.Photos {
+		photoReferences[i] = GooglePlacePhotoReferenceFromPhoto(photo)
 	}
 
 	return photoReferences

--- a/internal/domain/models/google_place.go
+++ b/internal/domain/models/google_place.go
@@ -10,7 +10,7 @@ type GooglePlace struct {
 	Name             string
 	Types            []string
 	Location         GeoLocation
-	PhotoReferences  []string
+	PhotoReferences  []GooglePlacePhotoReference
 	OpenNow          bool
 	PriceLevel       int
 	Rating           float32

--- a/internal/domain/models/google_place.go
+++ b/internal/domain/models/google_place.go
@@ -15,6 +15,8 @@ type GooglePlace struct {
 	PriceLevel       int
 	Rating           float32
 	UserRatingsTotal int
+	Vicinity         *string
+	FormattedAddress *string
 	Photos           *[]GooglePlacePhoto
 	PlaceDetail      *GooglePlaceDetail
 }

--- a/internal/domain/models/google_place_photo.go
+++ b/internal/domain/models/google_place_photo.go
@@ -17,3 +17,12 @@ func (g GooglePlacePhoto) ToImage() Image {
 		Large: utils.StrCopyPointerValue(g.Large),
 	}
 }
+
+func (g GooglePlacePhoto) ToPhotoReference() GooglePlacePhotoReference {
+	return GooglePlacePhotoReference{
+		PhotoReference:   g.PhotoReference,
+		Width:            g.Width,
+		Height:           g.Height,
+		HTMLAttributions: g.HTMLAttributions,
+	}
+}

--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -84,7 +84,7 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 				placeTypePointer = &placeType
 			}
 
-			placesSearched, err := s.placesApi.FindPlacesFromLocation(ctx, &googleplaces.FindPlacesFromLocationRequest{
+			placesSearched, err := s.placesApi.NearbySearch(ctx, &googleplaces.NearbySearchRequest{
 				Location: googleplaces.Location{
 					Latitude:  input.Location.Latitude,
 					Longitude: input.Location.Longitude,

--- a/internal/domain/services/plancandidate/place.go
+++ b/internal/domain/services/plancandidate/place.go
@@ -50,11 +50,7 @@ func (s Service) FetchCandidatePlaces(
 
 		// TODO: キャッシュする
 		// TODO: 大きいサイズの写真も取得する
-		thumbnail, err := s.placesApi.FetchPlacePhoto([]models.GooglePlacePhotoReference{
-			{
-				PhotoReference: place.Google.PhotoReferences[0],
-			},
-		}, googleplaces.ImageSizeSmall())
+		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences, googleplaces.ImageSizeSmall())
 		if err != nil {
 			s.logger.Warn(
 				"error while fetching place photo",

--- a/internal/infrastructure/api/google/places/details.go
+++ b/internal/infrastructure/api/google/places/details.go
@@ -13,7 +13,7 @@ type FetchPlaceDetailRequest struct {
 }
 
 // FetchPlaceDetail は IDを指定することで、対応する場所の情報を取得する
-// 取得される内容は FindPlacesFromLocation と同じ
+// 取得される内容は NearbySearch と同じ
 func (r PlacesApi) FetchPlaceDetail(ctx context.Context, req FetchPlaceDetailRequest) (*Place, error) {
 	r.logger.Info(
 		"Places API Place Details",

--- a/internal/infrastructure/api/google/places/details.go
+++ b/internal/infrastructure/api/google/places/details.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"go.uber.org/zap"
 	"googlemaps.github.io/maps"
+	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
 type FetchPlaceDetailRequest struct {
@@ -40,22 +41,17 @@ func (r PlacesApi) FetchPlaceDetail(ctx context.Context, req FetchPlaceDetailReq
 		return nil, err
 	}
 
-	var photoReferences []string
-	if resp.Photos != nil {
-		for _, photo := range resp.Photos {
-			photoReferences = append(photoReferences, photo.PhotoReference)
-		}
-	}
-
 	place := createPlace(
 		resp.PlaceID,
 		resp.Name,
 		resp.Types,
 		resp.Geometry,
-		photoReferences,
+		resp.Photos,
 		resp.OpeningHours != nil && resp.OpeningHours.OpenNow != nil && *resp.OpeningHours.OpenNow,
 		resp.Rating,
 		resp.UserRatingsTotal,
+		utils.StrOmitEmpty(resp.FormattedAddress),
+		utils.StrOmitEmpty(resp.Vicinity),
 		resp.PriceLevel,
 	)
 

--- a/internal/infrastructure/api/google/places/nearbysearch.go
+++ b/internal/infrastructure/api/google/places/nearbysearch.go
@@ -4,10 +4,59 @@ import (
 	"context"
 	"fmt"
 	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/utils"
 	"time"
 
 	"googlemaps.github.io/maps"
 )
+
+type FindPlacesFromLocationRequest struct {
+	Location    Location
+	Radius      uint
+	Language    string
+	Type        *maps.PlaceType
+	SearchCount int
+}
+
+func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFromLocationRequest) ([]Place, error) {
+	var placeType maps.PlaceType
+	if req.Type != nil {
+		placeType = *req.Type
+	}
+
+	placeSearchResults, err := r.nearBySearch(ctx, &maps.NearbySearchRequest{
+		Location: &maps.LatLng{
+			Lat: req.Location.Latitude,
+			Lng: req.Location.Longitude,
+		},
+		Radius:   req.Radius,
+		Language: req.Language,
+		Type:     placeType,
+	}, req.SearchCount)
+	if err != nil {
+		return nil, err
+	}
+
+	// Getting places nearby
+	var places []Place
+	for _, place := range placeSearchResults {
+		places = append(places, createPlace(
+			place.PlaceID,
+			place.Name,
+			place.Types,
+			place.Geometry,
+			place.Photos,
+			place.OpeningHours != nil && place.OpeningHours.OpenNow != nil && *place.OpeningHours.OpenNow,
+			place.Rating,
+			place.UserRatingsTotal,
+			utils.StrOmitEmpty(place.FormattedAddress),
+			utils.StrOmitEmpty(place.Vicinity),
+			place.PriceLevel,
+		))
+	}
+
+	return places, nil
+}
 
 // nearBySearch Places API Nearby Search
 // https://developers.google.com/maps/documentation/places/web-service/search-nearby

--- a/internal/infrastructure/api/google/places/nearbysearch.go
+++ b/internal/infrastructure/api/google/places/nearbysearch.go
@@ -10,7 +10,7 @@ import (
 	"googlemaps.github.io/maps"
 )
 
-type FindPlacesFromLocationRequest struct {
+type NearbySearchRequest struct {
 	Location    Location
 	Radius      uint
 	Language    string
@@ -18,7 +18,7 @@ type FindPlacesFromLocationRequest struct {
 	SearchCount int
 }
 
-func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFromLocationRequest) ([]Place, error) {
+func (r PlacesApi) NearbySearch(ctx context.Context, req *NearbySearchRequest) ([]Place, error) {
 	var placeType maps.PlaceType
 	if req.Type != nil {
 		placeType = *req.Type

--- a/internal/infrastructure/api/google/places/places.go
+++ b/internal/infrastructure/api/google/places/places.go
@@ -1,7 +1,6 @@
 package places
 
 import (
-	"context"
 	"fmt"
 	"go.uber.org/zap"
 	"os"
@@ -40,52 +39,4 @@ func NewPlacesApi() (*PlacesApi, error) {
 		mapsClient: c,
 		logger:     logger,
 	}, nil
-}
-
-type FindPlacesFromLocationRequest struct {
-	Location    Location
-	Radius      uint
-	Language    string
-	Type        *maps.PlaceType
-	SearchCount int
-}
-
-func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFromLocationRequest) ([]Place, error) {
-	var placeType maps.PlaceType
-	if req.Type != nil {
-		placeType = *req.Type
-	}
-
-	placeSearchResults, err := r.nearBySearch(ctx, &maps.NearbySearchRequest{
-		Location: &maps.LatLng{
-			Lat: req.Location.Latitude,
-			Lng: req.Location.Longitude,
-		},
-		Radius:   req.Radius,
-		Language: req.Language,
-		Type:     placeType,
-	}, req.SearchCount)
-	if err != nil {
-		return nil, err
-	}
-
-	// Getting places nearby
-	var places []Place
-	for _, place := range placeSearchResults {
-		places = append(places, createPlace(
-			place.PlaceID,
-			place.Name,
-			place.Types,
-			place.Geometry,
-			place.Photos,
-			place.OpeningHours != nil && place.OpeningHours.OpenNow != nil && *place.OpeningHours.OpenNow,
-			place.Rating,
-			place.UserRatingsTotal,
-			utils.StrOmitEmpty(place.FormattedAddress),
-			utils.StrOmitEmpty(place.Vicinity),
-			place.PriceLevel,
-		))
-	}
-
-	return places, nil
 }

--- a/internal/infrastructure/api/google/places/places.go
+++ b/internal/infrastructure/api/google/places/places.go
@@ -72,20 +72,17 @@ func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFr
 	// Getting places nearby
 	var places []Place
 	for _, place := range placeSearchResults {
-		var photoReferences []string
-		for _, photo := range place.Photos {
-			photoReferences = append(photoReferences, photo.PhotoReference)
-		}
-
 		places = append(places, createPlace(
 			place.PlaceID,
 			place.Name,
 			place.Types,
 			place.Geometry,
-			photoReferences,
+			place.Photos,
 			place.OpeningHours != nil && place.OpeningHours.OpenNow != nil && *place.OpeningHours.OpenNow,
 			place.Rating,
 			place.UserRatingsTotal,
+			utils.StrOmitEmpty(place.FormattedAddress),
+			utils.StrOmitEmpty(place.Vicinity),
 			place.PriceLevel,
 		))
 	}

--- a/internal/infrastructure/api/google/places/types.go
+++ b/internal/infrastructure/api/google/places/types.go
@@ -9,11 +9,13 @@ type Place struct {
 	Name             string
 	Types            []string
 	Location         Location
-	PhotoReferences  []string
+	PhotoReferences  []maps.Photo
 	OpenNow          bool
 	Rating           float32
 	UserRatingsTotal int
 	PriceLevel       int
+	FormattedAddress *string
+	Vicinity         *string
 	PlaceDetail      *PlaceDetail
 }
 
@@ -33,10 +35,12 @@ func createPlace(
 	name string,
 	types []string,
 	geometry maps.AddressGeometry,
-	photoReferences []string,
+	photoReferences []maps.Photo,
 	openNow bool,
 	rating float32,
 	userRatingsTotal int,
+	formattedAddress *string,
+	vicinity *string,
 	priceLevel int,
 ) Place {
 	return Place{
@@ -48,6 +52,8 @@ func createPlace(
 		Rating:           rating,
 		UserRatingsTotal: userRatingsTotal,
 		PriceLevel:       priceLevel,
+		FormattedAddress: formattedAddress,
+		Vicinity:         vicinity,
 		Location: Location{
 			Latitude:  geometry.Location.Lat,
 			Longitude: geometry.Location.Lng,

--- a/internal/infrastructure/firestore/entity/google_place.go
+++ b/internal/infrastructure/firestore/entity/google_place.go
@@ -4,12 +4,12 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
+// GooglePlaceEntity NearbySearchで取得できるデータをキャッシュ
 type GooglePlaceEntity struct {
 	PlaceID          string                         `firestore:"place_id"`
 	Name             string                         `firestore:"name"`
 	Types            []string                       `firestore:"types"`
 	Location         GeoLocationEntity              `firestore:"location"`
-	PhotoReferences  []string                       `firestore:"photo_references"`
 	OpenNow          bool                           `firestore:"open_now"`
 	Rating           float32                        `firestore:"rating"`
 	UserRatingsTotal int                            `firestore:"user_ratings_total"`
@@ -30,7 +30,6 @@ func GooglePlaceEntityFromGooglePlace(place models.GooglePlace) GooglePlaceEntit
 		PlaceID:          place.PlaceId,
 		Name:             place.Name,
 		Types:            place.Types,
-		PhotoReferences:  place.PhotoReferences,
 		OpenNow:          place.OpenNow,
 		Rating:           place.Rating,
 		UserRatingsTotal: place.UserRatingsTotal,
@@ -54,7 +53,6 @@ func (g GooglePlaceEntity) ToGooglePlace(photoEntities *[]GooglePlacePhotoEntity
 		Name:             g.Name,
 		Types:            g.Types,
 		Location:         location,
-		PhotoReferences:  g.PhotoReferences,
 		OpenNow:          g.OpenNow,
 		Rating:           g.Rating,
 		UserRatingsTotal: g.UserRatingsTotal,

--- a/internal/infrastructure/firestore/entity/google_place.go
+++ b/internal/infrastructure/firestore/entity/google_place.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
 // GooglePlaceEntity NearbySearchで取得できるデータをキャッシュ
@@ -14,6 +15,8 @@ type GooglePlaceEntity struct {
 	Rating           float32                        `firestore:"rating"`
 	UserRatingsTotal int                            `firestore:"user_ratings_total"`
 	PriceLevel       int                            `firestore:"price_level"`
+	FormattedAddress string                         `firestore:"formatted_address"`
+	Vicinity         string                         `firestore:"vicinity"`
 	OpeningHours     *GooglePlaceOpeningHoursEntity `firestore:"opening_hours"`
 }
 
@@ -35,6 +38,8 @@ func GooglePlaceEntityFromGooglePlace(place models.GooglePlace) GooglePlaceEntit
 		UserRatingsTotal: place.UserRatingsTotal,
 		PriceLevel:       place.PriceLevel,
 		OpeningHours:     openingHours,
+		FormattedAddress: utils.StrEmptyIfNil(place.FormattedAddress),
+		Vicinity:         utils.StrEmptyIfNil(place.Vicinity),
 		Location: GeoLocationEntity{
 			Latitude:  place.Location.Latitude,
 			Longitude: place.Location.Longitude,
@@ -57,6 +62,8 @@ func (g GooglePlaceEntity) ToGooglePlace(photoEntities *[]GooglePlacePhotoEntity
 		Rating:           g.Rating,
 		UserRatingsTotal: g.UserRatingsTotal,
 		PriceLevel:       g.PriceLevel,
+		FormattedAddress: utils.StrOmitEmpty(g.FormattedAddress),
+		Vicinity:         utils.StrOmitEmpty(g.Vicinity),
 		Photos:           g.toGooglePlacePhotos(photoEntities),
 		PlaceDetail:      g.toGooglePlaceDetail(photoEntities, reviewEntities),
 	}

--- a/internal/infrastructure/firestore/place.go
+++ b/internal/infrastructure/firestore/place.go
@@ -111,6 +111,11 @@ func (p PlaceRepository) SavePlacesFromGooglePlace(ctx context.Context, googlePl
 			if err := p.updateOpeningHours(tx, placeEntity.Id, *googlePlace.PlaceDetail); err != nil {
 				return fmt.Errorf("error while updating opening hours: %v", err)
 			}
+		} else if len(googlePlace.PhotoReferences) != 0 {
+			// Nearby Searchで画像を取得している場合は保存する
+			if err := p.saveGooglePhotoReferencesTx(tx, placeEntity.Id, googlePlace.PhotoReferences); err != nil {
+				return fmt.Errorf("error while saving google place photos: %v", err)
+			}
 		}
 
 		// Place Photo を保存する

--- a/internal/infrastructure/firestore/place.go
+++ b/internal/infrastructure/firestore/place.go
@@ -76,6 +76,11 @@ func (p PlaceRepository) SavePlacesFromGooglePlace(ctx context.Context, googlePl
 			}
 
 			if gp != nil {
+				p.logger.Info(
+					"Skip saving place because it is already saved",
+					zap.String("placeId", placeEntity.Id),
+					zap.String("googlePlaceId", googlePlace.PlaceId),
+				)
 				googlePlace = *gp
 				return nil
 			}
@@ -111,7 +116,7 @@ func (p PlaceRepository) SavePlacesFromGooglePlace(ctx context.Context, googlePl
 			if err := p.updateOpeningHours(tx, placeEntity.Id, *googlePlace.PlaceDetail); err != nil {
 				return fmt.Errorf("error while updating opening hours: %v", err)
 			}
-		} else if len(googlePlace.PhotoReferences) != 0 {
+		} else if len(googlePlace.PhotoReferences) > 0 {
 			// Nearby Searchで画像を取得している場合は保存する
 			if err := p.saveGooglePhotoReferencesTx(tx, placeEntity.Id, googlePlace.PhotoReferences); err != nil {
 				return fmt.Errorf("error while saving google place photos: %v", err)
@@ -618,12 +623,24 @@ func (p PlaceRepository) saveGooglePhotoReferencesTx(tx *firestore.Transaction, 
 	chErr := make(chan error)
 	for _, photoReference := range photoReferences {
 		go func(tx *firestore.Transaction, ch chan<- *models.GooglePlacePhotoReference, placeId string, photoReference models.GooglePlacePhotoReference) {
+			p.logger.Info(
+				"start saving google place photo references",
+				zap.String("placeId", placeId),
+				zap.String("photoReference", photoReference.PhotoReference),
+				zap.String("width", fmt.Sprintf("%d", photoReference.Width)),
+				zap.String("height", fmt.Sprintf("%d", photoReference.Height)),
+			)
 			photoEntity := entity.GooglePlacePhotoEntityFromGooglePhotoReference(photoReference)
 			if err := tx.Set(p.subCollectionGooglePlacePhoto(placeId).Doc(photoReference.PhotoReference), photoEntity); err != nil {
 				chErr <- fmt.Errorf("error while saving google place photo reference: %v", err)
 			} else {
 				ch <- &photoReference
 			}
+			p.logger.Info(
+				"successfully saved google place photo references",
+				zap.String("placeId", placeId),
+				zap.String("photoReference", photoReference.PhotoReference),
+			)
 		}(tx, ch, placeId, photoReference)
 	}
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Place Detailの呼び出しをしなくても良いようにするため、Nearby Searchで取得した画像の情報が保存されるようにした。
- また、Nearby Searchで取れる情報はなるべくキャッシュするために住所の情報も取得するようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- Place Detailの呼び出し回数を減らすため（そのための準備）

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] Nearby Searchで検索した段階でPhotoReferenceが保存されていることを確認(ログに表示されている保存の状況をみながらFirestoreで確認する)
![image](https://github.com/poroto-app/planner/assets/55840281/77016797-9743-4b02-ba65-f6a7adf7542a)

- [x] 住所の情報(vicinity)が保存されていることを確認
![image](https://github.com/poroto-app/planner/assets/55840281/8af92195-73e2-45d0-9896-02d0ba3ae61f)
