### PR TITLE
[Migration] ユーザーテーブルにタイムスタンプカラムを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ go test ./...
 ### Gooseのインストール
 https://pressly.github.io/goose/installation/
 ```shell
-go get -u github.com/pressly/goose/v3/cmd/goose
+go install github.com/pressly/goose/v3/cmd/goose@latest
 ```
 
 ### マイグレーションの作成
@@ -122,7 +122,7 @@ DB_PASSWORD=password \
 DB_HOST=localhost:3306 \
 DB_NAME=poroto \
 goose -dir db/migrations mysql "$DB_USER:$DB_PASSWORD@tcp($DB_HOST)/$DB_NAME?parseTime=true&loc=Asia%2FTokyo" up
-````
+```
 
 ### SQLBoilerをインストール
 [volatiletech/sqlboiler #Download](https://github.com/volatiletech/sqlboiler?tab=readme-ov-file#download)

--- a/db/migrations/20231223065247_add_timestamps_to_users.sql
+++ b/db/migrations/20231223065247_add_timestamps_to_users.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE users
+ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE users
+DROP COLUMN created_at,
+DROP COLUMN updated_at;
+-- +goose StatementEnd


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- ユーザーテーブルにタイムスタンプカラムを追加した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- Github ActionsでPlanetScaleに対してマイグレーションを自動実行できることを確認するため

### どのようにテストされているか
- [x] ローカルでマイグレーションが実行できることを確認
- [x]  ローカルでマイグレーションをロールバックできることを確認

```sh
# 実行
DB_USER=root \
DB_PASSWORD=password \
DB_HOST=localhost:3306 \
DB_NAME=poroto \
goose -dir db/migrations mysql "$DB_USER:$DB_PASSWORD@tcp($DB_HOST)/$DB_NAME?parseTime=true&loc=Asia%2FTokyo" up

# ロールバック
DB_USER=root \
DB_PASSWORD=password \
DB_HOST=localhost:3306 \
DB_NAME=poroto \
goose -dir db/migrations mysql "$DB_USER:$DB_PASSWORD@tcp($DB_HOST)/$DB_NAME?parseTime=true&loc=Asia%2FTokyo" down
```