### PR TITLE
[次回リリースに含める]  位置情報からプランを作成するリクエストにGoogle Place IDを含めない

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1375,13 +1375,10 @@ input CreatePlanByLocationInput {
     session: String
     latitude: Float!
     longitude: Float!
-    googlePlaceId: String
     categoriesPreferred: [String!]
     categoriesDisliked: [String!]
     freeTime: Int
-    # 現在地から作成されたプランか
-    # TODO: 必須パラメータにする
-    createdBasedOnCurrentLocation: Boolean
+    createdBasedOnCurrentLocation: Boolean!
 }
 
 type CreatePlanByLocationOutput {
@@ -9825,7 +9822,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByLocationInput(ctx context.
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"session", "latitude", "longitude", "googlePlaceId", "categoriesPreferred", "categoriesDisliked", "freeTime", "createdBasedOnCurrentLocation"}
+	fieldsInOrder := [...]string{"session", "latitude", "longitude", "categoriesPreferred", "categoriesDisliked", "freeTime", "createdBasedOnCurrentLocation"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -9859,15 +9856,6 @@ func (ec *executionContext) unmarshalInputCreatePlanByLocationInput(ctx context.
 				return it, err
 			}
 			it.Longitude = data
-		case "googlePlaceId":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("googlePlaceId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.GooglePlaceID = data
 		case "categoriesPreferred":
 			var err error
 
@@ -9899,7 +9887,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByLocationInput(ctx context.
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("createdBasedOnCurrentLocation"))
-			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -76,11 +76,10 @@ type CreatePlanByLocationInput struct {
 	Session                       *string  `json:"session,omitempty"`
 	Latitude                      float64  `json:"latitude"`
 	Longitude                     float64  `json:"longitude"`
-	GooglePlaceID                 *string  `json:"googlePlaceId,omitempty"`
 	CategoriesPreferred           []string `json:"categoriesPreferred,omitempty"`
 	CategoriesDisliked            []string `json:"categoriesDisliked,omitempty"`
 	FreeTime                      *int     `json:"freeTime,omitempty"`
-	CreatedBasedOnCurrentLocation *bool    `json:"createdBasedOnCurrentLocation,omitempty"`
+	CreatedBasedOnCurrentLocation bool     `json:"createdBasedOnCurrentLocation"`
 }
 
 type CreatePlanByLocationOutput struct {

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -34,12 +34,6 @@ func (r *mutationResolver) CreatePlanByLocation(ctx context.Context, input model
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	// TODO: 必須パラメータにする
-	createBasedOnCurrentLocation := false
-	if input.CreatedBasedOnCurrentLocation != nil {
-		createBasedOnCurrentLocation = *input.CreatedBasedOnCurrentLocation
-	}
-
 	locationStart := models.GeoLocation{
 		Latitude:  input.Latitude,
 		Longitude: input.Longitude,
@@ -62,11 +56,11 @@ func (r *mutationResolver) CreatePlanByLocation(ctx context.Context, input model
 		ctx,
 		planCandidateId,
 		locationStart,
-		input.GooglePlaceID,
+		nil,
 		&input.CategoriesPreferred,
 		&input.CategoriesDisliked,
 		input.FreeTime,
-		createBasedOnCurrentLocation,
+		input.CreatedBasedOnCurrentLocation,
 	)
 	if err != nil {
 		log.Printf("error while creating plan by location: %v", err)
@@ -81,7 +75,7 @@ func (r *mutationResolver) CreatePlanByLocation(ctx context.Context, input model
 		CategoryNamesPreferred:       &input.CategoriesPreferred,
 		CategoryNamesRejected:        &input.CategoriesDisliked,
 		FreeTime:                     input.FreeTime,
-		CreateBasedOnCurrentLocation: createBasedOnCurrentLocation,
+		CreateBasedOnCurrentLocation: input.CreatedBasedOnCurrentLocation,
 	}); err != nil {
 		log.Printf("error while saving plans of plan candidate(%s): %v", planCandidateId, err)
 	}

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -56,7 +56,6 @@ func (r *mutationResolver) CreatePlanByLocation(ctx context.Context, input model
 		ctx,
 		planCandidateId,
 		locationStart,
-		nil,
 		&input.CategoriesPreferred,
 		&input.CategoriesDisliked,
 		input.FreeTime,

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -31,13 +31,10 @@ input CreatePlanByLocationInput {
     session: String
     latitude: Float!
     longitude: Float!
-    googlePlaceId: String
     categoriesPreferred: [String!]
     categoriesDisliked: [String!]
     freeTime: Int
-    # 現在地から作成されたプランか
-    # TODO: 必須パラメータにする
-    createdBasedOnCurrentLocation: Boolean
+    createdBasedOnCurrentLocation: Boolean!
 }
 
 type CreatePlanByLocationOutput {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Google Place IDからプランを作成する処理があるため、緯度経度からプランを作成するときにはGoogle Place IDを含めないようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #373 
- #372 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 関数をよりシンプルにするため

### どのようにテストされているか
TODO
- [ ] プラン作成できることを確認
- [ ] プランを保存できることを確認
- [ ] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```