### PR TITLE
カテゴリごとに最低場所数を指定する

### DIFF
--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -18,6 +18,12 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		for _, photo := range *photos {
 			photoReferences = append(photoReferences, photo.ToPhotoReference())
 		}
+	} else if place.PhotoReferences != nil && len(place.PhotoReferences) > 0 {
+		// Nearby Search で取得した場合は PhotoReference がある
+		photoReferences = make([]models.GooglePlacePhotoReference, len(place.PhotoReferences))
+		for _, photo := range place.PhotoReferences {
+			photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
+		}
 	}
 
 	return models.GooglePlace{

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -25,6 +25,8 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		Rating:           place.Rating,
 		UserRatingsTotal: place.UserRatingsTotal,
 		PriceLevel:       place.PriceLevel,
+		FormattedAddress: place.FormattedAddress,
+		Vicinity:         place.Vicinity,
 		Photos:           photos,
 		PlaceDetail:      placeDetail,
 	}

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -22,9 +22,6 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		// Nearby Search で取得した場合は PhotoReference がある
 		photoReferences = make([]models.GooglePlacePhotoReference, len(place.PhotoReferences))
 		for i, photo := range place.PhotoReferences {
-			if photo.PhotoReference == "" {
-				continue
-			}
 			photoReferences[i] = GooglePlacePhotoReferenceFromPhoto(photo)
 		}
 	}

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -12,6 +12,14 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 		placeDetail = &d
 	}
 
+	var photoReferences []models.GooglePlacePhotoReference
+	if photos != nil {
+		photoReferences = make([]models.GooglePlacePhotoReference, len(*photos))
+		for _, photo := range *photos {
+			photoReferences = append(photoReferences, photo.ToPhotoReference())
+		}
+	}
+
 	return models.GooglePlace{
 		PlaceId: place.PlaceID,
 		Name:    place.Name,
@@ -20,7 +28,7 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 			Latitude:  place.Location.Latitude,
 			Longitude: place.Location.Longitude,
 		},
-		PhotoReferences:  place.PhotoReferences,
+		PhotoReferences:  photoReferences,
 		OpenNow:          place.OpenNow,
 		Rating:           place.Rating,
 		UserRatingsTotal: place.UserRatingsTotal,

