### PR TITLE
写真取得のためにPlaceDetailが呼ばれないようにする

### DIFF
--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -5,7 +5,6 @@ import (
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/models"
-	api "poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
 // FetchGooglePlacesPhotos は，指定された場所の写真を一括で取得する
@@ -37,13 +36,7 @@ func (s Service) FetchGooglePlacesPhotos(ctx context.Context, places []models.Go
 				return
 			}
 
-			photos, err := s.placesApi.FetchPlacePhotos(
-				ctx,
-				place.PlaceDetail.PhotoReferences,
-				1,
-				api.ImageSizeTypeSmall,
-				api.ImageSizeTypeLarge,
-			)
+			photos, err := s.placesApi.FetchPlacePhotos(ctx, place.PlaceDetail.PhotoReferences, 1)
 			if err != nil {
 				// TODO: channelを用いてエラーハンドリングする
 				s.logger.Warn(

--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -7,9 +7,52 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-// FetchGooglePlacesPhotos は，指定された場所の写真を一括で取得する
+// FetchPlacesPhotosAndSave は，指定された場所の写真を一括で取得し，保存する
+func (s Service) FetchPlacesPhotosAndSave(ctx context.Context, places ...models.Place) []models.Place {
+	var googlePlaces []models.GooglePlace
+	for _, place := range places {
+		googlePlaces = append(googlePlaces, place.Google)
+	}
+
+	// 写真が取得されていない場所のみ、画像が保存されるようにする
+	var googlePlaceIdsAlreadyHasImages []string
+	for _, googlePlace := range googlePlaces {
+		if googlePlace.Photos != nil && len(*googlePlace.Photos) > 0 {
+			googlePlaceIdsAlreadyHasImages = append(googlePlaceIdsAlreadyHasImages, googlePlace.PlaceId)
+		}
+	}
+
+	// 画像を取得
+	googlePlaces = s.fetchGooglePlacesPhotos(ctx, googlePlaces)
+
+	// 画像を保存
+	for _, googlePlace := range googlePlaces {
+		// すでに写真が取得済みの場合は何もしない
+		alreadyHasImages := array.IsContain(googlePlaceIdsAlreadyHasImages, googlePlace.PlaceId)
+		if alreadyHasImages {
+			continue
+		}
+
+		if googlePlace.Photos == nil || len(*googlePlace.Photos) == 0 {
+			continue
+		}
+
+		// 新しく画像を取得した場合は，保存する
+		if err := s.placeRepository.SaveGooglePlacePhotos(ctx, googlePlace.PlaceId, *googlePlace.Photos); err != nil {
+			continue
+		}
+	}
+
+	for i, googlePlace := range googlePlaces {
+		places[i].Google = googlePlace
+	}
+
+	return places
+}
+
+// fetchGooglePlacesPhotos は，指定された場所の写真を一括で取得する
 // すでに写真がある場合は，何もしない
-func (s Service) FetchGooglePlacesPhotos(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
+func (s Service) fetchGooglePlacesPhotos(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
 	if len(places) == 0 {
 		return places
 	}
@@ -63,55 +106,6 @@ func (s Service) FetchGooglePlacesPhotos(ctx context.Context, places []models.Go
 			places[i] = placeUpdated
 			break
 		}
-	}
-
-	return places
-}
-
-// FetchGooglePlacesPhotosAndSave は，指定された場所の写真を一括で取得し，保存する
-// 事前に FetchPlaceDetailAndSave で models.GooglePlaceDetail を取得しておく必要がある
-func (s Service) FetchGooglePlacesPhotosAndSave(ctx context.Context, planCandidateId string, places ...models.GooglePlace) []models.GooglePlace {
-	// 写真が取得されていない場所のみ、画像が保存されるようにする
-	var googlePlaceIdsAlreadyHasImages []string
-	for _, place := range places {
-		if place.Photos != nil && len(*place.Photos) > 0 {
-			googlePlaceIdsAlreadyHasImages = append(googlePlaceIdsAlreadyHasImages, place.PlaceId)
-		}
-	}
-
-	// 画像を取得
-	places = s.FetchGooglePlacesPhotos(ctx, places)
-
-	// 画像を保存
-	for _, place := range places {
-		// すでに写真が取得済みの場合は何もしない
-		alreadyHasImages := array.IsContain(googlePlaceIdsAlreadyHasImages, place.PlaceId)
-		if alreadyHasImages {
-			continue
-		}
-
-		if place.Photos == nil || len(*place.Photos) == 0 {
-			continue
-		}
-
-		if err := s.placeRepository.SaveGooglePlacePhotos(ctx, place.PlaceId, *place.Photos); err != nil {
-			continue
-		}
-	}
-
-	return places
-}
-
-func (s Service) FetchPlacesPhotosAndSave(ctx context.Context, planCandidateId string, places ...models.Place) []models.Place {
-	googlePlaces := make([]models.GooglePlace, len(places))
-	for i, place := range places {
-		googlePlaces[i] = place.Google
-	}
-
-	googlePlaces = s.FetchGooglePlacesPhotosAndSave(ctx, planCandidateId, googlePlaces...)
-
-	for i, googlePlace := range googlePlaces {
-		places[i].Google = googlePlace
 	}
 
 	return places

--- a/internal/domain/services/place/place_detail.go
+++ b/internal/domain/services/place/place_detail.go
@@ -3,7 +3,6 @@ package place
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/factory"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/infrastructure/api/google/places"
@@ -60,62 +59,4 @@ func (s Service) FetchPlaceDetailAndSave(ctx context.Context, googlePlaceId stri
 	}
 
 	return &placeDetail, nil
-}
-
-// FetchPlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
-func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
-	if len(places) == 0 {
-		return nil
-	}
-
-	googlePlaces := make([]models.GooglePlace, len(places))
-	for i, place := range places {
-		googlePlaces[i] = place.Google
-	}
-
-	// Place Detailを並行に取得する
-	ch := make(chan *models.GooglePlace, len(googlePlaces))
-	for _, googlePlace := range googlePlaces {
-		go func(ctx context.Context, googlePlace models.GooglePlace, ch chan<- *models.GooglePlace) {
-			if googlePlace.PlaceDetail != nil {
-				s.logger.Info(
-					"skip fetching place detail because place detail already exist",
-					zap.String("placeId", googlePlace.PlaceId),
-				)
-				ch <- &googlePlace
-				return
-			}
-
-			// 取得と保存を行う
-			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, googlePlace.PlaceId)
-			if err != nil {
-				ch <- nil
-				return
-			}
-
-			googlePlace.PlaceDetail = placeDetail
-
-			ch <- &googlePlace
-		}(ctx, googlePlace, ch)
-	}
-
-	for i := 0; i < len(googlePlaces); i++ {
-		placeWithPlaceDetail := <-ch
-		if placeWithPlaceDetail == nil {
-			continue
-		}
-
-		for iPlace, googlePlace := range googlePlaces {
-			if placeWithPlaceDetail.PlaceId == googlePlace.PlaceId {
-				googlePlaces[iPlace] = *placeWithPlaceDetail
-			}
-		}
-	}
-
-	// Place DetailとGoogle Placeを紐付ける
-	for i, googlePlace := range googlePlaces {
-		places[i].Google = googlePlace
-	}
-
-	return places
 }

--- a/internal/domain/services/place/place_detail.go
+++ b/internal/domain/services/place/place_detail.go
@@ -62,60 +62,57 @@ func (s Service) FetchPlaceDetailAndSave(ctx context.Context, googlePlaceId stri
 	return &placeDetail, nil
 }
 
-// FetchGooglePlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
-func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
+// FetchPlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
+func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
 	if len(places) == 0 {
 		return nil
 	}
 
-	ch := make(chan *models.GooglePlace, len(places))
-	for _, place := range places {
-		go func(ctx context.Context, place models.GooglePlace, ch chan<- *models.GooglePlace) {
-			if place.PlaceDetail != nil {
-				s.logger.Info(
-					"skip fetching place detail because place detail already exist",
-					zap.String("placeId", place.PlaceId),
-				)
-				ch <- &place
-				return
-			}
-
-			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, place.PlaceId)
-			if err != nil {
-				ch <- nil
-				return
-			}
-
-			place.PlaceDetail = placeDetail
-
-			ch <- &place
-		}(ctx, place, ch)
-	}
-
-	for i := 0; i < len(places); i++ {
-		placeWithPlaceDetail := <-ch
-		if placeWithPlaceDetail == nil {
-			continue
-		}
-
-		for iPlace, place := range places {
-			if placeWithPlaceDetail.PlaceId == place.PlaceId {
-				places[iPlace] = *placeWithPlaceDetail
-			}
-		}
-	}
-
-	return places
-}
-
-func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
 	googlePlaces := make([]models.GooglePlace, len(places))
 	for i, place := range places {
 		googlePlaces[i] = place.Google
 	}
 
