### PR TITLE
[Migration] Planet scaleで対応していないTRIGGER句を削除

### DIFF
--- a/db/migrations/20231227115353_create_place_table.sql
+++ b/db/migrations/20231227115353_create_place_table.sql
@@ -28,12 +28,6 @@ CREATE TABLE google_places
     SPATIAL INDEX (location)
 );
 
-CREATE TRIGGER google_places_before_insert
-    BEFORE INSERT
-    ON google_places
-    FOR EACH ROW
-    SET NEW.location = POINT(NEW.longitude, NEW.latitude);
-
 CREATE TABLE google_place_types
 (
     id              CHAR(36)     NOT NULL DEFAULT (UUID()),
@@ -129,8 +123,6 @@ DROP TABLE IF EXISTS google_place_photo_attributions;
 DROP TABLE IF EXISTS google_place_photo_references;
 
 DROP TABLE IF EXISTS google_place_types;
-
-DROP TRIGGER IF EXISTS google_places_before_insert;
 
 DROP TABLE IF EXISTS google_places;
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Placeテーブルを作成するときに記述してたTRIGGER句がPlanetScaleでは利用できないため削除した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- PlanetScaleで適切にマイグレーションを実行できるようにするため

### どのようにテストされているか
- [x] マイグレーションが実行できることを確認
- [x] マイグレーションがロールバックできることを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```