--- a/internal/domain/factory/google_place.go
+++ b/internal/domain/factory/google_place.go
@@ -15,14 +15,17 @@ func GooglePlaceFromPlaceEntity(place googleplaces.Place, photos *[]models.Googl
 	var photoReferences []models.GooglePlacePhotoReference
 	if photos != nil {
 		photoReferences = make([]models.GooglePlacePhotoReference, len(*photos))
-		for _, photo := range *photos {
-			photoReferences = append(photoReferences, photo.ToPhotoReference())
+		for i, photo := range *photos {
+			photoReferences[i] = photo.ToPhotoReference()
 		}
 	} else if place.PhotoReferences != nil && len(place.PhotoReferences) > 0 {
 		// Nearby Search で取得した場合は PhotoReference がある
 		photoReferences = make([]models.GooglePlacePhotoReference, len(place.PhotoReferences))
-		for _, photo := range place.PhotoReferences {
-			photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
+		for i, photo := range place.PhotoReferences {
+			if photo.PhotoReference == "" {
+				continue
+			}
+			photoReferences[i] = GooglePlacePhotoReferenceFromPhoto(photo)
 		}
 	}
 

--- a/internal/domain/factory/google_place_photo.go
+++ b/internal/domain/factory/google_place_photo.go
@@ -1,20 +1,25 @@
 package factory
 
 import (
+	"googlemaps.github.io/maps"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
 func GooglePlacePhotoReferencesFromPlaceDetail(placeDetail places.PlaceDetail) []models.GooglePlacePhotoReference {
 	var photoReferences []models.GooglePlacePhotoReference
-	for _, photoReference := range placeDetail.Photos {
-		photoReferences = append(photoReferences, models.GooglePlacePhotoReference{
-			PhotoReference:   photoReference.PhotoReference,
-			Width:            photoReference.Width,
-			Height:           photoReference.Height,
-			HTMLAttributions: photoReference.HTMLAttributions,
-		})
+	for _, photo := range placeDetail.Photos {
+		photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
 	}
 
 	return photoReferences
+}
+
+func GooglePlacePhotoReferenceFromPhoto(photo maps.Photo) models.GooglePlacePhotoReference {
+	return models.GooglePlacePhotoReference{
+		PhotoReference:   photo.PhotoReference,
+		Width:            photo.Width,
+		Height:           photo.Height,
+		HTMLAttributions: photo.HTMLAttributions,
+	}
 }

--- a/internal/domain/factory/google_place_photo.go
+++ b/internal/domain/factory/google_place_photo.go
@@ -7,9 +7,9 @@ import (
 )
 
 func GooglePlacePhotoReferencesFromPlaceDetail(placeDetail places.PlaceDetail) []models.GooglePlacePhotoReference {
-	var photoReferences []models.GooglePlacePhotoReference
-	for _, photo := range placeDetail.Photos {
-		photoReferences = append(photoReferences, GooglePlacePhotoReferenceFromPhoto(photo))
+	photoReferences := make([]models.GooglePlacePhotoReference, len(placeDetail.Photos))
+	for i, photo := range placeDetail.Photos {
+		photoReferences[i] = GooglePlacePhotoReferenceFromPhoto(photo)
 	}
 
 	return photoReferences

--- a/internal/domain/models/google_place.go
+++ b/internal/domain/models/google_place.go
@@ -10,7 +10,7 @@ type GooglePlace struct {
 	Name             string
 	Types            []string
 	Location         GeoLocation
-	PhotoReferences  []string
+	PhotoReferences  []GooglePlacePhotoReference
 	OpenNow          bool
 	PriceLevel       int
 	Rating           float32

--- a/internal/domain/models/google_place.go
+++ b/internal/domain/models/google_place.go
@@ -15,6 +15,8 @@ type GooglePlace struct {
 	PriceLevel       int
 	Rating           float32
 	UserRatingsTotal int
+	Vicinity         *string
+	FormattedAddress *string
 	Photos           *[]GooglePlacePhoto
 	PlaceDetail      *GooglePlaceDetail
 }

--- a/internal/domain/models/google_place_photo.go
+++ b/internal/domain/models/google_place_photo.go
@@ -17,3 +17,12 @@ func (g GooglePlacePhoto) ToImage() Image {
 		Large: utils.StrCopyPointerValue(g.Large),
 	}
 }
+
+func (g GooglePlacePhoto) ToPhotoReference() GooglePlacePhotoReference {
+	return GooglePlacePhotoReference{
+		PhotoReference:   g.PhotoReference,
+		Width:            g.Width,
+		Height:           g.Height,
+		HTMLAttributions: g.HTMLAttributions,
+	}
+}

--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -5,7 +5,6 @@ import (
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/models"
-	api "poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
 // FetchGooglePlacesPhotos は，指定された場所の写真を一括で取得する
@@ -37,13 +36,7 @@ func (s Service) FetchGooglePlacesPhotos(ctx context.Context, places []models.Go
 				return
 			}
 
-			photos, err := s.placesApi.FetchPlacePhotos(
-				ctx,
-				place.PlaceDetail.PhotoReferences,
-				1,
-				api.ImageSizeTypeSmall,
-				api.ImageSizeTypeLarge,
-			)
+			photos, err := s.placesApi.FetchPlacePhotos(ctx, place.PlaceDetail.PhotoReferences, 1)
 			if err != nil {
 				// TODO: channelを用いてエラーハンドリングする
 				s.logger.Warn(

--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -7,9 +7,52 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-// FetchGooglePlacesPhotos は，指定された場所の写真を一括で取得する
+// FetchPlacesPhotosAndSave は，指定された場所の写真を一括で取得し，保存する
+func (s Service) FetchPlacesPhotosAndSave(ctx context.Context, places ...models.Place) []models.Place {
+	var googlePlaces []models.GooglePlace
+	for _, place := range places {
+		googlePlaces = append(googlePlaces, place.Google)
+	}
+
+	// 写真が取得されていない場所のみ、画像が保存されるようにする
+	var googlePlaceIdsAlreadyHasImages []string
+	for _, googlePlace := range googlePlaces {
+		if googlePlace.Photos != nil && len(*googlePlace.Photos) > 0 {
+			googlePlaceIdsAlreadyHasImages = append(googlePlaceIdsAlreadyHasImages, googlePlace.PlaceId)
+		}
+	}
+
+	// 画像を取得
+	googlePlaces = s.fetchGooglePlacesPhotos(ctx, googlePlaces)
+
+	// 画像を保存
+	for _, googlePlace := range googlePlaces {
+		// すでに写真が取得済みの場合は何もしない
+		alreadyHasImages := array.IsContain(googlePlaceIdsAlreadyHasImages, googlePlace.PlaceId)
+		if alreadyHasImages {
+			continue
+		}
+
+		if googlePlace.Photos == nil || len(*googlePlace.Photos) == 0 {
+			continue
+		}
+
+		// 新しく画像を取得した場合は，保存する
+		if err := s.placeRepository.SaveGooglePlacePhotos(ctx, googlePlace.PlaceId, *googlePlace.Photos); err != nil {
+			continue
+		}
+	}
+
+	for i, googlePlace := range googlePlaces {
+		places[i].Google = googlePlace
+	}
+
+	return places
+}
+
+// fetchGooglePlacesPhotos は，指定された場所の写真を一括で取得する
 // すでに写真がある場合は，何もしない
-func (s Service) FetchGooglePlacesPhotos(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
+func (s Service) fetchGooglePlacesPhotos(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
 	if len(places) == 0 {
 		return places
 	}
@@ -63,55 +106,6 @@ func (s Service) FetchGooglePlacesPhotos(ctx context.Context, places []models.Go
 			places[i] = placeUpdated
 			break
 		}
-	}
-
-	return places
-}
-
-// FetchGooglePlacesPhotosAndSave は，指定された場所の写真を一括で取得し，保存する
-// 事前に FetchPlaceDetailAndSave で models.GooglePlaceDetail を取得しておく必要がある
-func (s Service) FetchGooglePlacesPhotosAndSave(ctx context.Context, planCandidateId string, places ...models.GooglePlace) []models.GooglePlace {
-	// 写真が取得されていない場所のみ、画像が保存されるようにする
-	var googlePlaceIdsAlreadyHasImages []string
-	for _, place := range places {
-		if place.Photos != nil && len(*place.Photos) > 0 {
-			googlePlaceIdsAlreadyHasImages = append(googlePlaceIdsAlreadyHasImages, place.PlaceId)
-		}
-	}
-
-	// 画像を取得
-	places = s.FetchGooglePlacesPhotos(ctx, places)
-
-	// 画像を保存
-	for _, place := range places {
-		// すでに写真が取得済みの場合は何もしない
-		alreadyHasImages := array.IsContain(googlePlaceIdsAlreadyHasImages, place.PlaceId)
-		if alreadyHasImages {
-			continue
-		}
-
-		if place.Photos == nil || len(*place.Photos) == 0 {
-			continue
-		}
-
-		if err := s.placeRepository.SaveGooglePlacePhotos(ctx, place.PlaceId, *place.Photos); err != nil {
-			continue
-		}
-	}
-
-	return places
-}
-
-func (s Service) FetchPlacesPhotosAndSave(ctx context.Context, planCandidateId string, places ...models.Place) []models.Place {
-	googlePlaces := make([]models.GooglePlace, len(places))
-	for i, place := range places {
-		googlePlaces[i] = place.Google
-	}
-
-	googlePlaces = s.FetchGooglePlacesPhotosAndSave(ctx, planCandidateId, googlePlaces...)
-
-	for i, googlePlace := range googlePlaces {
-		places[i].Google = googlePlace
 	}
 
 	return places

--- a/internal/domain/services/place/place_detail.go
+++ b/internal/domain/services/place/place_detail.go
@@ -3,7 +3,6 @@ package place
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/factory"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/infrastructure/api/google/places"
@@ -60,62 +59,4 @@ func (s Service) FetchPlaceDetailAndSave(ctx context.Context, googlePlaceId stri
 	}
 
 	return &placeDetail, nil
-}
-
-// FetchPlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
-func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
-	if len(places) == 0 {
-		return nil
-	}
-
-	googlePlaces := make([]models.GooglePlace, len(places))
-	for i, place := range places {
-		googlePlaces[i] = place.Google
-	}
-
-	// Place Detailを並行に取得する
-	ch := make(chan *models.GooglePlace, len(googlePlaces))
-	for _, googlePlace := range googlePlaces {
-		go func(ctx context.Context, googlePlace models.GooglePlace, ch chan<- *models.GooglePlace) {
-			if googlePlace.PlaceDetail != nil {
-				s.logger.Info(
-					"skip fetching place detail because place detail already exist",
-					zap.String("placeId", googlePlace.PlaceId),
-				)
-				ch <- &googlePlace
-				return
-			}
-
-			// 取得と保存を行う
-			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, googlePlace.PlaceId)
-			if err != nil {
-				ch <- nil
-				return
-			}
-
-			googlePlace.PlaceDetail = placeDetail
-
-			ch <- &googlePlace
-		}(ctx, googlePlace, ch)
-	}
-
-	for i := 0; i < len(googlePlaces); i++ {
-		placeWithPlaceDetail := <-ch
-		if placeWithPlaceDetail == nil {
-			continue
-		}
-
-		for iPlace, googlePlace := range googlePlaces {
-			if placeWithPlaceDetail.PlaceId == googlePlace.PlaceId {
-				googlePlaces[iPlace] = *placeWithPlaceDetail
-			}
-		}
-	}
-
-	// Place DetailとGoogle Placeを紐付ける
-	for i, googlePlace := range googlePlaces {
-		places[i].Google = googlePlace
-	}
-
-	return places
 }

--- a/internal/domain/services/place/place_detail.go
+++ b/internal/domain/services/place/place_detail.go
@@ -62,60 +62,57 @@ func (s Service) FetchPlaceDetailAndSave(ctx context.Context, googlePlaceId stri
 	return &placeDetail, nil
 }
 
-// FetchGooglePlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
-func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
+// FetchPlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
+func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
 	if len(places) == 0 {
 		return nil
 	}
 
-	ch := make(chan *models.GooglePlace, len(places))
-	for _, place := range places {
-		go func(ctx context.Context, place models.GooglePlace, ch chan<- *models.GooglePlace) {
-			if place.PlaceDetail != nil {
-				s.logger.Info(
-					"skip fetching place detail because place detail already exist",
-					zap.String("placeId", place.PlaceId),
-				)
-				ch <- &place
-				return
-			}
-
-			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, place.PlaceId)
-			if err != nil {
-				ch <- nil
-				return
-			}
-
-			place.PlaceDetail = placeDetail
-
-			ch <- &place
-		}(ctx, place, ch)
-	}
-
-	for i := 0; i < len(places); i++ {
-		placeWithPlaceDetail := <-ch
-		if placeWithPlaceDetail == nil {
-			continue
-		}
-
-		for iPlace, place := range places {
-			if placeWithPlaceDetail.PlaceId == place.PlaceId {
-				places[iPlace] = *placeWithPlaceDetail
-			}
-		}
-	}
-
-	return places
-}
-
-func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
 	googlePlaces := make([]models.GooglePlace, len(places))
 	for i, place := range places {
 		googlePlaces[i] = place.Google
 	}
 
-	googlePlaces = s.FetchGooglePlacesDetailAndSave(ctx, googlePlaces)
+	// Place Detailを並行に取得する
+	ch := make(chan *models.GooglePlace, len(googlePlaces))
+	for _, googlePlace := range googlePlaces {
+		go func(ctx context.Context, googlePlace models.GooglePlace, ch chan<- *models.GooglePlace) {
+			if googlePlace.PlaceDetail != nil {
+				s.logger.Info(
+					"skip fetching place detail because place detail already exist",
+					zap.String("placeId", googlePlace.PlaceId),
+				)
+				ch <- &googlePlace
+				return
+			}
 
+			// 取得と保存を行う
+			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, googlePlace.PlaceId)
+			if err != nil {
+				ch <- nil
+				return
+			}
+
+			googlePlace.PlaceDetail = placeDetail
+
+			ch <- &googlePlace
+		}(ctx, googlePlace, ch)
+	}
+
+	for i := 0; i < len(googlePlaces); i++ {
+		placeWithPlaceDetail := <-ch
+		if placeWithPlaceDetail == nil {
+			continue
+		}
+
+		for iPlace, googlePlace := range googlePlaces {
+			if placeWithPlaceDetail.PlaceId == googlePlace.PlaceId {
+				googlePlaces[iPlace] = *placeWithPlaceDetail
+			}
+		}
+	}
+
+	// Place DetailとGoogle Placeを紐付ける
 	for i, googlePlace := range googlePlaces {
 		places[i].Google = googlePlace
 	}

--- a/internal/domain/services/place/place_detail.go
+++ b/internal/domain/services/place/place_detail.go
@@ -29,7 +29,7 @@ func (s Service) FetchGooglePlace(ctx context.Context, googlePlaceId string) (*m
 }
 
 // FetchPlaceDetailAndSave Place Detail　情報を取得し、保存する
-func (s Service) FetchPlaceDetailAndSave(ctx context.Context, planCandidateId string, googlePlaceId string) (*models.GooglePlaceDetail, error) {
+func (s Service) FetchPlaceDetailAndSave(ctx context.Context, googlePlaceId string) (*models.GooglePlaceDetail, error) {
 	// キャッシュがある場合は取得する
 	savedPlace, err := s.placeRepository.FindByGooglePlaceID(ctx, googlePlaceId)
 	if err != nil {
@@ -63,7 +63,7 @@ func (s Service) FetchPlaceDetailAndSave(ctx context.Context, planCandidateId st
 }
 
 // FetchGooglePlacesDetailAndSave 複数の場所の Place Detail 情報を並行に取得し、保存する
-func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, planCandidateId string, places []models.GooglePlace) []models.GooglePlace {
+func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, places []models.GooglePlace) []models.GooglePlace {
 	if len(places) == 0 {
 		return nil
 	}
@@ -80,7 +80,7 @@ func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, planCandida
 				return
 			}
 
-			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, planCandidateId, place.PlaceId)
+			placeDetail, err := s.FetchPlaceDetailAndSave(ctx, place.PlaceId)
 			if err != nil {
 				ch <- nil
 				return
@@ -108,13 +108,13 @@ func (s Service) FetchGooglePlacesDetailAndSave(ctx context.Context, planCandida
 	return places
 }
 
-func (s Service) FetchPlacesDetailAndSave(ctx context.Context, planCandidateId string, places []models.Place) []models.Place {
+func (s Service) FetchPlacesDetailAndSave(ctx context.Context, places []models.Place) []models.Place {
 	googlePlaces := make([]models.GooglePlace, len(places))
 	for i, place := range places {
 		googlePlaces[i] = place.Google
 	}
 
-	googlePlaces = s.FetchGooglePlacesDetailAndSave(ctx, planCandidateId, googlePlaces)
+	googlePlaces = s.FetchGooglePlacesDetailAndSave(ctx, googlePlaces)
 
 	for i, googlePlace := range googlePlaces {
 		places[i].Google = googlePlace

--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -84,7 +84,7 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 				placeTypePointer = &placeType
 			}
 
-			placesSearched, err := s.placesApi.FindPlacesFromLocation(ctx, &googleplaces.FindPlacesFromLocationRequest{
+			placesSearched, err := s.placesApi.NearbySearch(ctx, &googleplaces.NearbySearchRequest{
 				Location: googleplaces.Location{
 					Latitude:  input.Location.Latitude,
 					Longitude: input.Location.Longitude,

--- a/internal/domain/services/plancandidate/add_place.go
+++ b/internal/domain/services/plancandidate/add_place.go
@@ -62,7 +62,7 @@ func (s Service) AddPlaceAfterPlace(ctx context.Context, planCandidateId string,
 		"Fetching photos and reviews for places for plan candidate",
 		zap.String("planCandidateId", planCandidateId),
 	)
-	placesWithPhoto := s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, *placeToAdd)
+	placesWithPhoto := s.placeService.FetchPlacesPhotosAndSave(ctx, *placeToAdd)
 	placeToAdd = &placesWithPhoto[0]
 	s.logger.Info(
 		"Successfully fetched photos and reviews for places for plan candidate",

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -104,7 +104,7 @@ func (s Service) CategoriesNearLocation(
 		}
 
 		// 場所の詳細情報を取得
-		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, params.CreatePlanSessionId, placesSortedByCategoryIndex)
+		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, placesSortedByCategoryIndex)
 
 		// 場所の写真を取得する
 		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesWithDetail...)

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -103,11 +103,8 @@ func (s Service) CategoriesNearLocation(
 			placesSortedByCategoryIndex = placesSortedByCategoryIndex[:params.MaxPlacesPerCategory]
 		}
 
-		// 場所の詳細情報を取得
-		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, placesSortedByCategoryIndex)
-
 		// 場所の写真を取得する
-		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesWithDetail...)
+		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesSortedByCategoryIndex...)
 
 		categoriesWithPlaces = append(categoriesWithPlaces, models.NewLocationCategoryWithPlaces(*category, placesWithPhotos))
 	}

--- a/internal/domain/services/plancandidate/category.go
+++ b/internal/domain/services/plancandidate/category.go
@@ -107,7 +107,7 @@ func (s Service) CategoriesNearLocation(
 		placesWithDetail := s.placeService.FetchPlacesDetailAndSave(ctx, params.CreatePlanSessionId, placesSortedByCategoryIndex)
 
 		// 場所の写真を取得する
-		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, params.CreatePlanSessionId, placesWithDetail...)
+		placesWithPhotos := s.placeService.FetchPlacesPhotosAndSave(ctx, placesWithDetail...)
 
 		categoriesWithPlaces = append(categoriesWithPlaces, models.NewLocationCategoryWithPlaces(*category, placesWithPhotos))
 	}

--- a/internal/domain/services/plancandidate/place.go
+++ b/internal/domain/services/plancandidate/place.go
@@ -2,7 +2,6 @@ package plancandidate
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"sort"
 
 	"poroto.app/poroto/planner/internal/domain/models"
@@ -47,20 +46,8 @@ func (s Service) FetchCandidatePlaces(
 			continue
 		}
 
-		// TODO: キャッシュする
-		// TODO: 大きいサイズの写真も取得する
-		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences)
-		if err != nil {
-			s.logger.Warn(
-				"error while fetching place photo",
-				zap.String("placeId", place.Id),
-				zap.String("planCandidateId", createPlanSessionId),
-				zap.Error(err),
-			)
-			continue
-		}
-
-		place.Google.Photos = &[]models.GooglePlacePhoto{*thumbnail}
+		placesWithPhoto := s.placeService.FetchPlacesPhotosAndSave(ctx, place)
+		place = placesWithPhoto[0]
 
 		placesToSuggest = append(placesToSuggest, place)
 

--- a/internal/domain/services/plancandidate/place.go
+++ b/internal/domain/services/plancandidate/place.go
@@ -50,11 +50,7 @@ func (s Service) FetchCandidatePlaces(
 
 		// TODO: キャッシュする
 		// TODO: 大きいサイズの写真も取得する
-		thumbnail, err := s.placesApi.FetchPlacePhoto([]models.GooglePlacePhotoReference{
-			{
-				PhotoReference: place.Google.PhotoReferences[0],
-			},
-		}, googleplaces.ImageSizeSmall())
+		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences, googleplaces.ImageSizeSmall())
 		if err != nil {
 			s.logger.Warn(
 				"error while fetching place photo",

--- a/internal/domain/services/plancandidate/place.go
+++ b/internal/domain/services/plancandidate/place.go
@@ -7,7 +7,6 @@ import (
 
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
-	googleplaces "poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
 // FetchCandidatePlaces はプランの候補となる場所を取得する
@@ -50,7 +49,7 @@ func (s Service) FetchCandidatePlaces(
 
 		// TODO: キャッシュする
 		// TODO: 大きいサイズの写真も取得する
-		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences, googleplaces.ImageSizeSmall())
+		thumbnail, err := s.placesApi.FetchPlacePhoto(place.Google.PhotoReferences)
 		if err != nil {
 			s.logger.Warn(
 				"error while fetching place photo",

--- a/internal/domain/services/plancandidate/places_to_add.go
+++ b/internal/domain/services/plancandidate/places_to_add.go
@@ -70,9 +70,6 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, planCandidateId string, p
 		placesToAdd = append(placesToAdd, place)
 	}
 
-	// 場所の詳細情報を取得
-	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, placesToAdd)
-
 	// 写真を取得
 	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToAdd...)
 

--- a/internal/domain/services/plancandidate/places_to_add.go
+++ b/internal/domain/services/plancandidate/places_to_add.go
@@ -74,7 +74,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, planCandidateId string, p
 	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToAdd)
 
 	// 写真を取得
-	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, placesToAdd...)
+	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToAdd...)
 
 	return placesToAdd, nil
 }

--- a/internal/domain/services/plancandidate/places_to_add.go
+++ b/internal/domain/services/plancandidate/places_to_add.go
@@ -71,7 +71,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, planCandidateId string, p
 	}
 
 	// 場所の詳細情報を取得
-	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToAdd)
+	placesToAdd = s.placeService.FetchPlacesDetailAndSave(ctx, placesToAdd)
 
 	// 写真を取得
 	placesToAdd = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToAdd...)

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -93,7 +93,7 @@ func (s Service) FetchPlacesToReplace(
 	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToReplace)
 
 	// 画像を取得
