### PR TITLE
[スキーマ変更] Google Place ID　からプランを作成するMutationを追加

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1392,9 +1392,6 @@ type CreatePlanByLocationOutput {
 input CreatePlanByPlaceInput {
     session: String!
     placeId: String!
-    categoriesPreferred: [String!]
-    categoriesDisliked: [String!]
-    freeTime: Int
 }
 
 type CreatePlanByPlaceOutput {
@@ -1403,8 +1400,11 @@ type CreatePlanByPlaceOutput {
 }
 
 input CreatePlanByGooglePlaceIdInput {
-    planCandidateId: String!
+    planCandidateId: String
     googlePlaceId: String!
+    categoriesPreferred: [String!]
+    categoriesDisliked: [String!]
+    freeTime: Int
 }
 
 type CreatePlanByGooglePlaceIdOutput {
@@ -9760,7 +9760,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByGooglePlaceIdInput(ctx con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"planCandidateId", "googlePlaceId"}
+	fieldsInOrder := [...]string{"planCandidateId", "googlePlaceId", "categoriesPreferred", "categoriesDisliked", "freeTime"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9771,7 +9771,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByGooglePlaceIdInput(ctx con
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("planCandidateId"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9785,6 +9785,33 @@ func (ec *executionContext) unmarshalInputCreatePlanByGooglePlaceIdInput(ctx con
 				return it, err
 			}
 			it.GooglePlaceID = data
+		case "categoriesPreferred":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoriesPreferred"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CategoriesPreferred = data
+		case "categoriesDisliked":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoriesDisliked"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CategoriesDisliked = data
+		case "freeTime":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("freeTime"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FreeTime = data
 		}
 	}
 
@@ -9890,7 +9917,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByPlaceInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"session", "placeId", "categoriesPreferred", "categoriesDisliked", "freeTime"}
+	fieldsInOrder := [...]string{"session", "placeId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9915,33 +9942,6 @@ func (ec *executionContext) unmarshalInputCreatePlanByPlaceInput(ctx context.Con
 				return it, err
 			}
 			it.PlaceID = data
-		case "categoriesPreferred":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoriesPreferred"))
-			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.CategoriesPreferred = data
-		case "categoriesDisliked":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoriesDisliked"))
-			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.CategoriesDisliked = data
-		case "freeTime":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("freeTime"))
-			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.FreeTime = data
 		}
 	}
 

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -68,6 +68,10 @@ type ComplexityRoot struct {
 		Plan func(childComplexity int) int
 	}
 
+	CreatePlanByGooglePlaceIdOutput struct {
+		PlanCandidate func(childComplexity int) int
+	}
+
 	CreatePlanByLocationOutput struct {
 		Plans   func(childComplexity int) int
 		Session func(childComplexity int) int
@@ -125,6 +129,7 @@ type ComplexityRoot struct {
 		AddPlaceToPlanCandidateAfterPlace func(childComplexity int, input *model.AddPlaceToPlanCandidateAfterPlaceInput) int
 		AutoReorderPlacesInPlanCandidate  func(childComplexity int, input model.AutoReorderPlacesInPlanCandidateInput) int
 		ChangePlacesOrderInPlanCandidate  func(childComplexity int, input model.ChangePlacesOrderInPlanCandidateInput) int
+		CreatePlanByGooglePlaceID         func(childComplexity int, input model.CreatePlanByGooglePlaceIDInput) int
 		CreatePlanByLocation              func(childComplexity int, input model.CreatePlanByLocationInput) int
 		CreatePlanByPlace                 func(childComplexity int, input model.CreatePlanByPlaceInput) int
 		DeletePlaceFromPlanCandidate      func(childComplexity int, input model.DeletePlaceFromPlanCandidateInput) int
@@ -251,6 +256,7 @@ type MutationResolver interface {
 	Ping(ctx context.Context, message string) (string, error)
 	CreatePlanByLocation(ctx context.Context, input model.CreatePlanByLocationInput) (*model.CreatePlanByLocationOutput, error)
 	CreatePlanByPlace(ctx context.Context, input model.CreatePlanByPlaceInput) (*model.CreatePlanByPlaceOutput, error)
+	CreatePlanByGooglePlaceID(ctx context.Context, input model.CreatePlanByGooglePlaceIDInput) (*model.CreatePlanByGooglePlaceIDOutput, error)
 	ChangePlacesOrderInPlanCandidate(ctx context.Context, input model.ChangePlacesOrderInPlanCandidateInput) (*model.ChangePlacesOrderInPlanCandidateOutput, error)
 	SavePlanFromCandidate(ctx context.Context, input model.SavePlanFromCandidateInput) (*model.SavePlanFromCandidateOutput, error)
 	AddPlaceToPlanCandidateAfterPlace(ctx context.Context, input *model.AddPlaceToPlanCandidateAfterPlaceInput) (*model.AddPlaceToPlanCandidateAfterPlaceOutput, error)
@@ -352,6 +358,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ChangePlacesOrderInPlanCandidateOutput.Plan(childComplexity), true
+
+	case "CreatePlanByGooglePlaceIdOutput.planCandidate":
+		if e.complexity.CreatePlanByGooglePlaceIdOutput.PlanCandidate == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanByGooglePlaceIdOutput.PlanCandidate(childComplexity), true
 
 	case "CreatePlanByLocationOutput.plans":
 		if e.complexity.CreatePlanByLocationOutput.Plans == nil {
@@ -570,6 +583,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.ChangePlacesOrderInPlanCandidate(childComplexity, args["input"].(model.ChangePlacesOrderInPlanCandidateInput)), true
+
+	case "Mutation.createPlanByGooglePlaceId":
+		if e.complexity.Mutation.CreatePlanByGooglePlaceID == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createPlanByGooglePlaceId_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreatePlanByGooglePlaceID(childComplexity, args["input"].(model.CreatePlanByGooglePlaceIDInput)), true
 
 	case "Mutation.createPlanByLocation":
 		if e.complexity.Mutation.CreatePlanByLocation == nil {
@@ -1155,6 +1180,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAvailablePlacesForPlanInput,
 		ec.unmarshalInputCachedCreatedPlansInput,
 		ec.unmarshalInputChangePlacesOrderInPlanCandidateInput,
+		ec.unmarshalInputCreatePlanByGooglePlaceIdInput,
 		ec.unmarshalInputCreatePlanByLocationInput,
 		ec.unmarshalInputCreatePlanByPlaceInput,
 		ec.unmarshalInputDeletePlaceFromPlanCandidateInput,
@@ -1321,6 +1347,8 @@ type PlaceCategory {
 
     createPlanByPlace(input: CreatePlanByPlaceInput!): CreatePlanByPlaceOutput!
 
+    createPlanByGooglePlaceId(input: CreatePlanByGooglePlaceIdInput!): CreatePlanByGooglePlaceIdOutput!
+
     changePlacesOrderInPlanCandidate(input: ChangePlacesOrderInPlanCandidateInput!): ChangePlacesOrderInPlanCandidateOutput!
 
     savePlanFromCandidate(input: SavePlanFromCandidateInput!): SavePlanFromCandidateOutput!
@@ -1369,6 +1397,15 @@ input CreatePlanByPlaceInput {
 type CreatePlanByPlaceOutput {
     session: String!
     plan: Plan!
+}
+
+input CreatePlanByGooglePlaceIdInput {
+    planCandidateId: String!
+    googlePlaceId: String!
+}
+
+type CreatePlanByGooglePlaceIdOutput {
+    planCandidate: PlanCandidate!
 }
 
 input ChangePlacesOrderInPlanCandidateInput {
@@ -1672,6 +1709,21 @@ func (ec *executionContext) field_Mutation_changePlacesOrderInPlanCandidate_args
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNChangePlacesOrderInPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐChangePlacesOrderInPlanCandidateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_createPlanByGooglePlaceId_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.CreatePlanByGooglePlaceIDInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNCreatePlanByGooglePlaceIdInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByGooglePlaceIDInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -2495,6 +2547,60 @@ func (ec *executionContext) fieldContext_ChangePlacesOrderInPlanCandidateOutput_
 				return ec.fieldContext_Plan_authorId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Plan", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanByGooglePlaceIdOutput_planCandidate(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanByGooglePlaceIDOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanByGooglePlaceIdOutput_planCandidate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PlanCandidate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PlanCandidate)
+	fc.Result = res
+	return ec.marshalNPlanCandidate2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanCandidate(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanByGooglePlaceIdOutput_planCandidate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanByGooglePlaceIdOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_PlanCandidate_id(ctx, field)
+			case "plans":
+				return ec.fieldContext_PlanCandidate_plans(ctx, field)
+			case "likedPlaceIds":
+				return ec.fieldContext_PlanCandidate_likedPlaceIds(ctx, field)
+			case "createdBasedOnCurrentLocation":
+				return ec.fieldContext_PlanCandidate_createdBasedOnCurrentLocation(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PlanCandidate", field.Name)
 		},
 	}
 	return fc, nil
@@ -3865,6 +3971,65 @@ func (ec *executionContext) fieldContext_Mutation_createPlanByPlace(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createPlanByPlace_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createPlanByGooglePlaceId(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createPlanByGooglePlaceId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreatePlanByGooglePlaceID(rctx, fc.Args["input"].(model.CreatePlanByGooglePlaceIDInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.CreatePlanByGooglePlaceIDOutput)
+	fc.Result = res
+	return ec.marshalNCreatePlanByGooglePlaceIdOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByGooglePlaceIDOutput(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createPlanByGooglePlaceId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "planCandidate":
+				return ec.fieldContext_CreatePlanByGooglePlaceIdOutput_planCandidate(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreatePlanByGooglePlaceIdOutput", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createPlanByGooglePlaceId_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9585,6 +9750,44 @@ func (ec *executionContext) unmarshalInputChangePlacesOrderInPlanCandidateInput(
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreatePlanByGooglePlaceIdInput(ctx context.Context, obj interface{}) (model.CreatePlanByGooglePlaceIDInput, error) {
+	var it model.CreatePlanByGooglePlaceIDInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"planCandidateId", "googlePlaceId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "planCandidateId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("planCandidateId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PlanCandidateID = data
+		case "googlePlaceId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("googlePlaceId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.GooglePlaceID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreatePlanByLocationInput(ctx context.Context, obj interface{}) (model.CreatePlanByLocationInput, error) {
 	var it model.CreatePlanByLocationInput
 	asMap := map[string]interface{}{}
@@ -10457,6 +10660,45 @@ func (ec *executionContext) _ChangePlacesOrderInPlanCandidateOutput(ctx context.
 	return out
 }
 
+var createPlanByGooglePlaceIdOutputImplementors = []string{"CreatePlanByGooglePlaceIdOutput"}
+
+func (ec *executionContext) _CreatePlanByGooglePlaceIdOutput(ctx context.Context, sel ast.SelectionSet, obj *model.CreatePlanByGooglePlaceIDOutput) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createPlanByGooglePlaceIdOutputImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreatePlanByGooglePlaceIdOutput")
+		case "planCandidate":
+			out.Values[i] = ec._CreatePlanByGooglePlaceIdOutput_planCandidate(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createPlanByLocationOutputImplementors = []string{"CreatePlanByLocationOutput"}
 
 func (ec *executionContext) _CreatePlanByLocationOutput(ctx context.Context, sel ast.SelectionSet, obj *model.CreatePlanByLocationOutput) graphql.Marshaler {
@@ -10905,6 +11147,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "createPlanByPlace":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createPlanByPlace(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createPlanByGooglePlaceId":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createPlanByGooglePlaceId(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -12491,6 +12740,25 @@ func (ec *executionContext) marshalNChangePlacesOrderInPlanCandidateOutput2ᚖpo
 		return graphql.Null
 	}
 	return ec._ChangePlacesOrderInPlanCandidateOutput(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNCreatePlanByGooglePlaceIdInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByGooglePlaceIDInput(ctx context.Context, v interface{}) (model.CreatePlanByGooglePlaceIDInput, error) {
+	res, err := ec.unmarshalInputCreatePlanByGooglePlaceIdInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreatePlanByGooglePlaceIdOutput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByGooglePlaceIDOutput(ctx context.Context, sel ast.SelectionSet, v model.CreatePlanByGooglePlaceIDOutput) graphql.Marshaler {
+	return ec._CreatePlanByGooglePlaceIdOutput(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreatePlanByGooglePlaceIdOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByGooglePlaceIDOutput(ctx context.Context, sel ast.SelectionSet, v *model.CreatePlanByGooglePlaceIDOutput) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreatePlanByGooglePlaceIdOutput(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCreatePlanByLocationInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByLocationInput(ctx context.Context, v interface{}) (model.CreatePlanByLocationInput, error) {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1392,6 +1392,9 @@ type CreatePlanByLocationOutput {
 input CreatePlanByPlaceInput {
     session: String!
     placeId: String!
+    categoriesPreferred: [String!]
+    categoriesDisliked: [String!]
+    freeTime: Int
 }
 
 type CreatePlanByPlaceOutput {
@@ -9887,7 +9890,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByPlaceInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"session", "placeId"}
+	fieldsInOrder := [...]string{"session", "placeId", "categoriesPreferred", "categoriesDisliked", "freeTime"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9912,6 +9915,33 @@ func (ec *executionContext) unmarshalInputCreatePlanByPlaceInput(ctx context.Con
 				return it, err
 			}
 			it.PlaceID = data
+		case "categoriesPreferred":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoriesPreferred"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CategoriesPreferred = data
+		case "categoriesDisliked":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoriesDisliked"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CategoriesDisliked = data
+		case "freeTime":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("freeTime"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FreeTime = data
 		}
 	}
 

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -60,6 +60,15 @@ type ChangePlacesOrderInPlanCandidateOutput struct {
 	Plan *Plan `json:"plan"`
 }
 
+type CreatePlanByGooglePlaceIDInput struct {
+	PlanCandidateID string `json:"planCandidateId"`
+	GooglePlaceID   string `json:"googlePlaceId"`
+}
+
+type CreatePlanByGooglePlaceIDOutput struct {
+	PlanCandidate *PlanCandidate `json:"planCandidate"`
+}
+
 type CreatePlanByLocationInput struct {
 	Session                       *string  `json:"session,omitempty"`
 	Latitude                      float64  `json:"latitude"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -61,8 +61,11 @@ type ChangePlacesOrderInPlanCandidateOutput struct {
 }
 
 type CreatePlanByGooglePlaceIDInput struct {
-	PlanCandidateID string `json:"planCandidateId"`
-	GooglePlaceID   string `json:"googlePlaceId"`
+	PlanCandidateID     *string  `json:"planCandidateId,omitempty"`
+	GooglePlaceID       string   `json:"googlePlaceId"`
+	CategoriesPreferred []string `json:"categoriesPreferred,omitempty"`
+	CategoriesDisliked  []string `json:"categoriesDisliked,omitempty"`
+	FreeTime            *int     `json:"freeTime,omitempty"`
 }
 
 type CreatePlanByGooglePlaceIDOutput struct {
@@ -86,11 +89,8 @@ type CreatePlanByLocationOutput struct {
 }
 
 type CreatePlanByPlaceInput struct {
-	Session             string   `json:"session"`
-	PlaceID             string   `json:"placeId"`
-	CategoriesPreferred []string `json:"categoriesPreferred,omitempty"`
-	CategoriesDisliked  []string `json:"categoriesDisliked,omitempty"`
-	FreeTime            *int     `json:"freeTime,omitempty"`
+	Session string `json:"session"`
+	PlaceID string `json:"placeId"`
 }
 
 type CreatePlanByPlaceOutput struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -86,8 +86,11 @@ type CreatePlanByLocationOutput struct {
 }
 
 type CreatePlanByPlaceInput struct {
-	Session string `json:"session"`
-	PlaceID string `json:"placeId"`
+	Session             string   `json:"session"`
+	PlaceID             string   `json:"placeId"`
+	CategoriesPreferred []string `json:"categoriesPreferred,omitempty"`
+	CategoriesDisliked  []string `json:"categoriesDisliked,omitempty"`
+	FreeTime            *int     `json:"freeTime,omitempty"`
 }
 
 type CreatePlanByPlaceOutput struct {

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -119,6 +119,11 @@ func (r *mutationResolver) CreatePlanByPlace(ctx context.Context, input model.Cr
 	}, nil
 }
 
+// CreatePlanByGooglePlaceID is the resolver for the createPlanByGooglePlaceId field.
+func (r *mutationResolver) CreatePlanByGooglePlaceID(ctx context.Context, input model.CreatePlanByGooglePlaceIDInput) (*model.CreatePlanByGooglePlaceIDOutput, error) {
+	panic(fmt.Errorf("not implemented: CreatePlanByGooglePlaceID - createPlanByGooglePlaceId"))
+}
+
 // ChangePlacesOrderInPlanCandidate is the resolver for the changePlacesOrderInPlanCandidate field.
 func (r *mutationResolver) ChangePlacesOrderInPlanCandidate(ctx context.Context, input model.ChangePlacesOrderInPlanCandidateInput) (*model.ChangePlacesOrderInPlanCandidateOutput, error) {
 	service, err := plancandidate.NewService(ctx)

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -48,9 +48,6 @@ type CreatePlanByLocationOutput {
 input CreatePlanByPlaceInput {
     session: String!
     placeId: String!
-    categoriesPreferred: [String!]
-    categoriesDisliked: [String!]
-    freeTime: Int
 }
 
 type CreatePlanByPlaceOutput {
@@ -59,8 +56,11 @@ type CreatePlanByPlaceOutput {
 }
 
 input CreatePlanByGooglePlaceIdInput {
-    planCandidateId: String!
+    planCandidateId: String
     googlePlaceId: String!
+    categoriesPreferred: [String!]
+    categoriesDisliked: [String!]
+    freeTime: Int
 }
 
 type CreatePlanByGooglePlaceIdOutput {

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -3,6 +3,8 @@ extend type Mutation {
 
     createPlanByPlace(input: CreatePlanByPlaceInput!): CreatePlanByPlaceOutput!
 
+    createPlanByGooglePlaceId(input: CreatePlanByGooglePlaceIdInput!): CreatePlanByGooglePlaceIdOutput!
+
     changePlacesOrderInPlanCandidate(input: ChangePlacesOrderInPlanCandidateInput!): ChangePlacesOrderInPlanCandidateOutput!
 
     savePlanFromCandidate(input: SavePlanFromCandidateInput!): SavePlanFromCandidateOutput!
@@ -51,6 +53,15 @@ input CreatePlanByPlaceInput {
 type CreatePlanByPlaceOutput {
     session: String!
     plan: Plan!
+}
+
+input CreatePlanByGooglePlaceIdInput {
+    planCandidateId: String!
+    googlePlaceId: String!
+}
+
+type CreatePlanByGooglePlaceIdOutput {
+    planCandidate: PlanCandidate!
 }
 
 input ChangePlacesOrderInPlanCandidateInput {

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -48,6 +48,9 @@ type CreatePlanByLocationOutput {
 input CreatePlanByPlaceInput {
     session: String!
     placeId: String!
+    categoriesPreferred: [String!]
+    categoriesDisliked: [String!]
+    freeTime: Int
 }
 
 type CreatePlanByPlaceOutput {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- poroto側でPlaceDetailのAPI呼び出しを発生させないために、Google Place IDからプランを作成するMutationを追加した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #369 
- #368 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- poroto側でPlaceDetailのAPI呼び出しを発生させないため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/graphql_create_plan_by_place_id
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```