### PR TITLE
SQLBoilerのログをZapで出力する

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func main() {
-	db, err := rdb.InitDB(os.Getenv("ENV") == "development")
+	db, err := rdb.InitDB(false)
 	if err != nil {
 		log.Fatalf("error while initializing db: %v", err)
 	}

--- a/internal/infrastructure/rdb/init.go
+++ b/internal/infrastructure/rdb/init.go
@@ -4,7 +4,9 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/volatiletech/sqlboiler/v4/boil"
+	"go.uber.org/zap"
 	"os"
+	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
 func InitDB(debugMode bool) (*sql.DB, error) {
@@ -27,7 +29,20 @@ func InitDB(debugMode bool) (*sql.DB, error) {
 	boil.SetDB(db)
 
 	if debugMode {
+		logger, err := utils.NewLogger(utils.LoggerOption{
+			Tag: "sqlboiler",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error while creating logger: %v\n", err)
+		}
+
+		stdOutLogger, err := zap.NewStdLogAt(logger, zap.DebugLevel)
+		if err != nil {
+			return nil, fmt.Errorf("error while creating logger: %v\n", err)
+		}
+
 		boil.DebugMode = true
+		boil.DebugWriter = stdOutLogger.Writer()
 	}
 
 	return db, nil

--- a/internal/infrastructure/rdb/init.go
+++ b/internal/infrastructure/rdb/init.go
@@ -36,7 +36,7 @@ func InitDB(debugMode bool) (*sql.DB, error) {
 			return nil, fmt.Errorf("error while creating logger: %v\n", err)
 		}
 
-		stdOutLogger, err := zap.NewStdLogAt(logger, zap.DebugLevel)
+		stdOutLogger, err := zap.NewStdLogAt(logger, zap.InfoLevel)
 		if err != nil {
 			return nil, fmt.Errorf("error while creating logger: %v\n", err)
 		}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- SQLBoilerのクエリログをzapを用いて出力するようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #395 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- ログレベルを調整することで、クエリを確認したいときだけ表示できるようにするため
- すべてのクエリログが出てしまうと、デバッグが難しくなってしまうため

### どのようにテストされているか