-	googlePlaces = s.FetchGooglePlacesDetailAndSave(ctx, googlePlaces)
+	// Place Detailを並行に取得する
+	ch := make(chan *models.GooglePlace, len(googlePlaces))
+	for _, googlePlace := range googlePlaces {
+		go func(ctx context.Context, googlePlace models.GooglePlace, ch chan<- *models.GooglePlace) {
+			if googlePlace.PlaceDetail != nil {
+				s.logger.Info(
+					"skip fetching place detail because place detail already exist",
+					zap.String("placeId", googlePlace.PlaceId),
+				)
+				ch <- &googlePlace
+				return
+			}
 
+			// 取得と保存を行う
+			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, googlePlace.PlaceId)
+			if err != nil {
+				ch <- nil
+				return
+			}
+
+			googlePlace.PlaceDetail = placeDetail
+
+			ch <- &googlePlace
+		}(ctx, googlePlace, ch)
+	}
+
+	for i := 0; i < len(googlePlaces); i++ {
+		placeWithPlaceDetail := <-ch
+		if placeWithPlaceDetail == nil {
+			continue
+		}
+
+		for iPlace, googlePlace := range googlePlaces {
+			if placeWithPlaceDetail.PlaceId == googlePlace.PlaceId {
+				googlePlaces[iPlace] = *placeWithPlaceDetail
+			}
+		}
+	}
+
+	// Place DetailとGoogle Placeを紐付ける
 	for i, googlePlace := range googlePlaces {
 		places[i].Google = googlePlace
 	}

