### PR TITLE
Dockerを用いてMySQLを起動できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ go mod tidy
 
 ### MySQLの起動（Docker）
 ```shell
-docker-compose up -d
+docker compose up -d
 ```
 
 ### IntelliJ IDEAの設定

--- a/README.md
+++ b/README.md
@@ -102,3 +102,13 @@ go generate ./...
 ```shell
 go test ./...
 ```
+
+## Trouble Shooting
+### MySQLをアップグレード・ダウングレードしたら起動できなくなった
+※ 本番環境ではデータを移行することが必要です
+
+ローカルでデータを削除する場合は以下のコマンドを利用します
+```shell
+docker compose down
+docker volume rm planner_mysql-data
+```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ go version
 go mod tidy
 ```
 
+### MySQLの起動（Docker）
+```shell
+docker-compose up -d
+```
+
 ### IntelliJ IDEAの設定
 1. `go env`を実行し、`GOROOT`を取得する
 2. `Languages & Frameworks` → `GO`→ `GOROOT` を開く
@@ -93,7 +98,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.46.2 golangci-l
 go generate ./...
 ```
 
-## Test
+## テストの実行
 ```shell
 go test ./...
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,8 @@ version: '3.1'
 
 services:
   db:
-    image: mysql:8.2
+    # SEE: https://planetscale.com/docs/reference/mysql-compatibility#overview
+    image: mysql:8.0
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: '3.1'
+
+services:
+  db:
+    image: mysql:8.2
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: poroto
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - my-db:/var/lib/mysql
+
+volumes:
+  my-db:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - my-db:/var/lib/mysql
+      - mysql-data:/var/lib/mysql
 
 volumes:
-  my-db:
+  mysql-data:


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- MySQLをDockerを用いて起動するためのファイルを作成

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- FirestoreからMySQLに順次移行を進めていくため
- だれの環境でも環境構築をしやすくするため

### どのようにテストされているか
- [x] `docker compose up`でMySQLサーバが起動することを確認

```shell
# planner
export BRANCH_PLANNER=feature/docker_mysql
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```