### PR TITLE
Google Place IDからプランを作成できるようにする

### DIFF
--- a/internal/domain/services/place/place_detail.go
+++ b/internal/domain/services/place/place_detail.go
@@ -10,6 +10,16 @@ import (
 
 // FetchGooglePlace PlaceDetail APIを用いて場所の情報を取得する
 func (s Service) FetchGooglePlace(ctx context.Context, googlePlaceId string) (*models.GooglePlace, error) {
+	// キャッシュがある場合は取得する
+	savedPlace, err := s.placeRepository.FindByGooglePlaceID(ctx, googlePlaceId)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch google place detail: %v", err)
+	}
+
+	if savedPlace != nil {
+		return &savedPlace.Google, nil
+	}
+
 	placeDetailEntity, err := s.placesApi.FetchPlaceDetail(ctx, places.FetchPlaceDetailRequest{
 		PlaceId:  googlePlaceId,
 		Language: "ja",
@@ -23,6 +33,8 @@ func (s Service) FetchGooglePlace(ctx context.Context, googlePlaceId string) (*m
 	}
 
 	googlePlace := factory.GooglePlaceFromPlaceEntity(*placeDetailEntity, nil)
+
+	// TODO: キャッシュする
 
 	return &googlePlace, nil
 }

--- a/internal/domain/services/plangen/create_by_google_place_id.go
+++ b/internal/domain/services/plangen/create_by_google_place_id.go
@@ -70,7 +70,8 @@ func (s Service) CreatePlanByGooglePlaceId(ctx context.Context, input CreatePlan
 			zap.String("planCandidateId", input.PlanCandidateId),
 			zap.Error(err),
 		)
-	} else if placesSearched != nil {
+	} else if placesSearched != nil && len(placesSearched) > 1 {
+		// すでに検索が行われている場合はキャッシュを利用する（開始地点は除く）
 		s.logger.Debug(
 			"places fetched",
 			zap.String("planCandidateId", input.PlanCandidateId),

--- a/internal/domain/services/plangen/create_by_google_place_id.go
+++ b/internal/domain/services/plangen/create_by_google_place_id.go
@@ -1,0 +1,189 @@
+package plangen
+
+import (
+	"context"
+	"fmt"
+	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/services/place"
+	"poroto.app/poroto/planner/internal/domain/services/placefilter"
+)
+
+const (
+	defaultShouldOpenNow = false
+)
+
+type CreatePlanByGooglePlaceIdInput struct {
+	PlanCandidateId        string
+	GooglePlaceId          string
+	CategoryNamesPreferred *[]string
+	CategoryNamesDisliked  *[]string
+	FreeTime               *int
+	ShouldOpenNow          *bool
+}
+
+func (s Service) CreatePlanByGooglePlaceId(ctx context.Context, input CreatePlanByGooglePlaceIdInput) (*[]models.Plan, error) {
+	if input.ShouldOpenNow == nil {
+		v := defaultShouldOpenNow
+		input.ShouldOpenNow = &v
+	}
+
+	// 開始地点となる場所を検索
+	startGooglePlace, err := s.placeService.FetchGooglePlace(ctx, input.GooglePlaceId)
+	if err != nil {
+		return nil, err
+	}
+
+	if startGooglePlace == nil {
+		return nil, fmt.Errorf("could not fetch google place: %v", input.GooglePlaceId)
+	}
+
+	// キャッシュする
+	placesSaved, err := s.placeService.SaveSearchedPlaces(ctx, input.PlanCandidateId, []models.GooglePlace{*startGooglePlace})
+	if err != nil {
+		return nil, fmt.Errorf("error while saving searched places: %v", err)
+	}
+	if len(placesSaved) == 0 {
+		return nil, fmt.Errorf("could not save searched places")
+	}
+	startPlace := placesSaved[0]
+
+	s.logger.Debug(
+		"successfully fetched start place by google place id",
+		zap.String("planCandidateId", input.PlanCandidateId),
+		zap.String("placeId", startPlace.Id),
+		zap.String("googlePlaceId", input.GooglePlaceId),
+		zap.String("name", startPlace.Name),
+	)
+
+	// 付近の場所を検索
+	var places []models.Place
+	placesSearched, err := s.placeService.FetchSearchedPlaces(ctx, input.PlanCandidateId)
+	if err != nil {
+		s.logger.Warn(
+			"error while fetching searched places",
+			zap.String("planCandidateId", input.PlanCandidateId),
+			zap.Error(err),
+		)
+	} else if placesSearched != nil {
+		s.logger.Debug(
+			"places fetched",
+			zap.String("planCandidateId", input.PlanCandidateId),
+			zap.Int("places", len(placesSearched)),
+		)
+		places = placesSearched
+	}
+
+	// 検索を行っていない場合は検索を行う
+	if places == nil {
+		googlePlaces, err := s.placeService.SearchNearbyPlaces(ctx, place.SearchNearbyPlacesInput{Location: startGooglePlace.Location})
+		if err != nil {
+			return nil, fmt.Errorf("error while fetching google places: %v\n", err)
+		}
+
+		placesSaved, err := s.placeService.SaveSearchedPlaces(ctx, input.PlanCandidateId, googlePlaces)
+		if err != nil {
+			return nil, fmt.Errorf("error while saving searched places: %v\n", err)
+		}
+
+		places = placesSaved
+	}
+
+	placesFiltered := places
+	placesFiltered = placefilter.FilterDefaultIgnore(placefilter.FilterDefaultIgnoreInput{
+		Places:        placesFiltered,
+		StartLocation: startGooglePlace.Location,
+	})
+
+	// レビューが低い、またはレビュー数が少ない場所を除外する
+	placesFiltered = placefilter.FilterByRating(placesFiltered, 3.0, 10)
+
+	// 除外されたカテゴリがある場合はそのカテゴリを除外する
+	if input.CategoryNamesDisliked != nil {
+		var categoriesDisliked []models.LocationCategory
+		for _, categoryName := range *input.CategoryNamesDisliked {
+			if category := models.GetCategoryOfName(categoryName); category != nil {
+				categoriesDisliked = append(categoriesDisliked, *category)
+			}
+		}
+		placesFiltered = placefilter.FilterByCategory(placesFiltered, categoriesDisliked, false)
+	}
+
+	s.logger.Debug(
+		"places filtered",
+		zap.String("planCandidateId", input.PlanCandidateId),
+		zap.String("planCandidateId", input.PlanCandidateId),
+		zap.String("startPlace", startGooglePlace.Name),
+		zap.Int("places", len(placesFiltered)),
+	)
+
+	// プラン作成の基準となる場所を選択
+	var placesRecommend []models.Place
+	placesRecommend = append(placesRecommend, startPlace)
+	placesRecommend = append(placesRecommend, s.SelectBasePlace(SelectBasePlaceInput{
+		BaseLocation:           startPlace.Location,
+		Places:                 placesFiltered,
+		CategoryNamesPreferred: input.CategoryNamesPreferred,
+		CategoryNamesDisliked:  input.CategoryNamesDisliked,
+		ShouldOpenNow:          *input.ShouldOpenNow,
+		MaxBasePlaceCount:      defaultMaxBasePlaceCount - 1,
+	})...)
+	for _, place := range placesRecommend {
+		s.logger.Debug(
+			"place recommended",
+			zap.String("placeId", place.Id),
+			zap.String("name", place.Name),
+		)
+	}
+
+	// プランを作成
+	var createPlanParams []CreatePlanParams
+	for _, placeRecommended := range placesRecommend {
+		var placesAlreadyInPlan []models.Place
+		for _, createPlanParam := range createPlanParams {
+			placesAlreadyInPlan = append(placesAlreadyInPlan, createPlanParam.places...)
+		}
+
+		// フィルタ処理は select base place などの中で行う
+		placesInPlan, err := s.createPlanPlaces(ctx, CreatePlanPlacesParams{
+			planCandidateId:              input.PlanCandidateId,
+			locationStart:                startGooglePlace.Location,
+			placeStart:                   placeRecommended,
+			places:                       placesFiltered,
+			placesOtherPlansContain:      placesAlreadyInPlan,
+			freeTime:                     input.FreeTime,
+			createBasedOnCurrentLocation: false,
+			shouldOpenWhileTraveling:     *input.ShouldOpenNow,
+		})
+		if err != nil {
+			s.logger.Warn(
+				"error while creating plan",
+				zap.String("planCandidateId", input.PlanCandidateId),
+				zap.String("placeId", placeRecommended.Id),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		createPlanParams = append(createPlanParams, CreatePlanParams{
+			locationStart: startGooglePlace.Location,
+			placeStart:    placeRecommended,
+			places:        placesInPlan,
+		})
+	}
+
+	plans := s.createPlanData(ctx, input.PlanCandidateId, createPlanParams...)
+
+	// 指定された場所を起点としたプランを最初に表示する
+	for i, plan := range plans {
+		if len(plan.Places) == 0 {
+			continue
+		}
+
+		if plan.Places[0].Google.PlaceId == input.GooglePlaceId {
+			plans[0], plans[i] = plans[i], plans[0]
+		}
+	}
+
+	return &plans, nil
+}

--- a/internal/domain/services/plangen/create_by_google_place_id.go
+++ b/internal/domain/services/plangen/create_by_google_place_id.go
@@ -22,7 +22,12 @@ type CreatePlanByGooglePlaceIdInput struct {
 	ShouldOpenNow          *bool
 }
 
-func (s Service) CreatePlanByGooglePlaceId(ctx context.Context, input CreatePlanByGooglePlaceIdInput) (*[]models.Plan, error) {
+type CreatePlanByGooglePlaceIdOutput struct {
+	Plans      []models.Plan
+	StartPlace models.Place
+}
+
+func (s Service) CreatePlanByGooglePlaceId(ctx context.Context, input CreatePlanByGooglePlaceIdInput) (*CreatePlanByGooglePlaceIdOutput, error) {
 	if input.ShouldOpenNow == nil {
 		v := defaultShouldOpenNow
 		input.ShouldOpenNow = &v
@@ -185,5 +190,8 @@ func (s Service) CreatePlanByGooglePlaceId(ctx context.Context, input CreatePlan
 		}
 	}
 
-	return &plans, nil
+	return &CreatePlanByGooglePlaceIdOutput{
+		Plans:      plans,
+		StartPlace: startPlace,
+	}, nil
 }

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -7,7 +7,9 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"go.uber.org/zap"
 	"log"
+	"poroto.app/poroto/planner/internal/domain/utils"
 
 	"github.com/google/uuid"
 	"poroto.app/poroto/planner/internal/domain/models"
@@ -121,7 +123,76 @@ func (r *mutationResolver) CreatePlanByPlace(ctx context.Context, input model.Cr
 
 // CreatePlanByGooglePlaceID is the resolver for the createPlanByGooglePlaceId field.
 func (r *mutationResolver) CreatePlanByGooglePlaceID(ctx context.Context, input model.CreatePlanByGooglePlaceIDInput) (*model.CreatePlanByGooglePlaceIDOutput, error) {
-	panic(fmt.Errorf("not implemented: CreatePlanByGooglePlaceID - createPlanByGooglePlaceId"))
+	logger, err := utils.NewLogger(utils.LoggerOption{Tag: "GraphQL"})
+	if err != nil {
+		log.Println("error while initializing logger: ", err)
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	planGenService, err := plangen.NewService(ctx)
+	if err != nil {
+		logger.Error("error while initializing plan generator service", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	planCandidateService, err := plancandidate.NewService(ctx)
+	if err != nil {
+		logger.Error("error while initializing plan candidate service", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	logger.Info(
+		"CreatePlanByGooglePlaceID",
+		zap.String("googlePlaceId", input.GooglePlaceID),
+	)
+
+	// プラン候補の作成
+	var planCandidateId string
+	if input.PlanCandidateID != nil {
+		planCandidateId = *input.PlanCandidateID
+	} else {
+		planCandidateId = uuid.New().String()
+		if err := planCandidateService.CreatePlanCandidate(ctx, planCandidateId); err != nil {
+			logger.Error("error while creating plan candidate", zap.Error(err))
+			return nil, fmt.Errorf("internal server error")
+		}
+	}
+
+	// プランの作成
+	createPlanByGooglePlaceidResult, err := planGenService.CreatePlanByGooglePlaceId(ctx, plangen.CreatePlanByGooglePlaceIdInput{
+		PlanCandidateId:        planCandidateId,
+		GooglePlaceId:          input.GooglePlaceID,
+		CategoryNamesPreferred: &input.CategoriesPreferred,
+		CategoryNamesDisliked:  &input.CategoriesDisliked,
+		FreeTime:               input.FreeTime,
+	})
+	if err != nil {
+		logger.Error("error while creating plan by google place id", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	// 作成されたプランの保存
+	if err := planCandidateService.SavePlans(ctx, plancandidate.SavePlansInput{
+		PlanCandidateId:              planCandidateId,
+		Plans:                        createPlanByGooglePlaceidResult.Plans,
+		CategoryNamesPreferred:       &input.CategoriesPreferred,
+		CategoryNamesRejected:        &input.CategoriesDisliked,
+		FreeTime:                     input.FreeTime,
+		CreateBasedOnCurrentLocation: false,
+	}); err != nil {
+		logger.Error("error while saving plans of plan candidate", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	graphqlPlans := factory.PlansFromDomainModel(&createPlanByGooglePlaceidResult.Plans, &createPlanByGooglePlaceidResult.StartPlace.Location)
+	return &model.CreatePlanByGooglePlaceIDOutput{
+		PlanCandidate: &model.PlanCandidate{
+			ID:                            planCandidateId,
+			Plans:                         graphqlPlans,
+			LikedPlaceIds:                 nil,
+			CreatedBasedOnCurrentLocation: false,
+		},
+	}, nil
 }
 
 // ChangePlacesOrderInPlanCandidate is the resolver for the changePlacesOrderInPlanCandidate field.

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -7,15 +7,15 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"log"
-	"poroto.app/poroto/planner/internal/domain/utils"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/plan"
 	"poroto.app/poroto/planner/internal/domain/services/plancandidate"
 	"poroto.app/poroto/planner/internal/domain/services/plangen"
+	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
 )


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 緯度・経度を指定せずに、Google Place IDからだけでプランを作成するResolver・Serviceの実装を行った

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #371 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- poroto側でPlaceDetail APIを用いて緯度・経度をしらべないで良いようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] `createPlanByGooglePlaceId`が動作することを確認(Postman)

```shell
# planner
export BRANCH_PLANNER=feature/graphql_create_plan_by_place_id_impl
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```