-	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, placesToReplace...)
+	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToReplace...)
 
 	return placesToReplace, nil
 }

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -90,7 +90,7 @@ func (s Service) FetchPlacesToReplace(
 	}
 
 	// 詳細情報を取得
-	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToReplace)
+	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, placesToReplace)
 
 	// 画像を取得
 	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToReplace...)

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -89,9 +89,6 @@ func (s Service) FetchPlacesToReplace(
 		placesToReplace = placesToReplace[:nLimit]
 	}
 
-	// 詳細情報を取得
-	placesToReplace = s.placeService.FetchPlacesDetailAndSave(ctx, placesToReplace)
-
 	// 画像を取得
 	placesToReplace = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToReplace...)
 

--- a/internal/domain/services/plangen/create.go
+++ b/internal/domain/services/plangen/create.go
@@ -148,7 +148,7 @@ func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesPa
 
 		if params.shouldOpenWhileTraveling && params.freeTime == nil {
 			// 場所の詳細を取得(Place Detailリクエストが発生するため、ある程度フィルタリングしたあとに行う)
-			placeDetail, err := s.placeService.FetchPlaceDetailAndSave(ctx, params.planCandidateId, place.Google.PlaceId)
+			placeDetail, err := s.placeService.FetchPlaceDetailAndSave(ctx, place.Google.PlaceId)
 			if err != nil {
 				s.logger.Warn(
 					"error while fetching place detail",

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -116,7 +116,7 @@ func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId strin
 		placesToUpdate = append(placesToUpdate, place)
 	}
 
-	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToUpdate)
+	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, placesToUpdate)
 	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToUpdate...)
 
 	for _, place := range placesToUpdate {

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -117,7 +117,7 @@ func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId strin
 	}
 
 	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, planCandidateId, placesToUpdate)
