### PR TITLE
Dockerfileを用いてDBのセットアップを行うDockerイメージをビルドする

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ go mod tidy
 
 ### MySQLの起動（Docker）
 ```shell
+cd docker
 docker compose up -d
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,8 +36,9 @@ services:
     ports:
       - "3307:3306"
   db-migrator:
-    # TODO: Dockerfile でビルドする
-    image: golang:1.18
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.db-setup
     depends_on:
       db:
         condition: service_healthy
@@ -48,14 +49,10 @@ services:
       DB_NAME: poroto
     volumes:
       - ./db/migrations:/db/migrations
-    command: >
-      sh -c "
-      go install github.com/pressly/goose/cmd/goose@latest &&
-      goose -dir /db/migrations mysql \"$$DB_USER:$$DB_PASSWORD@tcp($$DB_HOST)/$$DB_NAME?parseTime=true&loc=Asia%2FTokyo\" up
-      "
   db-test-migrator:
-    # TODO: Dockerfile でビルドする
-    image: golang:1.18
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.db-setup
     depends_on:
       db-test:
         condition: service_healthy
@@ -66,10 +63,5 @@ services:
       DB_NAME: poroto
     volumes:
       - ./db/migrations:/db/migrations
-    command: >
-      sh -c "
-      go install github.com/pressly/goose/cmd/goose@latest &&
-      goose -dir /db/migrations mysql \"$$DB_USER:$$DB_PASSWORD@tcp($$DB_HOST)/$$DB_NAME?parseTime=true&loc=Asia%2FTokyo\" up
-      "
 volumes:
   mysql-data:

--- a/docker/Dockerfile.db-setup
+++ b/docker/Dockerfile.db-setup
@@ -1,0 +1,21 @@
+# ベースイメージの指定
+FROM golang:1.18
+
+# 環境変数の設定
+ENV DB_USER=root \
+    DB_PASSWORD=password \
+    DB_HOST=db:3306 \
+    DB_NAME=poroto
+
+# gooseのインストール
+RUN go install github.com/pressly/goose/cmd/goose@latest
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# マイグレーションファイルをコンテナ内にコピー
+COPY ./db/migrations /db/migrations
+
+# エントリポイント（またはコマンド）の指定
+# データベースマイグレーションを実行するコマンドを記述
+CMD goose -dir /db/migrations mysql "$DB_USER:$DB_PASSWORD@tcp($DB_HOST)/$DB_NAME?parseTime=true&loc=Asia%2FTokyo" up

--- a/docker/Dockerfile.db-setup
+++ b/docker/Dockerfile.db-setup
@@ -1,12 +1,6 @@
 # ベースイメージの指定
 FROM golang:1.18
 
-# 環境変数の設定
-ENV DB_USER=root \
-    DB_PASSWORD=password \
-    DB_HOST=db:3306 \
-    DB_NAME=poroto
-
 # gooseのインストール
 RUN go install github.com/pressly/goose/cmd/goose@latest
 
@@ -14,7 +8,7 @@ RUN go install github.com/pressly/goose/cmd/goose@latest
 WORKDIR /app
 
 # マイグレーションファイルをコンテナ内にコピー
-COPY ./db/migrations /db/migrations
+COPY ../db/migrations /db/migrations
 
 # エントリポイント（またはコマンド）の指定
 # データベースマイグレーションを実行するコマンドを記述

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -37,8 +37,8 @@ services:
       - "3307:3306"
   db-migrator:
     build:
-      context: .
-      dockerfile: ./docker/Dockerfile.db-setup
+      context: ..
+      dockerfile: docker/Dockerfile.db-setup
     depends_on:
       db:
         condition: service_healthy
@@ -48,11 +48,11 @@ services:
       DB_HOST: db:3306
       DB_NAME: poroto
     volumes:
-      - ./db/migrations:/db/migrations
+      - ../db/migrations:/db/migrations
   db-test-migrator:
     build:
-      context: .
-      dockerfile: ./docker/Dockerfile.db-setup
+      context: ..
+      dockerfile: docker/Dockerfile.db-setup
     depends_on:
       db-test:
         condition: service_healthy
@@ -62,6 +62,6 @@ services:
       DB_HOST: db-test:3306
       DB_NAME: poroto
     volumes:
-      - ./db/migrations:/db/migrations
+      - ../db/migrations:/db/migrations
 volumes:
   mysql-data:


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- `docker compose`を用いてDBを起動するときに、自動的にマイグレーションを行うDockerコンテナのイメージをDockerfileから作成するようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #382 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 最初にDockerイメージをビルドすることで、2回目以降の`docker compose up`によるセットアップの速度を改善するため

### どのようにテストされているか
- [x] 以下のコマンドを用いて、2回目に実行したときに`docker-db-migrator-1`と`docker-db-test-migrator-1`がすぐにマイグレーションを実行することを確認（以前はライブラリのインストールをしてから実行されていた）
```sh
cd docker
docker compose up
docker compose up
```

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```