### PR TITLE
[Migration] プランテーブルに位置情報を表すカラムを追加

### DIFF
--- a/db/migrations/20240106073707_add_location_column_to_plan_table.sql
+++ b/db/migrations/20240106073707_add_location_column_to_plan_table.sql
@@ -2,12 +2,12 @@
 -- +goose StatementBegin
 ALTER TABLE plans
     ADD COLUMN location POINT NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)')),
-    ADD SPATIAL INDEX plan_location_index (location);
+    ADD SPATIAL INDEX location (location);
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE plans
     DROP COLUMN location,
-    DROP INDEX plan_location_index;
+    DROP INDEX location;
 -- +goose StatementEnd

--- a/db/migrations/20240106073707_add_location_column_to_plan_table.sql
+++ b/db/migrations/20240106073707_add_location_column_to_plan_table.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE plans
-    ADD COLUMN location POINT    NOT NULL,
+    ADD COLUMN location POINT    NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)')),
     ADD COLUMN geohash  CHAR(12) NOT NULL;
 -- +goose StatementEnd
 

--- a/db/migrations/20240106073707_add_location_column_to_plan_table.sql
+++ b/db/migrations/20240106073707_add_location_column_to_plan_table.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE plans
+    ADD COLUMN location POINT NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)')),
+    ADD SPATIAL INDEX plan_location_index (location);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE plans
+    DROP COLUMN location,
+    DROP INDEX plan_location_index;
+-- +goose StatementEnd

--- a/db/migrations/20240106073707_add_location_column_to_plan_table.sql
+++ b/db/migrations/20240106073707_add_location_column_to_plan_table.sql
@@ -1,13 +1,11 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE plans
-    ADD COLUMN location POINT NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)')),
-    ADD SPATIAL INDEX location (location);
+    ADD COLUMN location POINT NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)'));
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE plans
-    DROP COLUMN location,
-    DROP INDEX location;
+    DROP COLUMN location;
 -- +goose StatementEnd

--- a/db/migrations/20240106073707_add_location_column_to_plan_table.sql
+++ b/db/migrations/20240106073707_add_location_column_to_plan_table.sql
@@ -1,13 +1,11 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE plans
-    ADD COLUMN location POINT    NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)')),
-    ADD COLUMN geohash  CHAR(12) NOT NULL;
+    ADD COLUMN location POINT NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)'));
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE plans
-    DROP COLUMN location,
-    DROP COLUMN geohash;
+    DROP COLUMN location;
 -- +goose StatementEnd

--- a/db/migrations/20240106073707_add_location_column_to_plan_table.sql
+++ b/db/migrations/20240106073707_add_location_column_to_plan_table.sql
@@ -1,11 +1,13 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE plans
-    ADD COLUMN location POINT NOT NULL DEFAULT (ST_PointFromText('POINT(0 0)'));
+    ADD COLUMN location POINT    NOT NULL,
+    ADD COLUMN geohash  CHAR(12) NOT NULL;
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE plans
-    DROP COLUMN location;
+    DROP COLUMN location,
+    DROP COLUMN geohash;
 -- +goose StatementEnd

--- a/doc/database/er.md
+++ b/doc/database/er.md
@@ -172,6 +172,7 @@ erDiagram
         char(36) id PK
         char(36) user_id FK
         string name