--- a/internal/domain/services/place/place_detail.go
+++ b/internal/domain/services/place/place_detail.go
@@ -29,7 +29,7 @@ func (s Service) FetchGooglePlace(ctx context.Context, googlePlaceId string) (*m
 }
 
 // FetchPlaceDetailAndSave Place Detail　情報を取得し、保存する
-func (s Service) FetchPlaceDetailAndSave(ctx context.Context, planCandidateId string, googlePlaceId string) (*models.GooglePlaceDetail, error) {
+func (s Service) FetchPlaceDetailAndSave(ctx context.Context, googlePlaceId string) (*models.GooglePlaceDetail, error) {
 	// キャッシュがある場合は取得する
 	savedPlace, err := s.placeRepository.FindByGooglePlaceID(ctx, googlePlaceId)
 	if err != nil {
@@ -63,7 +63,7 @@ func (s Service) FetchPlaceDetailAndSave(ctx context.Context, planCandidateId st
 }
 
 // FetchGooglePlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
-func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, planCandidateId string, places []models.GooglePlace) []models.GooglePlace {
+func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
 	if len(places) == 0 {
 		return nil
 	}
@@ -80,7 +80,7 @@ func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, planCandida
 				return
 			}
 
-			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, planCandidateId, place.PlaceId)
+			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, place.PlaceId)
 			if err != nil {
 				ch <- nil
 				return
@@ -108,13 +108,13 @@ func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, planCandida
 	return places
 }
 
