### PR TITLE
staging, productionではリリースモードで実行されるようにする

### DIFF
--- a/internal/interface/rest/server.go
+++ b/internal/interface/rest/server.go
@@ -33,11 +33,11 @@ func NewRestServer(env string) *Server {
 }
 
 func (s Server) ServeHTTP() error {
-	r := gin.Default()
-
 	if s.isStaging() || s.isProduction() {
 		gin.SetMode(gin.ReleaseMode)
 	}
+
+	r := gin.Default()
 
 	r.Use(cors.New(cors.Config{
 		AllowMethods:     []string{"POST"},


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- サーバが落ちたときに自動リカバリできるようにstaging, production環境ではリリースモードで実行されるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x]`go run cmd/server/main.go` で起動すると以下のような警告が出ることを確認
  ```
  [GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
   - using env:   export GIN_MODE=release
   - using code:  gin.SetMode(gin.ReleaseMode)
  ```
- [x] `ENV="staging" go run cmd/server/main.go`とすると警告が出ないことを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```