### PR TITLE
場所を入れ替えるときに適切に場所が選択されるようにした

### DIFF
--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -7,9 +7,10 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/google/uuid"
 	"go.uber.org/zap"
-	"log"
 	"poroto.app/poroto/planner/graphql/factory"
 	"poroto.app/poroto/planner/graphql/model"
 	"poroto.app/poroto/planner/internal/domain/models"

--- a/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/graphql/resolver/plan_candidate_query.resolvers.go
@@ -7,13 +7,14 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"log"
-
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+	"log"
 	"poroto.app/poroto/planner/graphql/factory"
 	"poroto.app/poroto/planner/graphql/model"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/plancandidate"
+	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
 // CachedCreatedPlans is the resolver for the CachedCreatedPlans field.
@@ -142,6 +143,21 @@ func (r *queryResolver) PlacesToAddForPlanCandidate(ctx context.Context, input m
 
 // PlacesToReplaceForPlanCandidate is the resolver for the placesToReplaceForPlanCandidate field.
 func (r *queryResolver) PlacesToReplaceForPlanCandidate(ctx context.Context, input model.PlacesToReplaceForPlanCandidateInput) (*model.PlacesToReplaceForPlanCandidateOutput, error) {
+	logger, err := utils.NewLogger(utils.LoggerOption{
+		Tag: "GraphQL",
+	})
+	if err != nil {
+		log.Println("error while initializing logger: ", err)
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	logger.Info(
+		"PlacesToReplaceForPlanCandidate",
+		zap.String("planCandidateId", input.PlanCandidateID),
+		zap.String("planId", input.PlanID),
+		zap.String("placeId", input.PlaceID),
+	)
+
 	s, err := plancandidate.NewService(ctx)
 	if err != nil {
 		log.Println("error while initializing plan candidate service: ", err)

--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"math/rand"
+	"sort"
 	"time"
 )
 
@@ -63,6 +64,17 @@ func ShufflePlaces(places []Place) []Place {
 		j := rand.Intn(i + 1)
 		placesCopy[i], placesCopy[j] = placesCopy[j], placesCopy[i]
 	}
+
+	return placesCopy
+}
+
+func SortPlacesByRating(places []Place) []Place {
+	placesCopy := make([]Place, len(places))
+	copy(placesCopy, places)
+
+	sort.SliceStable(placesCopy, func(i, j int) bool {
+		return placesCopy[i].Google.Rating > placesCopy[j].Google.Rating
+	})
 
 	return placesCopy
 }

--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -1,5 +1,10 @@
 package models
 
+import (
+	"math/rand"
+	"time"
+)
+
 // Place 場所の情報
 type Place struct {
 	Id        string      `json:"id"`
@@ -43,4 +48,21 @@ func (p Place) EstimatedStayDuration() uint {
 func (p Place) EstimatedPriceRange() (priceRange *PriceRange) {
 	// TODO: 飲食店でprice_levelが0の場合は、価格帯が不明なので、nilを返す
 	return PriceRangeFromGooglePriceLevel(p.Google.PriceLevel)
+}
+
+// ShufflePlaces 場所の順番をシャッフルする
+func ShufflePlaces(places []Place) []Place {
+	placesCopy := make([]Place, len(places))
+	copy(placesCopy, places)
+
+	rand.Seed(time.Now().UnixNano())
+
+	// Fisher-Yatesアルゴリズム
+	// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+	for i := len(places) - 1; i > 0; i-- {
+		j := rand.Intn(i + 1)
+		placesCopy[i], placesCopy[j] = placesCopy[j], placesCopy[i]
+	}
+
+	return placesCopy
 }

--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -9,15 +9,6 @@ type Place struct {
 	LikeCount uint        `json:"like_count"`
 }
 
-func NewPlaceFromGooglePlace(placeId string, googlePlace GooglePlace) Place {
-	return Place{
-		Id:       placeId,
-		Google:   googlePlace,
-		Name:     googlePlace.Name,
-		Location: googlePlace.Location,
-	}
-}
-
 func (p Place) Categories() []LocationCategory {
 	return GetCategoriesFromSubCategories(p.Google.Types)
 }

--- a/internal/domain/models/place_test.go
+++ b/internal/domain/models/place_test.go
@@ -138,6 +138,39 @@ func TestShufflePlaces(t *testing.T) {
 	}
 }
 
+func TestSortPlacesByRating(t *testing.T) {
+	cases := []struct {
+		name     string
+		places   []Place
+		expected []Place
+	}{
+		{
+			name: "should return sorted places by rating",
+			places: []Place{
+				NewMockPlaceShinjukuStation(),
+				NewMockPlaceIsetan(),
+				NewMockPlaceShinjukuGyoen(),
+				NewMockPlaceTakashimaya(),
+			},
+			expected: []Place{
+				NewMockPlaceTakashimaya(),
+				NewMockPlaceShinjukuGyoen(),
+				NewMockPlaceIsetan(),
+				NewMockPlaceShinjukuStation(),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := SortPlacesByRating(c.places)
+			if diff := cmp.Diff(c.expected, actual); diff != "" {
+				t.Errorf("SortPlacesByRating() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 // ==============================================================
 // Mocks
 // ==============================================================
@@ -148,6 +181,9 @@ func NewMockPlaceShinjukuStation() Place {
 		Location: GeoLocation{
 			Latitude:  35.6899573,
 			Longitude: 139.7005071,
+		},
+		Google: GooglePlace{
+			Rating: 4.5,
 		},
 	}
 }
@@ -160,6 +196,9 @@ func NewMockPlaceIsetan() Place {
 			Latitude:  35.6916532,
 			Longitude: 139.7046449,
 		},
+		Google: GooglePlace{
+			Rating: 4.6,
+		},
 	}
 }
 
@@ -171,6 +210,9 @@ func NewMockPlaceShinjukuGyoen() Place {
 			Latitude:  35.6867668,
 			Longitude: 139.7123842,
 		},
+		Google: GooglePlace{
+			Rating: 4.7,
+		},
 	}
 }
 
@@ -181,6 +223,9 @@ func NewMockPlaceTakashimaya() Place {
 		Location: GeoLocation{
 			Latitude:  35.6875312,
 			Longitude: 139.7022521,
+		},
+		Google: GooglePlace{
+			Rating: 4.8,
 		},
 	}
 }

--- a/internal/domain/models/place_test.go
+++ b/internal/domain/models/place_test.go
@@ -100,6 +100,44 @@ func TestPlace_EstimatedStayDuration(t *testing.T) {
 	}
 }
 
+func TestShufflePlaces(t *testing.T) {
+	cases := []struct {
+		name     string
+		places   []Place
+		expected []Place
+	}{
+		{
+			name: "should return shuffled places",
+			places: []Place{
+				NewMockPlaceShinjukuStation(),
+				NewMockPlaceIsetan(),
+				NewMockPlaceShinjukuGyoen(),
+				NewMockPlaceTakashimaya(),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			original := make([]Place, len(c.places))
+			copy(original, c.places)
+
+			actual := ShufflePlaces(c.places)
+			if diff := cmp.Diff(len(c.places), len(actual)); diff != "" {
+				t.Errorf("ShufflePlaces() mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(original, actual); diff == "" {
+				t.Errorf("ShufflePlaces() should return shuffled places")
+			}
+
+			if diff := cmp.Diff(original, c.places); diff != "" {
+				t.Errorf("ShufflePlaces() should not modify original places")
+			}
+		})
+	}
+}
+
 // ==============================================================
 // Mocks
 // ==============================================================

--- a/internal/domain/services/placefilter/filter_by_has_photo.go
+++ b/internal/domain/services/placefilter/filter_by_has_photo.go
@@ -1,0 +1,13 @@
+package placefilter
+
+import "poroto.app/poroto/planner/internal/domain/models"
+
+// FilterByHasPhoto は写真を取得済み または　取得可能な場所のみを返す
+func FilterByHasPhoto(placesToFilter []models.Place) []models.Place {
+	return FilterPlaces(placesToFilter, func(place models.Place) bool {
+		hasPhoto := place.Google.Photos != nil && len(*place.Google.Photos) > 0
+		hasPhotoReference := place.Google.PhotoReferences != nil && len(place.Google.PhotoReferences) > 0
+		hasPhotoReferenceInPlaceDetail := place.Google.PlaceDetail != nil && len(place.Google.PlaceDetail.PhotoReferences) > 0
+		return hasPhoto || hasPhotoReference || hasPhotoReferenceInPlaceDetail
+	})
+}

--- a/internal/domain/services/placefilter/filter_by_has_photo_test.go
+++ b/internal/domain/services/placefilter/filter_by_has_photo_test.go
@@ -1,0 +1,110 @@
+package placefilter
+
+import (
+	"poroto.app/poroto/planner/internal/domain/models"
+	"testing"
+)
+
+func TestFilterByHasPhoto(t *testing.T) {
+	cases := []struct {
+		name     string
+		places   []models.Place
+		expected []models.Place
+	}{
+		{
+			name: "should return places which has photo",
+			places: []models.Place{
+				{
+					Id: "has_photo",
+					Google: models.GooglePlace{
+						Photos: &[]models.GooglePlacePhoto{{PhotoReference: "photo_reference"}},
+					},
+				},
+				{
+					Id: "empty_photo",
+					Google: models.GooglePlace{
+						Photos: &[]models.GooglePlacePhoto{},
+					},
+				},
+			},
+			expected: []models.Place{
+				{
+					Id: "has_photo",
+					Google: models.GooglePlace{
+						Photos: &[]models.GooglePlacePhoto{{PhotoReference: "photo_reference"}},
+					},
+				},
+			},
+		},
+		{
+			name: "should return places which has photo reference",
+			places: []models.Place{
+				{
+					Id: "has_photo_reference",
+					Google: models.GooglePlace{
+						PhotoReferences: []models.GooglePlacePhotoReference{{PhotoReference: "photo_reference"}},
+					},
+				},
+				{
+					Id: "empty_photo_reference",
+					Google: models.GooglePlace{
+						PhotoReferences: []models.GooglePlacePhotoReference{},
+					},
+				},
+			},
+			expected: []models.Place{
+				{
+					Id: "has_photo_reference",
+					Google: models.GooglePlace{
+						PhotoReferences: []models.GooglePlacePhotoReference{{PhotoReference: "photo_reference"}},
+					},
+				},
+			},
+		},
+		{
+			name: "should return places which has photo reference in place detail",
+			places: []models.Place{
+				{
+					Id: "has_photo_reference_in_place_detail",
+					Google: models.GooglePlace{
+						PlaceDetail: &models.GooglePlaceDetail{
+							PhotoReferences: []models.GooglePlacePhotoReference{{PhotoReference: "photo_reference"}},
+						},
+					},
+				},
+				{
+					Id: "empty_photo_reference_in_place_detail",
+					Google: models.GooglePlace{
+						PlaceDetail: &models.GooglePlaceDetail{
+							PhotoReferences: []models.GooglePlacePhotoReference{},
+						},
+					},
+				},
+			},
+			expected: []models.Place{
+				{
+					Id: "has_photo_reference_in_place_detail",
+					Google: models.GooglePlace{
+						PlaceDetail: &models.GooglePlaceDetail{
+							PhotoReferences: []models.GooglePlacePhotoReference{{PhotoReference: "photo_reference"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := FilterByHasPhoto(c.places)
+			if len(actual) != len(c.expected) {
+				t.Errorf("expected: %v, actual: %v", c.expected, actual)
+			}
+			for i, a := range actual {
+				if a.Id != c.expected[i].Id {
+					t.Errorf("expected: %v, actual: %v", c.expected, actual)
+				}
+			}
+		})
+	}
+}

--- a/internal/domain/services/plancandidate/places_to_add.go
+++ b/internal/domain/services/plancandidate/places_to_add.go
@@ -3,8 +3,6 @@ package plancandidate
 import (
 	"context"
 	"fmt"
-	"sort"
-
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
 )
@@ -56,9 +54,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, planCandidateId string, p
 	})
 
 	// レビューの高い順でソート
-	sort.SliceStable(placesFiltered, func(i, j int) bool {
-		return placesFiltered[i].Google.Rating > placesFiltered[j].Google.Rating
-	})
+	placesFiltered = models.SortPlacesByRating(placesFiltered)
 
 	// TODO: すべてのカテゴリの場所が表示されるようにする
 	var placesToAdd []models.Place

--- a/internal/domain/services/plancandidate/places_to_replace.go
+++ b/internal/domain/services/plancandidate/places_to_replace.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
-	"sort"
 )
 
-func (s Service) FetchPlacesToReplace(
+func (s *Service) FetchPlacesToReplace(
 	ctx context.Context,
 	planCandidateId string,
 	planId string,
@@ -30,6 +29,12 @@ func (s Service) FetchPlacesToReplace(
 		return nil, fmt.Errorf("plan not found")
 	}
 
+	if len(plan.Places) == 0 {
+		return nil, fmt.Errorf("plan has no places")
+	}
+
+	startPlace := plan.Places[0]
+
 	var placeToReplace *models.Place
 	for _, placeInPlan := range plan.Places {
 		if placeInPlan.Id != placeId {
@@ -47,6 +52,9 @@ func (s Service) FetchPlacesToReplace(
 	}
 
 	placesFiltered := placesSearched
+
+	// 遠い場所を除外
+	placesFiltered = placefilter.FilterWithinDistanceRange(placesFiltered, startPlace.Location, 0, 1000)
 
 	// 重複した場所を削除
 	placesFiltered = placefilter.FilterDuplicated(placesFiltered)
@@ -68,22 +76,42 @@ func (s Service) FetchPlacesToReplace(
 		return true
 	})
 
-	// 指定された場所と同じカテゴリの場所を選択
-	placesFiltered = placefilter.FilterByCategory(placesFiltered, placeToReplace.Categories(), true)
+	// 画像が取得できる場所のみを選択する
+	placesFiltered = placefilter.FilterByHasPhoto(placesFiltered)
 
-	// レビューの高い順でソート
-	sort.SliceStable(placesFiltered, func(i, j int) bool {
-		return placesFiltered[i].Google.Rating > placesFiltered[j].Google.Rating
+	// カテゴリのない場所を除外する
+	placesFiltered = placefilter.FilterPlaces(placesFiltered, func(place models.Place) bool {
+		return len(place.Categories()) > 0
 	})
 
-	var placesToReplace []models.Place
-	for _, place := range placesFiltered {
-		if len(place.Categories()) == 0 {
-			continue
-		}
+	// レビューの高い順でソート
+	placesFiltered = models.SortPlacesByRating(placesFiltered)
 
-		placesToReplace = append(placesToReplace, place)
+	// 10件程度を候補として選択する
+	if len(placesFiltered) > 10 {
+		placesFiltered = placesFiltered[:10]
 	}
+
+	// なるべく一様に選択されるようにシャッフルする
+	placesFiltered = models.ShufflePlaces(placesFiltered)
+
+	// 指定された場所と同じカテゴリの場所が候補の半分の数だけ含められるようにする
+	placesFilteredSameCategory := placefilter.FilterByCategory(placesFiltered, placeToReplace.Categories(), true)
+	nPlacesSameCategory := int(nLimit / 2)
+	if len(placesFilteredSameCategory) > nPlacesSameCategory {
+		placesFilteredSameCategory = placesFilteredSameCategory[:nPlacesSameCategory]
+	}
+
+	// 指定された場所と異なるカテゴリの場所が候補の半分の数だけ含められるようにする
+	placesFilteredDifferentCategory := placefilter.FilterByCategory(placesFiltered, placeToReplace.Categories(), false)
+	nPlacesDifferentCategory := int(nLimit) - nPlacesSameCategory
+	if len(placesFilteredDifferentCategory) > nPlacesDifferentCategory {
+		placesFilteredDifferentCategory = placesFilteredDifferentCategory[:nPlacesDifferentCategory]
+	}
+
+	var placesToReplace []models.Place
+	placesToReplace = append(placesToReplace, placesFilteredSameCategory...)
+	placesToReplace = append(placesToReplace, placesFilteredDifferentCategory...)
 
 	if len(placesToReplace) > int(nLimit) {
 		placesToReplace = placesToReplace[:nLimit]

--- a/internal/domain/services/plangen/select_base_place.go
+++ b/internal/domain/services/plangen/select_base_place.go
@@ -70,9 +70,7 @@ func (s Service) SelectBasePlace(input SelectBasePlaceInput) []models.Place {
 // categoriesPreferred が指定される場合は、同じカテゴリの場所が含まれないように選択する
 func selectByReview(places []models.Place) []models.Place {
 	// レビューの高い順にソート
-	sort.SliceStable(places, func(i, j int) bool {
-		return places[i].Google.Rating > places[j].Google.Rating
-	})
+	places = models.SortPlacesByRating(places)
 
 	var placesSelected []models.Place
 	for _, place := range places {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- before
  - 写真がないために、porotoで表示するときにフィルタされ表示されない
  - 選択した場所と同じカテゴリの場所だけが表示される
- after:
  - 写真が取得できる場所だけをフィルタリングすることで、なるべく表示されるようにする
  - ランダム性を入れることで、同じ場所ばかりが表示されることを避ける
  - 選択した場所と同じカテゴリの場所と別のカテゴリの場所が同じ数だけ表示されるようにする

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #345 
- #346 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 場所を入れ替えるときにより良い場所が見つけやすくなるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 表示するたびに場所が変わることを確認

```shell
# planner
export BRANCH_PLANNER=feature/improve_places_to_replace
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=feature/places_to_replace
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```