-func (s Service) FetchPlacesDetailAndSave(ctx context.Context, planCandidateId string, places []models.Place) []models.Place {
+func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
 	googlePlaces := make([]models.GooglePlace, len(places))
 	for i, place := range places {
 		googlePlaces[i] = place.Google
 	}
 
-	googlePlaces = s.FetchGooglePlacesDetailAndSave(ctx, planCandidateId, googlePlaces)
+	googlePlaces = s.FetchGooglePlacesDetailAndSave(ctx, googlePlaces)
 
 	for i, googlePlace := range googlePlaces {
 		places[i].Google = googlePlace

--- a/internal/domain/services/plancandidate/add_place.go
+++ b/internal/domain/services/plancandidate/add_place.go
@@ -62,7 +62,7 @@ func (s Service) AddPlaceAfterPlace(ctx context.Context, planCandidateId string,
 		"Fetching photos and reviews for places for plan candidate",
 		zap.String("planCandidateId", planCandidateId),
 	)
-	placesWithPhoto := s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, *placeToAdd)
+	placesWithPhoto := s.placeService.FetchPlacesPhotosAndSave(ctx, *placeToAdd)
 	placeToAdd = &placesWithPhoto[0]
 	s.logger.Info(
 		"Successfully fetched photos and reviews for places for plan candidate",

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -104,7 +104,7 @@ func (s Service) CategoriesNearLocation(
 		}
 
 		// 場所の詳細情報を取得
-		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, params.CreatePlanSessionId, placesSortedByCategoryIndex)
+		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, placesSortedByCategoryIndex)
 
 		// 場所の写真を取得する
 		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesWithDetail...)

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -103,11 +103,8 @@ func (s Service) CategoriesNearLocation(
 			placesSortedByCategoryIndex = placesSortedByCategoryIndex[:params.MaxPlacesPerCategory]
 		}
 
-		// 場所の詳細情報を取得
-		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, placesSortedByCategoryIndex)
-
 		// 場所の写真を取得する
-		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesWithDetail...)
+		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesSortedByCategoryIndex...)
 
 		categoriesWithPlaces = append(categoriesWithPlaces, models.NewLocationCategoryWithPlaces(*category, placesWithPhotos))
 	}

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -107,7 +107,7 @@ func (s Service) CategoriesNearLocation(
 		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, params.CreatePlanSessionId, placesSortedByCategoryIndex)
 
 		// 場所の写真を取得する
-		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, params.CreatePlanSessionId, placesWithDetail...)
+		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesWithDetail...)
 
 		categoriesWithPlaces = append(categoriesWithPlaces, models.NewLocationCategoryWithPlaces(*category, placesWithPhotos))
 	}

--- a/internal/domain/services/plancandidate/place.go
+++ b/internal/domain/services/plancandidate/place.go
@@ -2,7 +2,6 @@ package plancandidate
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"sort"
 
 	"poroto.app/poroto/planner/internal/domain/models"
@@ -47,20 +46,8 @@ func (s Service) FetchCandidatePlaces(
 			continue
 		}
 
-		// TODO: キャッシュする
-		// TODO: 大きいサイズの写真も取得する
-		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences)
-		if err != nil {
-			s.logger.Warn(
-				"error while fetching place photo",
-				zap.String("placeId", place.Id),
-				zap.String("planCandidateId", createPlanSessionId),
-				zap.Error(err),
-			)
-			continue
-		}
-
-		place.Google.Photos = &[]models.GooglePlacePhoto{*thumbnail}
+		placesWithPhoto := s.placeService.FetchPlacesPhotosAndSave(ctx, place)
+		place = placesWithPhoto[0]
 
 		placesToSuggest = append(placesToSuggest, place)
 

--- a/internal/domain/services/plancandidate/place.go
+++ b/internal/domain/services/plancandidate/place.go
@@ -7,7 +7,6 @@ import (
 
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
-	googleplaces "poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
 // FetchCandidatePlaces はプランの候補となる場所を取得する
@@ -50,7 +49,7 @@ func (s Service) FetchCandidatePlaces(
 
 		// TODO: キャッシュする
 		// TODO: 大きいサイズの写真も取得する
-		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences, googleplaces.ImageSizeSmall())
+		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences)
 		if err != nil {
 			s.logger.Warn(
 				"error while fetching place photo",

--- a/internal/domain/services/plancandidate/places_to_add.go
+++ b/internal/domain/services/plancandidate/places_to_add.go
@@ -70,9 +70,6 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, planCandidateId string, p
 		placesToAdd = append(placesToAdd, place)
 	}
 
-	// 場所の詳細情報を取得
-	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, placesToAdd)
-
 	// 写真を取得
 	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToAdd...)
 