+        point location "プランの大まかな場所"
     }
 
     plan_places {

--- a/doc/database/er.md
+++ b/doc/database/er.md
@@ -173,6 +173,7 @@ erDiagram
         char(36) user_id FK
         string name
         point location "プランの大まかな場所"
+        string geohash
     }
 
     plan_places {

--- a/doc/database/er.md
+++ b/doc/database/er.md
@@ -173,7 +173,6 @@ erDiagram
         char(36) user_id FK
         string name
         point location "プランの大まかな場所"
-        string geohash
     }
 
     plan_places {

--- a/internal/infrastructure/rdb/generated/plans.go
+++ b/internal/infrastructure/rdb/generated/plans.go
@@ -29,8 +29,6 @@ type Plan struct {
 	Name      string      `boil:"name" json:"name" toml:"name" yaml:"name"`
 	CreatedAt time.Time   `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
 	UpdatedAt time.Time   `boil:"updated_at" json:"updated_at" toml:"updated_at" yaml:"updated_at"`
-	Location  string      `boil:"location" json:"location" toml:"location" yaml:"location"`
-	Geohash   string      `boil:"geohash" json:"geohash" toml:"geohash" yaml:"geohash"`
 
 	R *planR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L planL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -42,16 +40,12 @@ var PlanColumns = struct {
 	Name      string
 	CreatedAt string
 	UpdatedAt string
-	Location  string
-	Geohash   string
 }{
 	ID:        "id",
 	UserID:    "user_id",
 	Name:      "name",
 	CreatedAt: "created_at",
 	UpdatedAt: "updated_at",
-	Location:  "location",
-	Geohash:   "geohash",
 }
 
 var PlanTableColumns = struct {
@@ -60,16 +54,12 @@ var PlanTableColumns = struct {
 	Name      string
 	CreatedAt string
 	UpdatedAt string
-	Location  string
-	Geohash   string
 }{
 	ID:        "plans.id",
 	UserID:    "plans.user_id",
 	Name:      "plans.name",
 	CreatedAt: "plans.created_at",
 	UpdatedAt: "plans.updated_at",
-	Location:  "plans.location",
-	Geohash:   "plans.geohash",
 }
 
 // Generated where
@@ -80,16 +70,12 @@ var PlanWhere = struct {
 	Name      whereHelperstring
 	CreatedAt whereHelpertime_Time
 	UpdatedAt whereHelpertime_Time
-	Location  whereHelperstring
-	Geohash   whereHelperstring
 }{
 	ID:        whereHelperstring{field: "`plans`.`id`"},
 	UserID:    whereHelpernull_String{field: "`plans`.`user_id`"},
 	Name:      whereHelperstring{field: "`plans`.`name`"},
 	CreatedAt: whereHelpertime_Time{field: "`plans`.`created_at`"},
 	UpdatedAt: whereHelpertime_Time{field: "`plans`.`updated_at`"},
-	Location:  whereHelperstring{field: "`plans`.`location`"},
-	Geohash:   whereHelperstring{field: "`plans`.`geohash`"},
 }
 
 // PlanRels is where relationship names are stored.
@@ -130,9 +116,9 @@ func (r *planR) GetPlanPlaces() PlanPlaceSlice {
 type planL struct{}
 
 var (
-	planAllColumns            = []string{"id", "user_id", "name", "created_at", "updated_at", "location", "geohash"}
-	planColumnsWithoutDefault = []string{"id", "user_id", "name", "geohash"}
-	planColumnsWithDefault    = []string{"created_at", "updated_at", "location"}
+	planAllColumns            = []string{"id", "user_id", "name", "created_at", "updated_at"}
+	planColumnsWithoutDefault = []string{"id", "user_id", "name"}
+	planColumnsWithDefault    = []string{"created_at", "updated_at"}
 	planPrimaryKeyColumns     = []string{"id"}
 	planGeneratedColumns      = []string{}
 )

--- a/internal/infrastructure/rdb/generated/plans.go
+++ b/internal/infrastructure/rdb/generated/plans.go
@@ -30,6 +30,7 @@ type Plan struct {
 	CreatedAt time.Time   `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
 	UpdatedAt time.Time   `boil:"updated_at" json:"updated_at" toml:"updated_at" yaml:"updated_at"`
 	Location  string      `boil:"location" json:"location" toml:"location" yaml:"location"`
+	Geohash   string      `boil:"geohash" json:"geohash" toml:"geohash" yaml:"geohash"`
 
 	R *planR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L planL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -42,6 +43,7 @@ var PlanColumns = struct {
 	CreatedAt string
 	UpdatedAt string
 	Location  string
+	Geohash   string
 }{
 	ID:        "id",
 	UserID:    "user_id",
@@ -49,6 +51,7 @@ var PlanColumns = struct {
 	CreatedAt: "created_at",
 	UpdatedAt: "updated_at",
 	Location:  "location",
+	Geohash:   "geohash",
 }
 
 var PlanTableColumns = struct {
@@ -58,6 +61,7 @@ var PlanTableColumns = struct {
 	CreatedAt string
 	UpdatedAt string
 	Location  string
+	Geohash   string
 }{
 	ID:        "plans.id",
 	UserID:    "plans.user_id",
@@ -65,6 +69,7 @@ var PlanTableColumns = struct {
 	CreatedAt: "plans.created_at",
 	UpdatedAt: "plans.updated_at",
 	Location:  "plans.location",
+	Geohash:   "plans.geohash",
 }
 
 // Generated where
@@ -76,6 +81,7 @@ var PlanWhere = struct {
 	CreatedAt whereHelpertime_Time
 	UpdatedAt whereHelpertime_Time
 	Location  whereHelperstring
+	Geohash   whereHelperstring
 }{
 	ID:        whereHelperstring{field: "`plans`.`id`"},
 	UserID:    whereHelpernull_String{field: "`plans`.`user_id`"},
@@ -83,6 +89,7 @@ var PlanWhere = struct {
 	CreatedAt: whereHelpertime_Time{field: "`plans`.`created_at`"},
 	UpdatedAt: whereHelpertime_Time{field: "`plans`.`updated_at`"},
 	Location:  whereHelperstring{field: "`plans`.`location`"},
+	Geohash:   whereHelperstring{field: "`plans`.`geohash`"},
 }
 
 // PlanRels is where relationship names are stored.
@@ -123,9 +130,9 @@ func (r *planR) GetPlanPlaces() PlanPlaceSlice {
 type planL struct{}
 
 var (
-	planAllColumns            = []string{"id", "user_id", "name", "created_at", "updated_at", "location"}
-	planColumnsWithoutDefault = []string{"id", "user_id", "name"}
-	planColumnsWithDefault    = []string{"created_at", "updated_at", "location"}
+	planAllColumns            = []string{"id", "user_id", "name", "created_at", "updated_at", "location", "geohash"}
+	planColumnsWithoutDefault = []string{"id", "user_id", "name", "location", "geohash"}
+	planColumnsWithDefault    = []string{"created_at", "updated_at"}
 	planPrimaryKeyColumns     = []string{"id"}
 	planGeneratedColumns      = []string{}
 )

--- a/internal/infrastructure/rdb/generated/plans.go
+++ b/internal/infrastructure/rdb/generated/plans.go
@@ -29,6 +29,7 @@ type Plan struct {
 	Name      string      `boil:"name" json:"name" toml:"name" yaml:"name"`
 	CreatedAt time.Time   `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
 	UpdatedAt time.Time   `boil:"updated_at" json:"updated_at" toml:"updated_at" yaml:"updated_at"`
+	Location  string      `boil:"location" json:"location" toml:"location" yaml:"location"`
 
 	R *planR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L planL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -40,12 +41,14 @@ var PlanColumns = struct {
 	Name      string
 	CreatedAt string
 	UpdatedAt string
+	Location  string
 }{
 	ID:        "id",
 	UserID:    "user_id",
 	Name:      "name",
 	CreatedAt: "created_at",
 	UpdatedAt: "updated_at",
+	Location:  "location",
 }
 
 var PlanTableColumns = struct {
@@ -54,12 +57,14 @@ var PlanTableColumns = struct {
 	Name      string
 	CreatedAt string
 	UpdatedAt string
+	Location  string
 }{
 	ID:        "plans.id",
 	UserID:    "plans.user_id",
 	Name:      "plans.name",
 	CreatedAt: "plans.created_at",
 	UpdatedAt: "plans.updated_at",
+	Location:  "plans.location",
 }
 
 // Generated where
@@ -70,12 +75,14 @@ var PlanWhere = struct {
 	Name      whereHelperstring
 	CreatedAt whereHelpertime_Time
 	UpdatedAt whereHelpertime_Time
+	Location  whereHelperstring
 }{
 	ID:        whereHelperstring{field: "`plans`.`id`"},
 	UserID:    whereHelpernull_String{field: "`plans`.`user_id`"},
 	Name:      whereHelperstring{field: "`plans`.`name`"},
 	CreatedAt: whereHelpertime_Time{field: "`plans`.`created_at`"},
 	UpdatedAt: whereHelpertime_Time{field: "`plans`.`updated_at`"},
+	Location:  whereHelperstring{field: "`plans`.`location`"},
 }
 
 // PlanRels is where relationship names are stored.
@@ -116,9 +123,9 @@ func (r *planR) GetPlanPlaces() PlanPlaceSlice {
 type planL struct{}
 
 var (
-	planAllColumns            = []string{"id", "user_id", "name", "created_at", "updated_at"}
+	planAllColumns            = []string{"id", "user_id", "name", "created_at", "updated_at", "location"}
 	planColumnsWithoutDefault = []string{"id", "user_id", "name"}
-	planColumnsWithDefault    = []string{"created_at", "updated_at"}
+	planColumnsWithDefault    = []string{"created_at", "updated_at", "location"}
 	planPrimaryKeyColumns     = []string{"id"}
 	planGeneratedColumns      = []string{}
 )

--- a/internal/infrastructure/rdb/generated/plans.go
+++ b/internal/infrastructure/rdb/generated/plans.go
@@ -131,8 +131,8 @@ type planL struct{}
 
 var (
 	planAllColumns            = []string{"id", "user_id", "name", "created_at", "updated_at", "location", "geohash"}
-	planColumnsWithoutDefault = []string{"id", "user_id", "name", "location", "geohash"}
-	planColumnsWithDefault    = []string{"created_at", "updated_at"}
+	planColumnsWithoutDefault = []string{"id", "user_id", "name", "geohash"}
+	planColumnsWithDefault    = []string{"created_at", "updated_at", "location"}
 	planPrimaryKeyColumns     = []string{"id"}
 	planGeneratedColumns      = []string{}
 )

--- a/internal/infrastructure/rdb/mock_test.go
+++ b/internal/infrastructure/rdb/mock_test.go
@@ -84,16 +84,18 @@ func savePlans(ctx context.Context, db *sql.DB, plans []models.Plan) error {
 		}
 		if _, err := queries.Raw(
 			fmt.Sprintf(
-				"INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, POINT(?, ?))",
+				"INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, POINT(?, ?))",
 				generated.TableNames.Plans,
 				generated.PlanColumns.ID,
 				generated.PlanColumns.UserID,
 				generated.PlanColumns.Name,
+				generated.PlanColumns.Geohash,
 				generated.PlanColumns.Location,
 			),
 			planEntity.ID,
 			planEntity.UserID,
 			planEntity.Name,
+			startLocation.GeoHash(),
 			startLocation.Longitude,
 			startLocation.Latitude,
 		).ExecContext(ctx, db); err != nil {

--- a/internal/infrastructure/rdb/mock_test.go
+++ b/internal/infrastructure/rdb/mock_test.go
@@ -84,18 +84,16 @@ func savePlans(ctx context.Context, db *sql.DB, plans []models.Plan) error {
 		}
 		if _, err := queries.Raw(
 			fmt.Sprintf(
-				"INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, POINT(?, ?))",
+				"INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, POINT(?, ?))",
 				generated.TableNames.Plans,
 				generated.PlanColumns.ID,
 				generated.PlanColumns.UserID,
 				generated.PlanColumns.Name,
-				generated.PlanColumns.Geohash,
 				generated.PlanColumns.Location,
 			),
 			planEntity.ID,
 			planEntity.UserID,
 			planEntity.Name,
-			startLocation.GeoHash(),
 			startLocation.Longitude,
 			startLocation.Latitude,
 		).ExecContext(ctx, db); err != nil {

--- a/internal/infrastructure/rdb/plan.go
+++ b/internal/infrastructure/rdb/plan.go
@@ -59,18 +59,16 @@ func (p PlanRepository) Save(ctx context.Context, plan *models.Plan) error {
 		planEntity := factory.NewPlanEntityFromDomainModel(*plan)
 		if _, err := queries.Raw(
 			fmt.Sprintf(
-				"INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, POINT(?, ?))",
+				"INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, POINT(?, ?))",
 				generated.TableNames.Plans,
 				generated.PlanColumns.ID,
 				generated.PlanColumns.UserID,
 				generated.PlanColumns.Name,
-				generated.PlanColumns.Geohash,
 				generated.PlanColumns.Location,
 			),
 			planEntity.ID,
 			planEntity.UserID,
 			planEntity.Name,
-			planEntity.Geohash,
 			startLocation.Longitude,
 			startLocation.Latitude,
 		).ExecContext(ctx, tx); err != nil {

--- a/internal/infrastructure/rdb/plan.go
+++ b/internal/infrastructure/rdb/plan.go
@@ -59,16 +59,18 @@ func (p PlanRepository) Save(ctx context.Context, plan *models.Plan) error {
 		planEntity := factory.NewPlanEntityFromDomainModel(*plan)
 		if _, err := queries.Raw(
 			fmt.Sprintf(
-				"INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, POINT(?, ?))",
+				"INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, POINT(?, ?))",
 				generated.TableNames.Plans,
 				generated.PlanColumns.ID,
 				generated.PlanColumns.UserID,
 				generated.PlanColumns.Name,
+				generated.PlanColumns.Geohash,
 				generated.PlanColumns.Location,
 			),
 			planEntity.ID,
 			planEntity.UserID,
 			planEntity.Name,
+			planEntity.Geohash,
 			startLocation.Longitude,
 			startLocation.Latitude,
 		).ExecContext(ctx, tx); err != nil {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 位置情報を用いて検索できるようにするために、`plan`テーブルに`location`カラムを追加した


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 近くのプランを検索できるようにするため

### どのようにテストされているか
- [x] マイグレーションが実行できることを確認
- [x] ロールバックできることを確認
```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```