-	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, planCandidateId, placesToUpdate...)
+	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToUpdate...)
 
 	for _, place := range placesToUpdate {
 		placeIdToPlace[place.Id] = place

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -116,7 +116,6 @@ func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId strin
 		placesToUpdate = append(placesToUpdate, place)
 	}
 
-	placesToUpdate = s.placeService.FetchPlacesDetailAndSave(ctx, placesToUpdate)
 	placesToUpdate = s.placeService.FetchPlacesPhotosAndSave(ctx, placesToUpdate...)
 
 	for _, place := range placesToUpdate {

--- a/internal/infrastructure/api/google/places/details.go
+++ b/internal/infrastructure/api/google/places/details.go
@@ -13,7 +13,7 @@ type FetchPlaceDetailRequest struct {
 }
 
 // FetchPlaceDetail は IDを指定することで、対応する場所の情報を取得する
-// 取得される内容は FindPlacesFromLocation と同じ
+// 取得される内容は NearbySearch と同じ
 func (r PlacesApi) FetchPlaceDetail(ctx context.Context, req FetchPlaceDetailRequest) (*Place, error) {
 	r.logger.Info(
 		"Places API Place Details",

--- a/internal/infrastructure/api/google/places/details.go
+++ b/internal/infrastructure/api/google/places/details.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"go.uber.org/zap"
 	"googlemaps.github.io/maps"
+	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
 type FetchPlaceDetailRequest struct {
@@ -40,22 +41,17 @@ func (r PlacesApi) FetchPlaceDetail(ctx context.Context, req FetchPlaceDetailReq
 		return nil, err
 	}
 
-	var photoReferences []string
-	if resp.Photos != nil {
-		for _, photo := range resp.Photos {
-			photoReferences = append(photoReferences, photo.PhotoReference)
-		}
-	}
-
 	place := createPlace(
 		resp.PlaceID,
 		resp.Name,
 		resp.Types,
 		resp.Geometry,
-		photoReferences,
+		resp.Photos,
 		resp.OpeningHours != nil && resp.OpeningHours.OpenNow != nil && *resp.OpeningHours.OpenNow,
 		resp.Rating,
 		resp.UserRatingsTotal,
+		utils.StrOmitEmpty(resp.FormattedAddress),
+		utils.StrOmitEmpty(resp.Vicinity),
 		resp.PriceLevel,
 	)
 

--- a/internal/infrastructure/api/google/places/nearbysearch.go
+++ b/internal/infrastructure/api/google/places/nearbysearch.go
@@ -4,10 +4,59 @@ import (
 	"context"
 	"fmt"
 	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/utils"
 	"time"
 
 	"googlemaps.github.io/maps"
 )
+
+type FindPlacesFromLocationRequest struct {
+	Location    Location
+	Radius      uint
+	Language    string
+	Type        *maps.PlaceType
+	SearchCount int
+}
+
+func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFromLocationRequest) ([]Place, error) {
+	var placeType maps.PlaceType
+	if req.Type != nil {
+		placeType = *req.Type
+	}
+
+	placeSearchResults, err := r.nearBySearch(ctx, &maps.NearbySearchRequest{
+		Location: &maps.LatLng{
+			Lat: req.Location.Latitude,
+			Lng: req.Location.Longitude,
+		},
+		Radius:   req.Radius,
+		Language: req.Language,
+		Type:     placeType,
+	}, req.SearchCount)
+	if err != nil {
+		return nil, err
+	}
+
+	// Getting places nearby
+	var places []Place
+	for _, place := range placeSearchResults {
+		places = append(places, createPlace(
+			place.PlaceID,
+			place.Name,
+			place.Types,
+			place.Geometry,
+			place.Photos,
+			place.OpeningHours != nil && place.OpeningHours.OpenNow != nil && *place.OpeningHours.OpenNow,
+			place.Rating,
+			place.UserRatingsTotal,
+			utils.StrOmitEmpty(place.FormattedAddress),
+			utils.StrOmitEmpty(place.Vicinity),
+			place.PriceLevel,
+		))
+	}
+
+	return places, nil
+}
 
 // nearBySearch Places API Nearby Search
 // https://developers.google.com/maps/documentation/places/web-service/search-nearby

--- a/internal/infrastructure/api/google/places/nearbysearch.go
+++ b/internal/infrastructure/api/google/places/nearbysearch.go
@@ -10,7 +10,7 @@ import (
 	"googlemaps.github.io/maps"
 )
 
-type FindPlacesFromLocationRequest struct {
+type NearbySearchRequest struct {
 	Location    Location
 	Radius      uint
 	Language    string
@@ -18,7 +18,7 @@ type FindPlacesFromLocationRequest struct {
 	SearchCount int
 }
 
-func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFromLocationRequest) ([]Place, error) {
+func (r PlacesApi) NearbySearch(ctx context.Context, req *NearbySearchRequest) ([]Place, error) {
 	var placeType maps.PlaceType
 	if req.Type != nil {
 		placeType = *req.Type

--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -15,50 +15,15 @@ type ImageSize struct {
 	Height uint
 }
 
-type ImageSizeType int
-
 type PlacePhotoWithSize struct {
 	photoReference models.GooglePlacePhotoReference
 	imageUrl       string
-	size           ImageSizeType
 }
 
 const (
-	imgMaxHeightLarge = 1000
-	imgMaxWidthLarge  = 1000
-	imgMaxHeightSmall = 400
-	imgMaxWidthSmall  = 400
+	imgMaxHeight = 2000
+	imgMaxWidth  = 2000
 )
-
-const (
-	ImageSizeTypeLarge ImageSizeType = iota
-	ImageSizeTypeSmall
-)
-
-func ImageSizeLarge() ImageSize {
-	return ImageSize{
-		Width:  imgMaxWidthLarge,
-		Height: imgMaxHeightLarge,
-	}
-}
-
-func ImageSizeSmall() ImageSize {
-	return ImageSize{
-		Width:  imgMaxWidthSmall,
-		Height: imgMaxHeightSmall,
-	}
-}
-
-func (i ImageSizeType) ImageSize() ImageSize {
-	switch i {
-	case ImageSizeTypeLarge:
-		return ImageSizeLarge()
-	case ImageSizeTypeSmall:
-		return ImageSizeSmall()
-	default:
-		panic(fmt.Sprintf("invalid image size type: %v", i))
-	}
-}
 
 func imgUrlBuilder(maxWidth uint, maxHeight uint, photoReference string, apiKey string) (string, error) {
 	u, err := url.Parse("https://maps.googleapis.com")
@@ -102,13 +67,13 @@ func fetchPublicImageUrl(photoUrl string) (*string, error) {
 }
 
 // FetchPlacePhoto は，指定された場所の画像を１件取得する
-func (r PlacesApi) FetchPlacePhoto(photoReferences []models.GooglePlacePhotoReference, imageSize ImageSize) (*models.GooglePlacePhoto, error) {
+func (r PlacesApi) FetchPlacePhoto(photoReferences []models.GooglePlacePhotoReference) (*models.GooglePlacePhoto, error) {
 	if len(photoReferences) == 0 {
 		return nil, nil
 	}
 
 	photoReference := photoReferences[0]
-	imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photoReference.PhotoReference, r.apiKey)
+	imgUrl, err := imgUrlBuilder(imgMaxWidth, imgMaxHeight, photoReference.PhotoReference, r.apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -126,94 +91,71 @@ func (r PlacesApi) FetchPlacePhoto(photoReferences []models.GooglePlacePhotoRefe
 // imageSizeTypes が指定されている場合は，高画質の写真を取得する
 // 画像取得は呼び出し料金が高いため、複数の場所の写真を取得するときは注意
 // https://developers.google.com/maps/documentation/places/web-service/usage-and-billing?hl=ja#places-photo-new
-// TODO: 単一の画像だけを取得するようにする
-func (r PlacesApi) FetchPlacePhotos(ctx context.Context, photoReferences []models.GooglePlacePhotoReference, maxPhotoCount int, imageSizeTypes ...ImageSizeType) ([]models.GooglePlacePhoto, error) {
-	if len(imageSizeTypes) == 0 {
-		imageSizeTypes = []ImageSizeType{ImageSizeTypeLarge}
-	}
-
-	ch := make(chan *PlacePhotoWithSize, len(photoReferences)*len(imageSizeTypes))
+func (r PlacesApi) FetchPlacePhotos(ctx context.Context, photoReferences []models.GooglePlacePhotoReference, maxPhotoCount int) ([]models.GooglePlacePhoto, error) {
+	ch := make(chan *PlacePhotoWithSize, len(photoReferences))
 	for iPhoto, photoReference := range photoReferences {
-		for _, imageSizeType := range imageSizeTypes {
-			go func(ctx context.Context, photoIndex int, photoReference models.GooglePlacePhotoReference, imageSizeType ImageSizeType, ch chan<- *PlacePhotoWithSize) {
-				// 画像取得数が上限に達した場合は、何もしない
-				if photoIndex >= maxPhotoCount {
-					ch <- nil
-					return
+		go func(ctx context.Context, photoIndex int, photoReference models.GooglePlacePhotoReference, ch chan<- *PlacePhotoWithSize) {
+			// 画像取得数が上限に達した場合は、何もしない
+			if photoIndex >= maxPhotoCount {
+				ch <- nil
+				return
+			}
+
+			var imageSize ImageSize
+			if photoReference.Width > imgMaxWidth || photoReference.Height > imgMaxHeight {
+				imageSize = ImageSize{
+					Width:  imgMaxWidth,
+					Height: imgMaxHeight,
 				}
-
-				imageSize := imageSizeType.ImageSize()
-
-				imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photoReference.PhotoReference, r.apiKey)
-				if err != nil {
-					// TODO: channelにエラーを送信するようにする
-					r.logger.Warn(
-						"skipping photoReference because of error while building image url",
-						zap.Error(err),
-						zap.String("photoReference", photoReference.PhotoReference),
-					)
-					ch <- nil
-					return
+			} else {
+				imageSize = ImageSize{
+					Width:  uint(photoReference.Width),
+					Height: uint(photoReference.Height),
 				}
+			}
 
-				r.logger.Info(
-					"Places API Fetch Place Photo",
+			imgUrl, err := imgUrlBuilder(imageSize.Width, imageSize.Height, photoReference.PhotoReference, r.apiKey)
+			if err != nil {
+				// TODO: channelにエラーを送信するようにする
+				r.logger.Warn(
+					"skipping photoReference because of error while building image url",
+					zap.Error(err),
 					zap.String("photoReference", photoReference.PhotoReference),
 				)
-				publicImageUrl, err := fetchPublicImageUrl(imgUrl)
-				if err != nil {
-					// TODO: channelにエラーを送信するようにする
-					r.logger.Warn(
-						"skipping photoReference because of error while fetching public image url",
-						zap.Error(err),
-						zap.String("photoReference", photoReference.PhotoReference),
-					)
-					ch <- nil
-					return
-				}
+				ch <- nil
+				return
+			}
 
-				ch <- &PlacePhotoWithSize{
-					photoReference: photoReference,
-					imageUrl:       *publicImageUrl,
-					size:           imageSizeType,
-				}
-			}(ctx, iPhoto, photoReference, imageSizeType, ch)
-		}
+			r.logger.Info(
+				"Places API Fetch Place Photo",
+				zap.String("photoReference", photoReference.PhotoReference),
+			)
+			publicImageUrl, err := fetchPublicImageUrl(imgUrl)
+			if err != nil {
+				// TODO: channelにエラーを送信するようにする
+				r.logger.Warn(
+					"skipping photoReference because of error while fetching public image url",
+					zap.Error(err),
+					zap.String("photoReference", photoReference.PhotoReference),
+				)
+				ch <- nil
+				return
+			}
+
+			ch <- &PlacePhotoWithSize{
+				photoReference: photoReference,
+				imageUrl:       *publicImageUrl,
+			}
+		}(ctx, iPhoto, photoReference, ch)
 	}
 
-	var placePhotoWithSizes []PlacePhotoWithSize
-	for i := 0; i < len(photoReferences)*len(imageSizeTypes); i++ {
+	var placePhotos []models.GooglePlacePhoto
+	for i := 0; i < len(photoReferences); i++ {
 		placePhotoWithSize := <-ch
 		if placePhotoWithSize == nil {
 			continue
 		}
-		placePhotoWithSizes = append(placePhotoWithSizes, *placePhotoWithSize)
-	}
-
-	var placePhotos []models.GooglePlacePhoto
-	for _, photoReference := range photoReferences {
-		var photoUrlSmall, photoUrlLarge *string
-
-		for _, placePhotoWithSize := range placePhotoWithSizes {
-			if placePhotoWithSize.photoReference.PhotoReference != photoReference.PhotoReference {
-				continue
-			}
-
-			switch placePhotoWithSize.size {
-			case ImageSizeTypeLarge:
-				photoUrlLarge = &placePhotoWithSize.imageUrl
-			case ImageSizeTypeSmall:
-				photoUrlSmall = &placePhotoWithSize.imageUrl
-			default:
-				panic(fmt.Sprintf("invalid image size type: %v", placePhotoWithSize.size))
-			}
-		}
-
-		if photoUrlLarge == nil && photoUrlSmall == nil {
-			continue
-		}
-
-		placePhotos = append(placePhotos, photoReference.ToGooglePlacePhoto(photoUrlSmall, photoUrlLarge))
+		placePhotos = append(placePhotos, placePhotoWithSize.photoReference.ToGooglePlacePhoto(nil, &placePhotoWithSize.imageUrl))
 	}
 
 	// すべての写真の取得に失敗した場合は、エラーを返す

--- a/internal/infrastructure/api/google/places/places.go
+++ b/internal/infrastructure/api/google/places/places.go
@@ -1,7 +1,6 @@
 package places
 
 import (
-	"context"
 	"fmt"
 	"go.uber.org/zap"
 	"os"
@@ -40,52 +39,4 @@ func NewPlacesApi() (*PlacesApi, error) {
 		mapsClient: c,
 		logger:     logger,
 	}, nil
-}
-
-type FindPlacesFromLocationRequest struct {
-	Location    Location
-	Radius      uint
-	Language    string
-	Type        *maps.PlaceType
-	SearchCount int
-}
-
-func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFromLocationRequest) ([]Place, error) {
-	var placeType maps.PlaceType
-	if req.Type != nil {
-		placeType = *req.Type
-	}
-
-	placeSearchResults, err := r.nearBySearch(ctx, &maps.NearbySearchRequest{
-		Location: &maps.LatLng{
-			Lat: req.Location.Latitude,
-			Lng: req.Location.Longitude,
-		},
-		Radius:   req.Radius,
-		Language: req.Language,
-		Type:     placeType,
-	}, req.SearchCount)
-	if err != nil {
-		return nil, err
-	}
-
-	// Getting places nearby
-	var places []Place
-	for _, place := range placeSearchResults {
-		places = append(places, createPlace(
-			place.PlaceID,
-			place.Name,
-			place.Types,
-			place.Geometry,
-			place.Photos,
-			place.OpeningHours != nil && place.OpeningHours.OpenNow != nil && *place.OpeningHours.OpenNow,
-			place.Rating,
-			place.UserRatingsTotal,
-			utils.StrOmitEmpty(place.FormattedAddress),
-			utils.StrOmitEmpty(place.Vicinity),
-			place.PriceLevel,
-		))
-	}
-
-	return places, nil
 }

--- a/internal/infrastructure/api/google/places/places.go
+++ b/internal/infrastructure/api/google/places/places.go
@@ -72,20 +72,17 @@ func (r PlacesApi) FindPlacesFromLocation(ctx context.Context, req *FindPlacesFr
 	// Getting places nearby
 	var places []Place
 	for _, place := range placeSearchResults {
-		var photoReferences []string
-		for _, photo := range place.Photos {
-			photoReferences = append(photoReferences, photo.PhotoReference)
-		}
-
 		places = append(places, createPlace(
 			place.PlaceID,
 			place.Name,
 			place.Types,
 			place.Geometry,
-			photoReferences,
+			place.Photos,
 			place.OpeningHours != nil && place.OpeningHours.OpenNow != nil && *place.OpeningHours.OpenNow,
 			place.Rating,
 			place.UserRatingsTotal,
+			utils.StrOmitEmpty(place.FormattedAddress),
+			utils.StrOmitEmpty(place.Vicinity),
 			place.PriceLevel,
 		))
 	}

--- a/internal/infrastructure/api/google/places/types.go
+++ b/internal/infrastructure/api/google/places/types.go
@@ -9,11 +9,13 @@ type Place struct {
 	Name             string
 	Types            []string
 	Location         Location
-	PhotoReferences  []string
+	PhotoReferences  []maps.Photo
 	OpenNow          bool
 	Rating           float32
 	UserRatingsTotal int
 	PriceLevel       int
+	FormattedAddress *string
+	Vicinity         *string
 	PlaceDetail      *PlaceDetail
 }
 
@@ -33,10 +35,12 @@ func createPlace(
 	name string,
 	types []string,
 	geometry maps.AddressGeometry,
-	photoReferences []string,
+	photoReferences []maps.Photo,
 	openNow bool,
 	rating float32,
 	userRatingsTotal int,
+	formattedAddress *string,
+	vicinity *string,
 	priceLevel int,
 ) Place {
 	return Place{
@@ -48,6 +52,8 @@ func createPlace(
 		Rating:           rating,
 		UserRatingsTotal: userRatingsTotal,
 		PriceLevel:       priceLevel,
+		FormattedAddress: formattedAddress,
+		Vicinity:         vicinity,
 		Location: Location{
 			Latitude:  geometry.Location.Lat,
 			Longitude: geometry.Location.Lng,

--- a/internal/infrastructure/firestore/entity/google_place.go
+++ b/internal/infrastructure/firestore/entity/google_place.go
@@ -4,12 +4,12 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
+// GooglePlaceEntity NearbySearchで取得できるデータをキャッシュ
 type GooglePlaceEntity struct {
 	PlaceID          string                         `firestore:"place_id"`
 	Name             string                         `firestore:"name"`
 	Types            []string                       `firestore:"types"`
 	Location         GeoLocationEntity              `firestore:"location"`
-	PhotoReferences  []string                       `firestore:"photo_references"`
 	OpenNow          bool                           `firestore:"open_now"`
 	Rating           float32                        `firestore:"rating"`
 	UserRatingsTotal int                            `firestore:"user_ratings_total"`
@@ -30,7 +30,6 @@ func GooglePlaceEntityFromGooglePlace(place models.GooglePlace) GooglePlaceEntit
 		PlaceID:          place.PlaceId,
 		Name:             place.Name,
 		Types:            place.Types,
-		PhotoReferences:  place.PhotoReferences,
 		OpenNow:          place.OpenNow,
 		Rating:           place.Rating,
 		UserRatingsTotal: place.UserRatingsTotal,
@@ -54,7 +53,6 @@ func (g GooglePlaceEntity) ToGooglePlace(photoEntities *[]GooglePlacePhotoEntity
 		Name:             g.Name,
 		Types:            g.Types,
 		Location:         location,
-		PhotoReferences:  g.PhotoReferences,
 		OpenNow:          g.OpenNow,
 		Rating:           g.Rating,
 		UserRatingsTotal: g.UserRatingsTotal,

--- a/internal/infrastructure/firestore/entity/google_place.go
+++ b/internal/infrastructure/firestore/entity/google_place.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
 // GooglePlaceEntity NearbySearchで取得できるデータをキャッシュ
@@ -14,6 +15,8 @@ type GooglePlaceEntity struct {
 	Rating           float32                        `firestore:"rating"`
 	UserRatingsTotal int                            `firestore:"user_ratings_total"`
 	PriceLevel       int                            `firestore:"price_level"`
+	FormattedAddress string                         `firestore:"formatted_address"`
+	Vicinity         string                         `firestore:"vicinity"`
 	OpeningHours     *GooglePlaceOpeningHoursEntity `firestore:"opening_hours"`
 }
 
@@ -35,6 +38,8 @@ func GooglePlaceEntityFromGooglePlace(place models.GooglePlace) GooglePlaceEntit
 		UserRatingsTotal: place.UserRatingsTotal,
 		PriceLevel:       place.PriceLevel,
 		OpeningHours:     openingHours,
+		FormattedAddress: utils.StrEmptyIfNil(place.FormattedAddress),
+		Vicinity:         utils.StrEmptyIfNil(place.Vicinity),
 		Location: GeoLocationEntity{
 			Latitude:  place.Location.Latitude,
 			Longitude: place.Location.Longitude,
@@ -57,6 +62,8 @@ func (g GooglePlaceEntity) ToGooglePlace(photoEntities *[]GooglePlacePhotoEntity
 		Rating:           g.Rating,
 		UserRatingsTotal: g.UserRatingsTotal,
 		PriceLevel:       g.PriceLevel,
+		FormattedAddress: utils.StrOmitEmpty(g.FormattedAddress),
+		Vicinity:         utils.StrOmitEmpty(g.Vicinity),
 		Photos:           g.toGooglePlacePhotos(photoEntities),
 		PlaceDetail:      g.toGooglePlaceDetail(photoEntities, reviewEntities),
 	}

--- a/internal/infrastructure/firestore/place.go
+++ b/internal/infrastructure/firestore/place.go
@@ -111,6 +111,11 @@ func (p PlaceRepository) SavePlacesFromGooglePlace(ctx context.Context, googlePl
 			if err := p.updateOpeningHours(tx, placeEntity.Id, *googlePlace.PlaceDetail); err != nil {
 				return fmt.Errorf("error while updating opening hours: %v", err)
 			}
+		} else if len(googlePlace.PhotoReferences) != 0 {
+			// Nearby Searchで画像を取得している場合は保存する
+			if err := p.saveGooglePhotoReferencesTx(tx, placeEntity.Id, googlePlace.PhotoReferences); err != nil {
+				return fmt.Errorf("error while saving google place photos: %v", err)
+			}
 		}
 
 		// Place Photo を保存する

--- a/internal/infrastructure/firestore/place.go
+++ b/internal/infrastructure/firestore/place.go
@@ -76,6 +76,11 @@ func (p PlaceRepository) SavePlacesFromGooglePlace(ctx context.Context, googlePl
 			}
 
 			if gp != nil {
+				p.logger.Info(
+					"Skip saving place because it is already saved",
+					zap.String("placeId", placeEntity.Id),
+					zap.String("googlePlaceId", googlePlace.PlaceId),
+				)
 				googlePlace = *gp
 				return nil
 			}
@@ -111,7 +116,7 @@ func (p PlaceRepository) SavePlacesFromGooglePlace(ctx context.Context, googlePl
 			if err := p.updateOpeningHours(tx, placeEntity.Id, *googlePlace.PlaceDetail); err != nil {
 				return fmt.Errorf("error while updating opening hours: %v", err)
 			}
-		} else if len(googlePlace.PhotoReferences) != 0 {
+		} else if len(googlePlace.PhotoReferences) > 0 {
 			// Nearby Searchで画像を取得している場合は保存する
 			if err := p.saveGooglePhotoReferencesTx(tx, placeEntity.Id, googlePlace.PhotoReferences); err != nil {
 				return fmt.Errorf("error while saving google place photos: %v", err)
@@ -618,12 +623,24 @@ func (p PlaceRepository) saveGooglePhotoReferencesTx(tx *firestore.Transaction, 
 	chErr := make(chan error)
 	for _, photoReference := range photoReferences {
 		go func(tx *firestore.Transaction, ch chan<- *models.GooglePlacePhotoReference, placeId string, photoReference models.GooglePlacePhotoReference) {
+			p.logger.Info(
+				"start saving google place photo references",
+				zap.String("placeId", placeId),
+				zap.String("photoReference", photoReference.PhotoReference),
+				zap.String("width", fmt.Sprintf("%d", photoReference.Width)),
+				zap.String("height", fmt.Sprintf("%d", photoReference.Height)),
+			)
 			photoEntity := entity.GooglePlacePhotoEntityFromGooglePhotoReference(photoReference)
 			if err := tx.Set(p.subCollectionGooglePlacePhoto(placeId).Doc(photoReference.PhotoReference), photoEntity); err != nil {
 				chErr <- fmt.Errorf("error while saving google place photo reference: %v", err)
 			} else {
 				ch <- &photoReference
 			}
+			p.logger.Info(
+				"successfully saved google place photo references",
+				zap.String("placeId", placeId),
+				zap.String("photoReference", photoReference.PhotoReference),
+			)
 		}(tx, ch, placeId, photoReference)
 	}
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- キャッシュデータを利用するとき、特定のカテゴリに属している場所の数が一定以上いたときに、Nearby Searchを行わない機能の修正
- この閾値の設定をカテゴリごとに行うようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #344 
- #345 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 飲食店はなるべく多くの場所が利用できたほうが良いが、ショッピングモールは場所の数が少ないため、もっと少なくていいなどの指定をできるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/search_condition_per_category
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```