--- a/internal/domain/services/plancandidate/places_to_add.go
+++ b/internal/domain/services/plancandidate/places_to_add.go
@@ -74,7 +74,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, planCandidateId string, p
 	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToAdd)
 
 	// 写真を取得
-	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, placesToAdd...)
+	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToAdd...)
 
 	return placesToAdd, nil
 }

--- a/internal/domain/services/plancandidate/places_to_add.go
+++ b/internal/domain/services/plancandidate/places_to_add.go
@@ -71,7 +71,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, planCandidateId string, p
 	}
 
 	// 場所の詳細情報を取得
-	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToAdd)
+	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, placesToAdd)
 
 	// 写真を取得
 	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToAdd...)

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -93,7 +93,7 @@ func (s Service) FetchPlacesToReplace(
 	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToReplace)
 
 	// 画像を取得
-	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, placesToReplace...)
+	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToReplace...)
 
 	return placesToReplace, nil
 }

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -90,7 +90,7 @@ func (s Service) FetchPlacesToReplace(
 	}
 
 	// 詳細情報を取得
-	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToReplace)
+	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, placesToReplace)
 
 	// 画像を取得
 	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToReplace...)

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -89,9 +89,6 @@ func (s Service) FetchPlacesToReplace(
 		placesToReplace = placesToReplace[:nLimit]
 	}
 
-	// 詳細情報を取得
-	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, placesToReplace)
-
 	// 画像を取得
 	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToReplace...)
 

--- a/internal/domain/services/plangen/create.go
+++ b/internal/domain/services/plangen/create.go
@@ -148,7 +148,7 @@ func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesPa
 
 		if params.shouldOpenWhileTraveling && params.freeTime == nil {
 			// 場所の詳細を取得(Place Detailリクエストが発生するため、ある程度フィルタリングしたあとに行う)
-			placeDetail, err := s.placeService.FetchPlaceDetailAndSave(ctx, params.planCandidateId, place.Google.PlaceId)
+			placeDetail, err := s.placeService.FetchPlaceDetailAndSave(ctx, place.Google.PlaceId)
 			if err != nil {
 				s.logger.Warn(
 					"error while fetching place detail",

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -116,7 +116,7 @@ func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId strin
 		placesToUpdate = append(placesToUpdate, place)
 	}
 
-	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToUpdate)
+	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, placesToUpdate)
 	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToUpdate...)
 
 	for _, place := range placesToUpdate {

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -117,7 +117,7 @@ func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId strin
 	}
 
 	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToUpdate)
-	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, placesToUpdate...)
+	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToUpdate...)
 
 	for _, place := range placesToUpdate {
 		placeIdToPlace[place.Id] = place

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -116,7 +116,6 @@ func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId strin
 		placesToUpdate = append(placesToUpdate, place)
 	}
 
