### PR TITLE
PlanCandidateを取得するクエリを追加

### DIFF
--- a/internal/interface/graphql/factory/plan.go
+++ b/internal/interface/graphql/factory/plan.go
@@ -8,14 +8,6 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidate, startLocation *models.GeoLocation) *graphql.PlanCandidate {
-	return &graphql.PlanCandidate{
-		ID:            planCandidate.Id,
-		Plans:         PlansFromDomainModel(&planCandidate.Plans, startLocation),
-		LikedPlaceIds: planCandidate.LikedPlaceIds,
-	}
-}
-
 func PlansFromDomainModel(plans *[]models.Plan, startLocation *models.GeoLocation) []*graphql.Plan {
 	graphqlPlans := make([]*graphql.Plan, 0)
 

--- a/internal/interface/graphql/factory/plan_candidate.go
+++ b/internal/interface/graphql/factory/plan_candidate.go
@@ -6,6 +6,10 @@ import (
 )
 
 func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidate, startLocation *models.GeoLocation) *graphql.PlanCandidate {
+	if planCandidate == nil {
+		return nil
+	}
+
 	return &graphql.PlanCandidate{
 		ID:                            planCandidate.Id,
 		Plans:                         PlansFromDomainModel(&planCandidate.Plans, startLocation),

--- a/internal/interface/graphql/factory/plan_candidate.go
+++ b/internal/interface/graphql/factory/plan_candidate.go
@@ -1,0 +1,14 @@
+package factory
+
+import (
+	"poroto.app/poroto/planner/internal/domain/models"
+	graphql "poroto.app/poroto/planner/internal/interface/graphql/model"
+)
+
+func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidate, startLocation *models.GeoLocation) *graphql.PlanCandidate {
+	return &graphql.PlanCandidate{
+		ID:            planCandidate.Id,
+		Plans:         PlansFromDomainModel(&planCandidate.Plans, startLocation),
+		LikedPlaceIds: planCandidate.LikedPlaceIds,
+	}
+}

--- a/internal/interface/graphql/factory/plan_candidate.go
+++ b/internal/interface/graphql/factory/plan_candidate.go
@@ -5,14 +5,14 @@ import (
 	graphql "poroto.app/poroto/planner/internal/interface/graphql/model"
 )
 
-func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidate, startLocation *models.GeoLocation) *graphql.PlanCandidate {
+func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidate) *graphql.PlanCandidate {
 	if planCandidate == nil {
 		return nil
 	}
 
 	return &graphql.PlanCandidate{
 		ID:                            planCandidate.Id,
-		Plans:                         PlansFromDomainModel(&planCandidate.Plans, startLocation),
+		Plans:                         PlansFromDomainModel(&planCandidate.Plans, planCandidate.MetaData.LocationStart),
 		LikedPlaceIds:                 planCandidate.LikedPlaceIds,
 		CreatedBasedOnCurrentLocation: planCandidate.MetaData.CreatedBasedOnCurrentLocation,
 	}

--- a/internal/interface/graphql/factory/plan_candidate.go
+++ b/internal/interface/graphql/factory/plan_candidate.go
@@ -7,8 +7,9 @@ import (
 
 func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidate, startLocation *models.GeoLocation) *graphql.PlanCandidate {
 	return &graphql.PlanCandidate{
-		ID:            planCandidate.Id,
-		Plans:         PlansFromDomainModel(&planCandidate.Plans, startLocation),
-		LikedPlaceIds: planCandidate.LikedPlaceIds,
+		ID:                            planCandidate.Id,
+		Plans:                         PlansFromDomainModel(&planCandidate.Plans, startLocation),
+		LikedPlaceIds:                 planCandidate.LikedPlaceIds,
+		CreatedBasedOnCurrentLocation: planCandidate.MetaData.CreatedBasedOnCurrentLocation,
 	}
 }

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1496,7 +1496,7 @@ input PlanCandidateInput {
 }
 
 type PlanCandidateOutput {
-    planCandidate: PlanCandidate!
+    planCandidate: PlanCandidate
 }
 
 input AvailablePlacesForPlanInput {
@@ -5897,14 +5897,11 @@ func (ec *executionContext) _PlanCandidateOutput_planCandidate(ctx context.Conte
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*model.PlanCandidate)
 	fc.Result = res
-	return ec.marshalNPlanCandidate2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidate(ctx, field.Selections, res)
+	return ec.marshalOPlanCandidate2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidate(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanCandidateOutput_planCandidate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -11422,9 +11419,6 @@ func (ec *executionContext) _PlanCandidateOutput(ctx context.Context, sel ast.Se
 			out.Values[i] = graphql.MarshalString("PlanCandidateOutput")
 		case "planCandidate":
 			out.Values[i] = ec._PlanCandidateOutput_planCandidate(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -13621,6 +13615,13 @@ func (ec *executionContext) marshalOPlan2ᚖporotoᚗappᚋporotoᚋplannerᚋin
 		return graphql.Null
 	}
 	return ec._Plan(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOPlanCandidate2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidate(ctx context.Context, sel ast.SelectionSet, v *model.PlanCandidate) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._PlanCandidate(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOPriceRange2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPriceRange(ctx context.Context, sel ast.SelectionSet, v *model.PriceRange) graphql.Marshaler {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -189,6 +189,10 @@ type ComplexityRoot struct {
 		Plans         func(childComplexity int) int
 	}
 
+	PlanCandidateOutput struct {
+		PlanCandidate func(childComplexity int) int
+	}
+
 	PlansByLocationOutput struct {
 		PageKey func(childComplexity int) int
 		Plans   func(childComplexity int) int
@@ -213,6 +217,7 @@ type ComplexityRoot struct {
 		PlacesToAddForPlanCandidate     func(childComplexity int, input model.PlacesToAddForPlanCandidateInput) int
 		PlacesToReplaceForPlanCandidate func(childComplexity int, input model.PlacesToReplaceForPlanCandidateInput) int
 		Plan                            func(childComplexity int, id string) int
+		PlanCandidate                   func(childComplexity int, input model.PlanCandidateInput) int
 		Plans                           func(childComplexity int, pageKey *string) int
 		PlansByLocation                 func(childComplexity int, input model.PlansByLocationInput) int
 		PlansByUser                     func(childComplexity int, input model.PlansByUserInput) int
@@ -257,6 +262,7 @@ type MutationResolver interface {
 type QueryResolver interface {
 	Version(ctx context.Context) (string, error)
 	CachedCreatedPlans(ctx context.Context, input model.CachedCreatedPlansInput) (*model.CachedCreatedPlans, error)
+	PlanCandidate(ctx context.Context, input model.PlanCandidateInput) (*model.PlanCandidateOutput, error)
 	NearbyPlaceCategories(ctx context.Context, input model.NearbyPlaceCategoriesInput) (*model.NearbyPlaceCategoryOutput, error)
 	AvailablePlacesForPlan(ctx context.Context, input model.AvailablePlacesForPlanInput) (*model.AvailablePlacesForPlan, error)
 	PlacesToAddForPlanCandidate(ctx context.Context, input model.PlacesToAddForPlanCandidateInput) (*model.PlacesToAddForPlanCandidateOutput, error)
@@ -870,6 +876,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PlanCandidate.Plans(childComplexity), true
 
+	case "PlanCandidateOutput.planCandidate":
+		if e.complexity.PlanCandidateOutput.PlanCandidate == nil {
+			break
+		}
+
+		return e.complexity.PlanCandidateOutput.PlanCandidate(childComplexity), true
+
 	case "PlansByLocationOutput.pageKey":
 		if e.complexity.PlansByLocationOutput.PageKey == nil {
 			break
@@ -1003,6 +1016,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Plan(childComplexity, args["id"].(string)), true
 
+	case "Query.planCandidate":
+		if e.complexity.Query.PlanCandidate == nil {
+			break
+		}
+
+		args, err := ec.field_Query_planCandidate_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.PlanCandidate(childComplexity, args["input"].(model.PlanCandidateInput)), true
+
 	case "Query.plans":
 		if e.complexity.Query.Plans == nil {
 			break
@@ -1131,6 +1156,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputNearbyPlaceCategoriesInput,
 		ec.unmarshalInputPlacesToAddForPlanCandidateInput,
 		ec.unmarshalInputPlacesToReplaceForPlanCandidateInput,
+		ec.unmarshalInputPlanCandidateInput,
 		ec.unmarshalInputPlansByLocationInput,
 		ec.unmarshalInputPlansByUserInput,
 		ec.unmarshalInputReplacePlaceOfPlanCandidateInput,
@@ -1425,9 +1451,11 @@ type LikeToPlaceInPlanCandidateOutput {
     planCandidate: PlanCandidate!
 }`, BuiltIn: false},
 	{Name: "../schema/plan_candidate_query.graphqls", Input: `extend type Query {
-    # TODO: planCandidates 等に変更する
+    # TODO: DELETE ME!
     # キャッシュされたプラン一覧を取得する
     cachedCreatedPlans(input: CachedCreatedPlansInput!): CachedCreatedPlans!
+
+    planCandidate(input : PlanCandidateInput!): PlanCandidateOutput!
 
     nearbyPlaceCategories(input: NearbyPlaceCategoriesInput!): NearbyPlaceCategoryOutput!
 
@@ -1442,15 +1470,25 @@ type LikeToPlaceInPlanCandidateOutput {
     placesToReplaceForPlanCandidate(input: PlacesToReplaceForPlanCandidateInput!): PlacesToReplaceForPlanCandidateOutput!
 }
 
+# TODO: DELETE ME!
 type CachedCreatedPlans {
     plans: [Plan!]!
     createdBasedOnCurrentLocation: Boolean!
     likedPlaceIds: [ID!]!
 }
 
+# TODO: DELETE ME!
 input CachedCreatedPlansInput {
     # CreatePlanByLocationOutputのsession
     session: String!
+}
+
+input PlanCandidateInput {
+    planCandidateId: ID!
+}
+
+type PlanCandidateOutput {
+    planCandidate: PlanCandidate!
 }
 
 input AvailablePlacesForPlanInput {
@@ -1850,6 +1888,21 @@ func (ec *executionContext) field_Query_placesToReplaceForPlanCandidate_args(ctx
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNPlacesToReplaceForPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlacesToReplaceForPlanCandidateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_planCandidate_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.PlanCandidateInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidateInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -5768,6 +5821,58 @@ func (ec *executionContext) fieldContext_PlanCandidate_likedPlaceIds(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _PlanCandidateOutput_planCandidate(ctx context.Context, field graphql.CollectedField, obj *model.PlanCandidateOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlanCandidateOutput_planCandidate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PlanCandidate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PlanCandidate)
+	fc.Result = res
+	return ec.marshalNPlanCandidate2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidate(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlanCandidateOutput_planCandidate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlanCandidateOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_PlanCandidate_id(ctx, field)
+			case "plans":
+				return ec.fieldContext_PlanCandidate_plans(ctx, field)
+			case "likedPlaceIds":
+				return ec.fieldContext_PlanCandidate_likedPlaceIds(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PlanCandidate", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PlansByLocationOutput_plans(ctx context.Context, field graphql.CollectedField, obj *model.PlansByLocationOutput) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PlansByLocationOutput_plans(ctx, field)
 	if err != nil {
@@ -6214,6 +6319,65 @@ func (ec *executionContext) fieldContext_Query_cachedCreatedPlans(ctx context.Co
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_cachedCreatedPlans_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_planCandidate(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_planCandidate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().PlanCandidate(rctx, fc.Args["input"].(model.PlanCandidateInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PlanCandidateOutput)
+	fc.Result = res
+	return ec.marshalNPlanCandidateOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidateOutput(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_planCandidate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "planCandidate":
+				return ec.fieldContext_PlanCandidateOutput_planCandidate(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PlanCandidateOutput", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_planCandidate_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9799,6 +9963,35 @@ func (ec *executionContext) unmarshalInputPlacesToReplaceForPlanCandidateInput(c
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputPlanCandidateInput(ctx context.Context, obj interface{}) (model.PlanCandidateInput, error) {
+	var it model.PlanCandidateInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"planCandidateId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "planCandidateId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("planCandidateId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PlanCandidateID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputPlansByLocationInput(ctx context.Context, obj interface{}) (model.PlansByLocationInput, error) {
 	var it model.PlansByLocationInput
 	asMap := map[string]interface{}{}
@@ -11154,6 +11347,45 @@ func (ec *executionContext) _PlanCandidate(ctx context.Context, sel ast.Selectio
 	return out
 }
 
+var planCandidateOutputImplementors = []string{"PlanCandidateOutput"}
+
+func (ec *executionContext) _PlanCandidateOutput(ctx context.Context, sel ast.SelectionSet, obj *model.PlanCandidateOutput) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, planCandidateOutputImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PlanCandidateOutput")
+		case "planCandidate":
+			out.Values[i] = ec._PlanCandidateOutput_planCandidate(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var plansByLocationOutputImplementors = []string{"PlansByLocationOutput"}
 
 func (ec *executionContext) _PlansByLocationOutput(ctx context.Context, sel ast.SelectionSet, obj *model.PlansByLocationOutput) graphql.Marshaler {
@@ -11339,6 +11571,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_cachedCreatedPlans(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "planCandidate":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_planCandidate(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -12754,6 +13008,25 @@ func (ec *executionContext) marshalNPlanCandidate2ᚖporotoᚗappᚋporotoᚋpla
 		return graphql.Null
 	}
 	return ec._PlanCandidate(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidateInput(ctx context.Context, v interface{}) (model.PlanCandidateInput, error) {
+	res, err := ec.unmarshalInputPlanCandidateInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNPlanCandidateOutput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidateOutput(ctx context.Context, sel ast.SelectionSet, v model.PlanCandidateOutput) graphql.Marshaler {
+	return ec._PlanCandidateOutput(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPlanCandidateOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidateOutput(ctx context.Context, sel ast.SelectionSet, v *model.PlanCandidateOutput) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._PlanCandidateOutput(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNPlansByLocationInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlansByLocationInput(ctx context.Context, v interface{}) (model.PlansByLocationInput, error) {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -184,9 +184,10 @@ type ComplexityRoot struct {
 	}
 
 	PlanCandidate struct {
-		ID            func(childComplexity int) int
-		LikedPlaceIds func(childComplexity int) int
-		Plans         func(childComplexity int) int
+		CreatedBasedOnCurrentLocation func(childComplexity int) int
+		ID                            func(childComplexity int) int
+		LikedPlaceIds                 func(childComplexity int) int
+		Plans                         func(childComplexity int) int
 	}
 
 	PlanCandidateOutput struct {
@@ -854,6 +855,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Plan.Transitions(childComplexity), true
+
+	case "PlanCandidate.createdBasedOnCurrentLocation":
+		if e.complexity.PlanCandidate.CreatedBasedOnCurrentLocation == nil {
+			break
+		}
+
+		return e.complexity.PlanCandidate.CreatedBasedOnCurrentLocation(childComplexity), true
 
 	case "PlanCandidate.id":
 		if e.complexity.PlanCandidate.ID == nil {
@@ -1531,6 +1539,7 @@ type PlacesToReplaceForPlanCandidateOutput {
     id: String!
     plans: [Plan!]!
     likedPlaceIds: [String!]!
+    createdBasedOnCurrentLocation: Boolean!
 }`, BuiltIn: false},
 	{Name: "../schema/plan_query.graphqls", Input: `extend type Query {
     plan(id: String!): Plan
@@ -3503,6 +3512,8 @@ func (ec *executionContext) fieldContext_LikeToPlaceInPlanCandidateOutput_planCa
 				return ec.fieldContext_PlanCandidate_plans(ctx, field)
 			case "likedPlaceIds":
 				return ec.fieldContext_PlanCandidate_likedPlaceIds(ctx, field)
+			case "createdBasedOnCurrentLocation":
+				return ec.fieldContext_PlanCandidate_createdBasedOnCurrentLocation(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PlanCandidate", field.Name)
 		},
@@ -5821,6 +5832,50 @@ func (ec *executionContext) fieldContext_PlanCandidate_likedPlaceIds(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _PlanCandidate_createdBasedOnCurrentLocation(ctx context.Context, field graphql.CollectedField, obj *model.PlanCandidate) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlanCandidate_createdBasedOnCurrentLocation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedBasedOnCurrentLocation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlanCandidate_createdBasedOnCurrentLocation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlanCandidate",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PlanCandidateOutput_planCandidate(ctx context.Context, field graphql.CollectedField, obj *model.PlanCandidateOutput) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PlanCandidateOutput_planCandidate(ctx, field)
 	if err != nil {
@@ -5866,6 +5921,8 @@ func (ec *executionContext) fieldContext_PlanCandidateOutput_planCandidate(ctx c
 				return ec.fieldContext_PlanCandidate_plans(ctx, field)
 			case "likedPlaceIds":
 				return ec.fieldContext_PlanCandidate_likedPlaceIds(ctx, field)
+			case "createdBasedOnCurrentLocation":
+				return ec.fieldContext_PlanCandidate_createdBasedOnCurrentLocation(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PlanCandidate", field.Name)
 		},
@@ -11321,6 +11378,11 @@ func (ec *executionContext) _PlanCandidate(ctx context.Context, sel ast.Selectio
 			}
 		case "likedPlaceIds":
 			out.Values[i] = ec._PlanCandidate_likedPlaceIds(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createdBasedOnCurrentLocation":
+			out.Values[i] = ec._PlanCandidate_createdBasedOnCurrentLocation(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -222,6 +222,14 @@ type PlanCandidate struct {
 	LikedPlaceIds []string `json:"likedPlaceIds"`
 }
 
+type PlanCandidateInput struct {
+	PlanCandidateID string `json:"planCandidateId"`
+}
+
+type PlanCandidateOutput struct {
+	PlanCandidate *PlanCandidate `json:"planCandidate"`
+}
+
 type PlansByLocationInput struct {
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -228,7 +228,7 @@ type PlanCandidateInput struct {
 }
 
 type PlanCandidateOutput struct {
-	PlanCandidate *PlanCandidate `json:"planCandidate"`
+	PlanCandidate *PlanCandidate `json:"planCandidate,omitempty"`
 }
 
 type PlansByLocationInput struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -217,9 +217,10 @@ type Plan struct {
 }
 
 type PlanCandidate struct {
-	ID            string   `json:"id"`
-	Plans         []*Plan  `json:"plans"`
-	LikedPlaceIds []string `json:"likedPlaceIds"`
+	ID                            string   `json:"id"`
+	Plans                         []*Plan  `json:"plans"`
+	LikedPlaceIds                 []string `json:"likedPlaceIds"`
+	CreatedBasedOnCurrentLocation bool     `json:"createdBasedOnCurrentLocation"`
 }
 
 type PlanCandidateInput struct {

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -325,7 +325,7 @@ func (r *mutationResolver) LikeToPlaceInPlanCandidate(ctx context.Context, input
 		return nil, fmt.Errorf("could not like to place in plan candidate")
 	}
 
-	graphqlPlanCandidate := factory.PlanCandidateFromDomainModel(planCandidateUpdated, planCandidateUpdated.MetaData.LocationStart)
+	graphqlPlanCandidate := factory.PlanCandidateFromDomainModel(planCandidateUpdated)
 
 	if err != nil {
 		log.Printf("error while converting plan candidate to graphql model: %v", err)

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -45,6 +45,11 @@ func (r *queryResolver) CachedCreatedPlans(ctx context.Context, input model.Cach
 	}, nil
 }
 
+// PlanCandidate is the resolver for the planCandidate field.
+func (r *queryResolver) PlanCandidate(ctx context.Context, input model.PlanCandidateInput) (*model.PlanCandidateOutput, error) {
+	panic(fmt.Errorf("not implemented: PlanCandidate - planCandidate"))
+}
+
 // NearbyPlaceCategories is the resolver for the nearbyPlaceCategories field.
 func (r *queryResolver) NearbyPlaceCategories(ctx context.Context, input model.NearbyPlaceCategoriesInput) (*model.NearbyPlaceCategoryOutput, error) {
 	logger, err := utils.NewLogger(utils.LoggerOption{

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -70,7 +70,7 @@ func (r *queryResolver) PlanCandidate(ctx context.Context, input model.PlanCandi
 		return nil, err
 	}
 
-	graphqlPlanCandidate := factory.PlanCandidateFromDomainModel(planCandidate, planCandidate.MetaData.LocationStart)
+	graphqlPlanCandidate := factory.PlanCandidateFromDomainModel(planCandidate)
 	return &model.PlanCandidateOutput{
 		PlanCandidate: graphqlPlanCandidate,
 	}, nil

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -70,12 +70,6 @@ func (r *queryResolver) PlanCandidate(ctx context.Context, input model.PlanCandi
 		return nil, err
 	}
 
-	if planCandidate == nil {
-		return &model.PlanCandidateOutput{
-			PlanCandidate: nil,
-		}, nil
-	}
-
 	graphqlPlanCandidate := factory.PlanCandidateFromDomainModel(planCandidate, planCandidate.MetaData.LocationStart)
 	return &model.PlanCandidateOutput{
 		PlanCandidate: graphqlPlanCandidate,

--- a/internal/interface/graphql/schema/plan_candidate_query.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_query.graphqls
@@ -1,7 +1,9 @@
 extend type Query {
-    # TODO: planCandidates 等に変更する
+    # TODO: DELETE ME!
     # キャッシュされたプラン一覧を取得する
     cachedCreatedPlans(input: CachedCreatedPlansInput!): CachedCreatedPlans!
+
+    planCandidate(input : PlanCandidateInput!): PlanCandidateOutput!
 
     nearbyPlaceCategories(input: NearbyPlaceCategoriesInput!): NearbyPlaceCategoryOutput!
 
@@ -16,15 +18,25 @@ extend type Query {
     placesToReplaceForPlanCandidate(input: PlacesToReplaceForPlanCandidateInput!): PlacesToReplaceForPlanCandidateOutput!
 }
 
+# TODO: DELETE ME!
 type CachedCreatedPlans {
     plans: [Plan!]!
     createdBasedOnCurrentLocation: Boolean!
     likedPlaceIds: [ID!]!
 }
 
+# TODO: DELETE ME!
 input CachedCreatedPlansInput {
     # CreatePlanByLocationOutputのsession
     session: String!
+}
+
+input PlanCandidateInput {
+    planCandidateId: ID!
+}
+
+type PlanCandidateOutput {
+    planCandidate: PlanCandidate!
 }
 
 input AvailablePlacesForPlanInput {

--- a/internal/interface/graphql/schema/plan_candidate_query.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_query.graphqls
@@ -36,7 +36,7 @@ input PlanCandidateInput {
 }
 
 type PlanCandidateOutput {
-    planCandidate: PlanCandidate!
+    planCandidate: PlanCandidate
 }
 
 input AvailablePlacesForPlanInput {

--- a/internal/interface/graphql/schema/plan_candidate_type.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_type.graphqls
@@ -2,4 +2,5 @@ type PlanCandidate {
     id: String!
     plans: [Plan!]!
     likedPlaceIds: [String!]!
+    createdBasedOnCurrentLocation: Boolean!
 }


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 今までCachedPlanCandidateとしていたクエリを`PlanCandidate`とした
- `CachedPlanCandidate`は次のリリースで削除する

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] Postmanで`PlanCandidate`の動作を確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```