### PR TITLE
カテゴリ検索時に検索範囲を指定できるようにする

### DIFF
--- a/internal/domain/services/place/photo.go
+++ b/internal/domain/services/place/photo.go
@@ -62,7 +62,7 @@ func (s Service) fetchGooglePlacesPhotos(ctx context.Context, places []models.Go
 		go func(ctx context.Context, place models.GooglePlace, ch chan<- models.GooglePlace) {
 			// すでに写真がある場合は，何もしない
 			if place.Photos != nil && len(*place.Photos) > 0 {
-				s.logger.Info(
+				s.logger.Debug(
 					"skip fetching place photos because photos already exist",
 					zap.String("placeId", place.PlaceId),
 				)
@@ -71,7 +71,7 @@ func (s Service) fetchGooglePlacesPhotos(ctx context.Context, places []models.Go
 			}
 
 			if place.PlaceDetail == nil || len(place.PlaceDetail.PhotoReferences) == 0 {
-				s.logger.Info(
+				s.logger.Debug(
 					"skip fetching place photos because photo references not found",
 					zap.String("placeId", place.PlaceId),
 				)

--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -191,6 +191,11 @@ func (s Service) placeTypesToSearch() []placeTypeWithCondition {
 			ignorePlaceCount: 1,
 		},
 		{
+			placeType:        maps.PlaceTypeTouristAttraction,
+			searchRange:      30 * 1000,
+			ignorePlaceCount: 1,
+		},
+		{
 			placeType:        maps.PlaceTypeZoo,
 			searchRange:      30 * 1000,
 			ignorePlaceCount: 1,

--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -212,7 +212,7 @@ func (s Service) placeTypesToSearch() []placeTypeWithCondition {
 		{
 			placeType:        maps.PlaceTypeSpa,
 			searchRange:      30 * 1000,
-			filterRange:      5 * 1000,
+			filterRange:      3 * 1000,
 			ignorePlaceCount: 1,
 		},
 		{

--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -154,8 +154,6 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 }
 
 func (s Service) placeTypesToSearch() []placeTypeWithCondition {
-	//maps.PlaceTypeSpa,
-	//maps.PlaceTypeZoo,
 	return []placeTypeWithCondition{
 		{
 			placeType:        maps.PlaceTypeAquarium,
@@ -164,8 +162,8 @@ func (s Service) placeTypesToSearch() []placeTypeWithCondition {
 		},
 		{
 			placeType:        maps.PlaceTypeAmusementPark,
-			searchRange:      2 * 1000,
-			ignorePlaceCount: 3,
+			searchRange:      30 * 1000,
+			ignorePlaceCount: 1,
 		},
 		{
 			placeType:        maps.PlaceTypeCafe,

--- a/internal/domain/services/place/search_nearby_location.go
+++ b/internal/domain/services/place/search_nearby_location.go
@@ -32,7 +32,6 @@ type placeTypeWithCondition struct {
 	placeType        maps.PlaceType
 	searchRange      uint
 	ignorePlaceCount uint
-	rankedBy         maps.RankBy
 }
 
 // SearchNearbyPlaces location で指定された場所の付近にある場所を検索する
@@ -65,7 +64,7 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 		placesInSearchRange := placefilter.FilterWithinDistanceRange(places, input.Location, 0, float64(placeTypeToSearch.searchRange))
 		if len(placesInSearchRange) >= int(placeTypeToSearch.ignorePlaceCount) {
 			// 必要な分だけ場所の検索結果が取得できた場合は、そのカテゴリの検索は行わない
-			s.logger.Info(
+			s.logger.Debug(
 				"skip searching place type because it has enough places",
 				zap.String("placeType", string(placeTypeToSearch.placeType)),
 				zap.Int("places", len(places)),
@@ -92,7 +91,6 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 				Language:    "ja",
 				Type:        placeTypePointer,
 				SearchCount: 1,
-				RankedBy:    placeTypeWithCondition.rankedBy,
 			})
 			if err != nil {
 				// TODO: channelを用いてエラーハンドリングする
@@ -105,7 +103,7 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 				)
 			}
 
-			s.logger.Debug(
+			s.logger.Info(
 				"successfully fetched nearby places",
 				zap.String("placeType", string(placeTypeWithCondition.placeType)),
 				zap.Uint("searchRange", placeTypeWithCondition.searchRange),
@@ -163,49 +161,41 @@ func (s Service) placeTypesToSearch() []placeTypeWithCondition {
 			placeType:        maps.PlaceTypeAquarium,
 			searchRange:      30 * 1000,
 			ignorePlaceCount: 1,
-			rankedBy:         maps.RankByDistance,
 		},
 		{
 			placeType:        maps.PlaceTypeAmusementPark,
 			searchRange:      2 * 1000,
 			ignorePlaceCount: 3,
-			rankedBy:         maps.RankByProminence,
 		},
 		{
 			placeType:        maps.PlaceTypeCafe,
 			searchRange:      2 * 1000,
 			ignorePlaceCount: 5,
-			rankedBy:         maps.RankByProminence,
 		},
 		{
 			placeType:        maps.PlaceTypeMuseum,
 			searchRange:      30 * 1000,
 			ignorePlaceCount: 1,
-			rankedBy:         maps.RankByDistance,
 		},
 		{
 			placeType:        maps.PlaceTypeRestaurant,
 			searchRange:      2 * 1000,
 			ignorePlaceCount: 5,
-			rankedBy:         maps.RankByProminence,
 		},
 		{
 			placeType:        maps.PlaceTypeShoppingMall,
 			searchRange:      2 * 1000,
 			ignorePlaceCount: 3,
-			rankedBy:         maps.RankByProminence,
 		},
 		{
 			placeType:        maps.PlaceTypeSpa,
 			searchRange:      30 * 1000,
 			ignorePlaceCount: 1,
-			rankedBy:         maps.RankByDistance,
 		},
 		{
 			placeType:        maps.PlaceTypeZoo,
 			searchRange:      30 * 1000,
 			ignorePlaceCount: 1,
-			rankedBy:         maps.RankByDistance,
 		},
 	}
 }

--- a/internal/domain/services/plan/save.go
+++ b/internal/domain/services/plan/save.go
@@ -39,7 +39,7 @@ func (s Service) SavePlanFromPlanCandidate(ctx context.Context, planCandidateId 
 	}
 
 	if planSaved != nil {
-		s.logger.Info(
+		s.logger.Debug(
 			"plan already exists. skip saving plan",
 			zap.String("planId", planId),
 		)

--- a/internal/domain/utils/logger.go
+++ b/internal/domain/utils/logger.go
@@ -7,10 +7,19 @@ import (
 )
 
 type LoggerOption struct {
-	Tag string
+	Tag      string
+	LogLevel *zapcore.Level
 }
 
 func NewLogger(option LoggerOption) (*zap.Logger, error) {
+	if option.LogLevel == nil {
+		if os.Getenv("ENV") == "production" {
+			*option.LogLevel = zap.InfoLevel
+		} else {
+			*option.LogLevel = zap.DebugLevel
+		}
+	}
+
 	var logger *zap.Logger
 	if os.Getenv("ENV") == "production" {
 		l, err := zap.NewProduction()
@@ -24,6 +33,7 @@ func NewLogger(option LoggerOption) (*zap.Logger, error) {
 		dc.Encoding = "console"
 		dc.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		dc.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		dc.Level = zap.NewAtomicLevelAt(*option.LogLevel)
 
 		l, err := dc.Build()
 		if err != nil {

--- a/internal/domain/utils/logger.go
+++ b/internal/domain/utils/logger.go
@@ -6,6 +6,11 @@ import (
 	"os"
 )
 
+const (
+	defaultLogLevelDevelopment = zap.InfoLevel
+	defaultLogLevelProduction  = zap.DebugLevel
+)
+
 type LoggerOption struct {
 	Tag      string
 	LogLevel *zapcore.Level
@@ -15,9 +20,9 @@ func NewLogger(option LoggerOption) (*zap.Logger, error) {
 	if option.LogLevel == nil {
 		var defaultLogLevel zapcore.Level
 		if os.Getenv("ENV") == "production" {
-			defaultLogLevel = zap.InfoLevel
+			defaultLogLevel = defaultLogLevelProduction
 		} else {
-			defaultLogLevel = zap.DebugLevel
+			defaultLogLevel = defaultLogLevelDevelopment
 		}
 		option.LogLevel = &defaultLogLevel
 	}

--- a/internal/domain/utils/logger.go
+++ b/internal/domain/utils/logger.go
@@ -13,11 +13,13 @@ type LoggerOption struct {
 
 func NewLogger(option LoggerOption) (*zap.Logger, error) {
 	if option.LogLevel == nil {
+		var defaultLogLevel zapcore.Level
 		if os.Getenv("ENV") == "production" {
-			*option.LogLevel = zap.InfoLevel
+			defaultLogLevel = zap.InfoLevel
 		} else {
-			*option.LogLevel = zap.DebugLevel
+			defaultLogLevel = zap.DebugLevel
 		}
+		option.LogLevel = &defaultLogLevel
 	}
 
 	var logger *zap.Logger

--- a/internal/domain/utils/logger.go
+++ b/internal/domain/utils/logger.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	defaultLogLevelDevelopment = zap.InfoLevel
-	defaultLogLevelProduction  = zap.DebugLevel
+	defaultLogLevelProduction  = zap.InfoLevel
 )
 
 type LoggerOption struct {
@@ -55,4 +55,8 @@ func NewLogger(option LoggerOption) (*zap.Logger, error) {
 	}
 
 	return logger, nil
+}
+
+func LoggerLevelPointer(level zapcore.Level) *zapcore.Level {
+	return &level
 }

--- a/internal/infrastructure/api/google/places/nearbysearch.go
+++ b/internal/infrastructure/api/google/places/nearbysearch.go
@@ -16,6 +16,7 @@ type NearbySearchRequest struct {
 	Language    string
 	Type        *maps.PlaceType
 	SearchCount int
+	RankedBy    maps.RankBy
 }
 
 func (r PlacesApi) NearbySearch(ctx context.Context, req *NearbySearchRequest) ([]Place, error) {
@@ -32,6 +33,7 @@ func (r PlacesApi) NearbySearch(ctx context.Context, req *NearbySearchRequest) (
 		Radius:   req.Radius,
 		Language: req.Language,
 		Type:     placeType,
+		RankBy:   req.RankedBy,
 	}, req.SearchCount)
 	if err != nil {
 		return nil, err
@@ -69,6 +71,7 @@ func (r PlacesApi) nearBySearch(ctx context.Context, req *maps.NearbySearchReque
 		zap.String("language", req.Language),
 		zap.String("type", string(req.Type)),
 		zap.Int("pagesCount", pagesCount),
+		zap.String("rankBy", string(req.RankBy)),
 	)
 	if pagesCount < 1 {
 		pagesCount = 1

--- a/internal/infrastructure/firestore/place.go
+++ b/internal/infrastructure/firestore/place.go
@@ -76,7 +76,7 @@ func (p PlaceRepository) SavePlacesFromGooglePlace(ctx context.Context, googlePl
 			}
 
 			if gp != nil {
-				p.logger.Info(
+				p.logger.Debug(
 					"Skip saving place because it is already saved",
 					zap.String("placeId", placeEntity.Id),
 					zap.String("googlePlaceId", googlePlace.PlaceId),


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 水族館等の施設の数が少ない場所を検索するときには、広い範囲を検索するように修正した。
- また、「保存された検索結果にN個含まれていたらNearbySearchを行わない」とするときの、距離のフィルタリングもかけられるようにした。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 水族館や温泉等のカテゴリの場所が必要に応じて検索されるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/search_range
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```