-	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, placesToUpdate)
 	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToUpdate...)
 
 	for _, place := range placesToUpdate {

--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -15,50 +15,15 @@ type ImageSize struct {
 	Height uint
 }
 
-type ImageSizeType int
-
 type PlacePhotoWithSize struct {
 	photoReference models.GooglePlacePhotoReference
 	imageUrl       string
-	size           ImageSizeType
 }
 
 const (
-	imgMaxHeightLarge = 1000
-	imgMaxWidthLarge  = 1000
-	imgMaxHeightSmall = 400
-	imgMaxWidthSmall  = 400
+	imgMaxHeight = 2000
+	imgMaxWidth  = 2000
 )
-
-const (
-	ImageSizeTypeLarge ImageSizeType = iota
-	ImageSizeTypeSmall
-)
-
-func ImageSizeLarge() ImageSize {
-	return ImageSize{
-		Width:  imgMaxWidthLarge,
-		Height: imgMaxHeightLarge,
-	}
-}
-
-func ImageSizeSmall() ImageSize {
-	return ImageSize{
-		Width:  imgMaxWidthSmall,
-		Height: imgMaxHeightSmall,
-	}
-}
-
-func (i ImageSizeType) ImageSize() ImageSize {
-	switch i {
-	case ImageSizeTypeLarge:
-		return ImageSizeLarge()
-	case ImageSizeTypeSmall:
-		return ImageSizeSmall()
-	default:
-		panic(fmt.Sprintf("invalid image size type: %v", i))
-	}
-}
 
 func imgUrlBuilder(maxWidth uint, maxHeight uint, photoReference string, apiKey string) (string, error) {
 	u, err := url.Parse("https://maps.googleapis.com")
@@ -102,13 +67,13 @@ func fetchPublicImageUrl(photoUrl string) (*string, error) {
 }
 
 // FetchPlacePhoto は，指定された場所の画像を１件取得する
-func (r PlacesApi) FetchPlacePhoto(photoReferences []models.GooglePlacePhotoReference, imageSize ImageSize) (*models.GooglePlacePhoto, error) {
+func (r PlacesApi) FetchPlacePhoto(photoReferences []models.GooglePlacePhotoReference) (*models.GooglePlacePhoto, error) {
 	if len(photoReferences) == 0 {
 		return nil, nil
 	}
 
 	photoReference := photoReferences[0]
-	imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photoReference.PhotoReference, r.apiKey)
+	imgUrl, err := imgUrlBuilder(imgMaxWidth, imgMaxHeight, photoReference.PhotoReference, r.apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -126,94 +91,71 @@ func (r PlacesApi) FetchPlacePhoto(photoReferences []models.GooglePlacePhotoRefe
 // imageSizeTypes が指定されている場合は，高画質の写真を取得する
 // 画像取得は呼び出し料金が高いため、複数の場所の写真を取得するときは注意
 // https://developers.google.com/maps/documentation/places/web-service/usage-and-billing?hl=ja#places-photo-new
-// TODO: 単一の画像だけを取得するようにする
-func (r PlacesApi) FetchPlacePhotos(ctx context.Context, photoReferences []models.GooglePlacePhotoReference, maxPhotoCount int, imageSizeTypes ...ImageSizeType) ([]models.GooglePlacePhoto, error) {
-	if len(imageSizeTypes) == 0 {
-		imageSizeTypes = []ImageSizeType{ImageSizeTypeLarge}
-	}
-
-	ch := make(chan *PlacePhotoWithSize, len(photoReferences)*len(imageSizeTypes))
+func (r PlacesApi) FetchPlacePhotos(ctx context.Context, photoReferences []models.GooglePlacePhotoReference, maxPhotoCount int) ([]models.GooglePlacePhoto, error) {
+	ch := make(chan *PlacePhotoWithSize, len(photoReferences))
 	for iPhoto, photoReference := range photoReferences {
-		for _, imageSizeType := range imageSizeTypes {
-			go func(ctx context.Context, photoIndex int, photoReference models.GooglePlacePhotoReference, imageSizeType ImageSizeType, ch chan<- *PlacePhotoWithSize) {
-				// 画像取得数が上限に達した場合は、何もしない
-				if photoIndex >= maxPhotoCount {
-					ch <- nil
-					return
+		go func(ctx context.Context, photoIndex int, photoReference models.GooglePlacePhotoReference, ch chan<- *PlacePhotoWithSize) {
+			// 画像取得数が上限に達した場合は、何もしない
+			if photoIndex >= maxPhotoCount {
+				ch <- nil
+				return
+			}
+
+			var imageSize ImageSize
+			if photoReference.Width > imgMaxWidth || photoReference.Height > imgMaxHeight {
+				imageSize = ImageSize{
+					Width:  imgMaxWidth,
+					Height: imgMaxHeight,
 				}
-
-				imageSize := imageSizeType.ImageSize()
-
-				imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photoReference.PhotoReference, r.apiKey)
-				if err != nil {
-					// TODO: channelにエラーを送信するようにする
-					r.logger.Warn(
-						"skipping photoReference because of error while building image url",
-						zap.Error(err),
-						zap.String("photoReference", photoReference.PhotoReference),
-					)
-					ch <- nil
-					return
+			} else {
+				imageSize = ImageSize{
+					Width:  uint(photoReference.Width),
+					Height: uint(photoReference.Height),
 				}
+			}
 
-				r.logger.Info(
-					"Places API Fetch Place Photo",
+			imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photoReference.PhotoReference, r.apiKey)
+			if err != nil {
+				// TODO: channelにエラーを送信するようにする
+				r.logger.Warn(
+					"skipping photoReference because of error while building image url",
+					zap.Error(err),
 					zap.String("photoReference", photoReference.PhotoReference),
 				)
-				publicImageUrl, err := fetchPublicImageUrl(imgUrl)
-				if err != nil {
-					// TODO: channelにエラーを送信するようにする
-					r.logger.Warn(
-						"skipping photoReference because of error while fetching public image url",
-						zap.Error(err),
-						zap.String("photoReference", photoReference.PhotoReference),
-					)
-					ch <- nil
-					return
-				}
+				ch <- nil
+				return
+			}
 
-				ch <- &PlacePhotoWithSize{
-					photoReference: photoReference,
-					imageUrl:       *publicImageUrl,
-					size:           imageSizeType,
-				}
-			}(ctx, iPhoto, photoReference, imageSizeType, ch)
-		}
+			r.logger.Info(
+				"Places API Fetch Place Photo",
+				zap.String("photoReference", photoReference.PhotoReference),
+			)
+			publicImageUrl, err := fetchPublicImageUrl(imgUrl)
+			if err != nil {
+				// TODO: channelにエラーを送信するようにする
+				r.logger.Warn(
+					"skipping photoReference because of error while fetching public image url",
+					zap.Error(err),
+					zap.String("photoReference", photoReference.PhotoReference),
+				)
+				ch <- nil
+				return
+			}
+
+			ch <- &PlacePhotoWithSize{
+				photoReference: photoReference,
+				imageUrl:       *publicImageUrl,
+			}
+		}(ctx, iPhoto, photoReference, ch)
 	}
 
-	var placePhotoWithSizes []PlacePhotoWithSize
-	for i := 0; i < len(photoReferences)*len(imageSizeTypes); i++ {
+	var placePhotos []models.GooglePlacePhoto
+	for i := 0; i < len(photoReferences); i++ {
 		placePhotoWithSize := <-ch
 		if placePhotoWithSize == nil {
 			continue
 		}
-		placePhotoWithSizes = append(placePhotoWithSizes, *placePhotoWithSize)
-	}
-
-	var placePhotos []models.GooglePlacePhoto
-	for _, photoReference := range photoReferences {
-		var photoUrlSmall, photoUrlLarge *string
-
-		for _, placePhotoWithSize := range placePhotoWithSizes {
-			if placePhotoWithSize.photoReference.PhotoReference != photoReference.PhotoReference {
-				continue
-			}
-
-			switch placePhotoWithSize.size {
-			case ImageSizeTypeLarge:
-				photoUrlLarge = &placePhotoWithSize.imageUrl
-			case ImageSizeTypeSmall:
-				photoUrlSmall = &placePhotoWithSize.imageUrl
-			default:
-				panic(fmt.Sprintf("invalid image size type: %v", placePhotoWithSize.size))
-			}
-		}
-
-		if photoUrlLarge == nil && photoUrlSmall == nil {
-			continue
-		}
-
-		placePhotos = append(placePhotos, photoReference.ToGooglePlacePhoto(photoUrlSmall, photoUrlLarge))
+		placePhotos = append(placePhotos, placePhotoWithSize.photoReference.ToGooglePlacePhoto(nil, &placePhotoWithSize.imageUrl))
 	}
 
 	// すべての写真の取得に失敗した場合は、エラーを返す


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Place Detailの呼び出し回数を減らすための修正
- Nearby Searchから取得した情報だけから写真を取得できるようにした
- これにより、写真取得のためにPlaceDetailを呼ぶ必要がなくなった

**プラン作成終了までのPlaces APIの呼び出し回数**
|before|after|
|---|---|
|50|22|

```txt
go run cmd/server/main.go &> log.txt
cat log.txt | grep  "PlacesApi" | wc 
```

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #344 
### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- Place Detailの呼び出し回数を減らすため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 通常通りに写真が表示されていることを確認
- [x] Places Apiの呼び出し回数が減少していることを確認

```shell
# planner
export BRANCH_PLANNER=feature/remove_place_detail_call
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```