### PR TITLE
Github ActionsでPlanetScaleのDeploy Requestが作成されるようにする

### DIFF
--- a/.github/workflows/planetscale_create_deploy_request.yaml
+++ b/.github/workflows/planetscale_create_deploy_request.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a deploy request
-        uses: planetscale/create-deploy-request-action@v1
+        uses: planetscale/create-deploy-request-action@v2
         id: create_deploy_request
         with:
           org_name: poroto
@@ -21,7 +21,7 @@ jobs:
           PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
       - name: Deploy a deploy request
-        uses: planetscale/deploy-deploy-request-action@v1
+        uses: planetscale/deploy-deploy-request-action@v4
         with:
           org_name: poroto
           database_name: poroto
@@ -37,7 +37,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Create a branch
-        uses: planetscale/create-branch-action@v1
+        uses: planetscale/create-branch-action@v4
         id: create_branch
         with:
           org_name: poroto

--- a/.github/workflows/planetscale_create_deploy_request.yaml
+++ b/.github/workflows/planetscale_create_deploy_request.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   # SEE: https://planetscale.com/blog/announcing-the-planetscale-github-actions
-  merge_changes:
+  merge-changes:
     runs-on: ubuntu-latest
     steps:
       - name: Create a deploy request
@@ -31,7 +31,7 @@ jobs:
           PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
   create-staging-branch:
-    needs: merge_changes
+    needs: merge-changes
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/planetscale_create_deploy_request.yaml
+++ b/.github/workflows/planetscale_create_deploy_request.yaml
@@ -6,7 +6,8 @@ on:
 #    paths: ["db/migrations/**"]
 
 jobs:
-  create-deploy-request:
+  # SEE: https://planetscale.com/blog/announcing-the-planetscale-github-actions
+  merge_changes:
     runs-on: ubuntu-latest
     steps:
       - name: Create a deploy request
@@ -16,6 +17,33 @@ jobs:
           org_name: poroto
           database_name: poroto
           branch_name: staging
+        env:
+          PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+      - name: Deploy a deploy request
+        uses: planetscale/deploy-deploy-request-action@v1
+        with:
+          org_name: poroto
+          database_name: poroto
+          number: ${{ steps.create_deploy_request.outputs.number }}
+          wait: true
+        env:
+          PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+  create-staging-branch:
+    needs: merge_changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Create a branch
+        uses: planetscale/create-branch-action@v1
+        id: create_branch
+        with:
+          org_name: poroto
+          database_name: poroto
+          branch_name: staging
+          from: main
         env:
           PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}

--- a/.github/workflows/planetscale_create_deploy_request.yaml
+++ b/.github/workflows/planetscale_create_deploy_request.yaml
@@ -30,20 +30,3 @@ jobs:
         env:
           PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
-  create-staging-branch:
-    needs: merge-changes
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Create a branch
-        uses: planetscale/create-branch-action@v4
-        id: create_branch
-        with:
-          org_name: poroto
-          database_name: poroto
-          branch_name: staging
-          from: main
-        env:
-          PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
-          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}

--- a/.github/workflows/planetscale_create_deploy_request.yaml
+++ b/.github/workflows/planetscale_create_deploy_request.yaml
@@ -1,4 +1,5 @@
 name: create-deploy-request
+run-name: Creating PlanetScale Deploy Request by @${{ github.actor }}
 on:
   pull_request:
 #    branches: [main]

--- a/.github/workflows/planetscale_create_deploy_request.yaml
+++ b/.github/workflows/planetscale_create_deploy_request.yaml
@@ -2,8 +2,8 @@ name: create-deploy-request
 run-name: Creating PlanetScale Deploy Request by @${{ github.actor }}
 on:
   pull_request:
-#    branches: [main]
-#    paths: ["db/migrations/**"]
+    branches: [main]
+    paths: ["db/migrations/**"]
 
 jobs:
   # SEE: https://planetscale.com/blog/announcing-the-planetscale-github-actions

--- a/.github/workflows/planetscale_create_deploy_request.yaml
+++ b/.github/workflows/planetscale_create_deploy_request.yaml
@@ -1,0 +1,20 @@
+name: create-deploy-request
+on:
+  pull_request:
+#    branches: [main]
+#    paths: ["db/migrations/**"]
+
+jobs:
+  create-deploy-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a deploy request
+        uses: planetscale/create-deploy-request-action@v1
+        id: create_deploy_request
+        with:
+          org_name: poroto
+          database_name: poroto
+          branch_name: staging
+        env:
+          PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Github ActionsでPlanetScaleのstagingブランチをmainブランチに自動デプロイできるようにした
- （PlanetScaleのstaging環境に行われたマイグレーションをproduction環境にも行われるようにする）

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #365 
- #363 
- #362 
- #361 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] Github Actionsが実行されることを確認
https://github.com/poroto-app/planner/actions/runs/7287643523