### PR TITLE
[スキーマ変更] プラン取得時にページトークンを生成するようにする

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module poroto.app/poroto/planner
 go 1.19
 
 require (
-	cloud.google.com/go/firestore v1.14.0
 	firebase.google.com/go/v4 v4.13.0
 	github.com/99designs/gqlgen v0.17.34
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.0
@@ -21,7 +20,6 @@ require (
 	github.com/volatiletech/strmangle v0.0.5
 	go.uber.org/zap v1.26.0
 	google.golang.org/api v0.155.0
-	google.golang.org/grpc v1.60.1
 	googlemaps.github.io/maps v1.7.0
 )
 
@@ -29,6 +27,7 @@ require (
 	cloud.google.com/go v0.110.10 // indirect
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	cloud.google.com/go/firestore v1.14.0 // indirect
 	cloud.google.com/go/functions v1.15.4 // indirect
 	cloud.google.com/go/iam v1.1.5 // indirect
 	cloud.google.com/go/longrunning v0.5.4 // indirect
@@ -101,6 +100,7 @@ require (
 	google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231211222908-989df2bf70f3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231212172506-995d672761c0 // indirect
+	google.golang.org/grpc v1.60.1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/domain/repository/plan.go
+++ b/internal/domain/repository/plan.go
@@ -6,11 +6,17 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
+type SortedByCreatedAtQueryCursor string
+
 type PlanRepository interface {
 	Save(ctx context.Context, plan *models.Plan) error
-	SortedByCreatedAt(ctx context.Context, queryCursor *string, limit int) (*[]models.Plan, error)
+
+	SortedByCreatedAt(ctx context.Context, queryCursor *SortedByCreatedAtQueryCursor, limit int) (*[]models.Plan, *SortedByCreatedAtQueryCursor, error)
+
 	Find(ctx context.Context, planId string) (*models.Plan, error)
+
 	FindByAuthorId(ctx context.Context, authorId string) (*[]models.Plan, error)
+
 	// SortedByLocation location で指定した地点に近いプランを返す
 	SortedByLocation(ctx context.Context, location models.GeoLocation, queryCursor *string, limit int) (*[]models.Plan, *string, error)
 }

--- a/internal/domain/services/plan/fetch_all.go
+++ b/internal/domain/services/plan/fetch_all.go
@@ -3,19 +3,32 @@ package plan
 import (
 	"context"
 	"fmt"
-	"poroto.app/poroto/planner/internal/domain/repository"
-
 	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/repository"
+	"poroto.app/poroto/planner/internal/domain/utils"
 )
 
-func (s Service) FetchPlans(ctx context.Context, pageToken *string) (*[]models.Plan, *string, error) {
+const (
+	defaultPlanPageSize = 10
+)
+
+type FetchPlansInput struct {
+	PageToken *string
+	Limit     *int
+}
+
+func (s Service) FetchPlans(ctx context.Context, input FetchPlansInput) (*[]models.Plan, *string, error) {
 	var queryCursor *repository.SortedByCreatedAtQueryCursor
-	if pageToken != nil {
-		qc := repository.SortedByCreatedAtQueryCursor(*pageToken)
-		queryCursor = &qc
+	if input.PageToken != nil {
+		queryCursor = utils.ToPointer(repository.SortedByCreatedAtQueryCursor(*input.PageToken))
 	}
 
-	plans, nextQueryCursor, err := s.planRepository.SortedByCreatedAt(ctx, queryCursor, 10)
+	limit := defaultPlanPageSize
+	if input.Limit != nil {
+		limit = *input.Limit
+	}
+
+	plans, nextQueryCursor, err := s.planRepository.SortedByCreatedAt(ctx, queryCursor, limit)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error while fetching plans: %v", err)
 	}

--- a/internal/domain/services/plan/fetch_all.go
+++ b/internal/domain/services/plan/fetch_all.go
@@ -3,14 +3,23 @@ package plan
 import (
 	"context"
 	"fmt"
+	"poroto.app/poroto/planner/internal/domain/repository"
 
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-func (s Service) FetchPlans(ctx context.Context, nextPageToken *string) (*[]models.Plan, error) {
-	plans, err := s.planRepository.SortedByCreatedAt(ctx, nextPageToken, 10)
+func (s Service) FetchPlans(ctx context.Context, pageToken *string) (*[]models.Plan, error) {
+	var queryCursor *repository.SortedByCreatedAtQueryCursor
+	if pageToken != nil {
+		qc := repository.SortedByCreatedAtQueryCursor(*pageToken)
+		queryCursor = &qc
+	}
+
+	// TODO: PageTokenをreturnする
+	plans, _, err := s.planRepository.SortedByCreatedAt(ctx, queryCursor, 10)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plans: %v", err)
 	}
+
 	return plans, nil
 }

--- a/internal/domain/services/plan/fetch_all.go
+++ b/internal/domain/services/plan/fetch_all.go
@@ -8,18 +8,23 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-func (s Service) FetchPlans(ctx context.Context, pageToken *string) (*[]models.Plan, error) {
+func (s Service) FetchPlans(ctx context.Context, pageToken *string) (*[]models.Plan, *string, error) {
 	var queryCursor *repository.SortedByCreatedAtQueryCursor
 	if pageToken != nil {
 		qc := repository.SortedByCreatedAtQueryCursor(*pageToken)
 		queryCursor = &qc
 	}
 
-	// TODO: PageTokenをreturnする
-	plans, _, err := s.planRepository.SortedByCreatedAt(ctx, queryCursor, 10)
+	plans, nextQueryCursor, err := s.planRepository.SortedByCreatedAt(ctx, queryCursor, 10)
 	if err != nil {
-		return nil, fmt.Errorf("error while fetching plans: %v", err)
+		return nil, nil, fmt.Errorf("error while fetching plans: %v", err)
 	}
 
-	return plans, nil
+	var nextPageToken *string
+	if nextQueryCursor != nil {
+		pk := string(*nextQueryCursor)
+		nextPageToken = &pk
+	}
+
+	return plans, nextPageToken, nil
 }

--- a/internal/infrastructure/rdb/plan_test.go
+++ b/internal/infrastructure/rdb/plan_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/repository"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
 	"testing"
 	"time"
@@ -341,7 +342,7 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 		savedPlanSlice      generated.PlanSlice
 		savedPlanPlaceSlice generated.PlanPlaceSlice
 		savedPlaces         []models.Place
-		queryCursor         *string
+		queryCursor         *repository.SortedByCreatedAtQueryCursor
 		limit               int
 		expected            []models.Plan
 	}{
@@ -466,7 +467,7 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 				t.Errorf("error saving plan place: %v", err)
 			}
 
-			plans, err := planRepository.SortedByCreatedAt(textContext, c.queryCursor, c.limit)
+			plans, _, err := planRepository.SortedByCreatedAt(textContext, c.queryCursor, c.limit)
 			if err != nil {
 				t.Errorf("error finding plans: %v", err)
 			}

--- a/internal/infrastructure/rdb/transaction.go
+++ b/internal/infrastructure/rdb/transaction.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-type repository interface {
+type Repository interface {
 	GetDB() *sql.DB
 }
 
-func runTransaction(ctx context.Context, r repository, f func(ctx context.Context, tx *sql.Tx) error) error {
+func runTransaction(ctx context.Context, r Repository, f func(ctx context.Context, tx *sql.Tx) error) error {
 	tx, err := r.GetDB().BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -209,6 +209,11 @@ type ComplexityRoot struct {
 		Plans  func(childComplexity int) int
 	}
 
+	PlansOutput struct {
+		NextPageKey func(childComplexity int) int
+		Plans       func(childComplexity int) int
+	}
+
 	PriceRange struct {
 		GooglePriceLevel func(childComplexity int) int
 		PriceRangeMax    func(childComplexity int) int
@@ -224,7 +229,7 @@ type ComplexityRoot struct {
 		PlacesToReplaceForPlanCandidate func(childComplexity int, input model.PlacesToReplaceForPlanCandidateInput) int
 		Plan                            func(childComplexity int, id string) int
 		PlanCandidate                   func(childComplexity int, input model.PlanCandidateInput) int
-		Plans                           func(childComplexity int, pageKey *string) int
+		Plans                           func(childComplexity int, input *model.PlansInput) int
 		PlansByLocation                 func(childComplexity int, input model.PlansByLocationInput) int
 		PlansByUser                     func(childComplexity int, input model.PlansByUserInput) int
 		Version                         func(childComplexity int) int
@@ -275,7 +280,7 @@ type QueryResolver interface {
 	PlacesToAddForPlanCandidate(ctx context.Context, input model.PlacesToAddForPlanCandidateInput) (*model.PlacesToAddForPlanCandidateOutput, error)
 	PlacesToReplaceForPlanCandidate(ctx context.Context, input model.PlacesToReplaceForPlanCandidateInput) (*model.PlacesToReplaceForPlanCandidateOutput, error)
 	Plan(ctx context.Context, id string) (*model.Plan, error)
-	Plans(ctx context.Context, pageKey *string) ([]*model.Plan, error)
+	Plans(ctx context.Context, input *model.PlansInput) (*model.PlansOutput, error)
 	PlansByLocation(ctx context.Context, input model.PlansByLocationInput) (*model.PlansByLocationOutput, error)
 	PlansByUser(ctx context.Context, input model.PlansByUserInput) (*model.PlansByUserOutput, error)
 	FirebaseUser(ctx context.Context, input *model.FirebaseUserInput) (*model.User, error)
@@ -944,6 +949,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PlansByUserOutput.Plans(childComplexity), true
 
+	case "PlansOutput.nextPageKey":
+		if e.complexity.PlansOutput.NextPageKey == nil {
+			break
+		}
+
+		return e.complexity.PlansOutput.NextPageKey(childComplexity), true
+
+	case "PlansOutput.plans":
+		if e.complexity.PlansOutput.Plans == nil {
+			break
+		}
+
+		return e.complexity.PlansOutput.Plans(childComplexity), true
+
 	case "PriceRange.googlePriceLevel":
 		if e.complexity.PriceRange.GooglePriceLevel == nil {
 			break
@@ -1071,7 +1090,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Plans(childComplexity, args["pageKey"].(*string)), true
+		return e.complexity.Query.Plans(childComplexity, args["input"].(*model.PlansInput)), true
 
 	case "Query.plansByLocation":
 		if e.complexity.Query.PlansByLocation == nil {
@@ -1193,6 +1212,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPlanCandidateInput,
 		ec.unmarshalInputPlansByLocationInput,
 		ec.unmarshalInputPlansByUserInput,
+		ec.unmarshalInputPlansInput,
 		ec.unmarshalInputReplacePlaceOfPlanCandidateInput,
 		ec.unmarshalInputSavePlanFromCandidateInput,
 	)
@@ -1584,11 +1604,20 @@ type PlacesToReplaceForPlanCandidateOutput {
 	{Name: "../schema/plan_query.graphqls", Input: `extend type Query {
     plan(id: String!): Plan
 
-    plans(pageKey: String): [Plan!]!
+    plans(input: PlansInput): PlansOutput!
 
     plansByLocation(input: PlansByLocationInput!): PlansByLocationOutput!
 
     plansByUser(input: PlansByUserInput!): PlansByUserOutput!
+}
+
+input PlansInput {
+    pageKey: String
+}
+
+type PlansOutput {
+    plans: [Plan!]!
+    nextPageKey: String
 }
 
 input PlansByLocationInput {
@@ -2023,15 +2052,15 @@ func (ec *executionContext) field_Query_plansByUser_args(ctx context.Context, ra
 func (ec *executionContext) field_Query_plans_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *string
-	if tmp, ok := rawArgs["pageKey"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pageKey"))
-		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+	var arg0 *model.PlansInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalOPlansInput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlansInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["pageKey"] = arg0
+	args["input"] = arg0
 	return args, nil
 }
 
@@ -6308,6 +6337,107 @@ func (ec *executionContext) fieldContext_PlansByUserOutput_author(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _PlansOutput_plans(ctx context.Context, field graphql.CollectedField, obj *model.PlansOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlansOutput_plans(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Plans, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Plan)
+	fc.Result = res
+	return ec.marshalNPlan2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlansOutput_plans(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlansOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Plan_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Plan_name(ctx, field)
+			case "places":
+				return ec.fieldContext_Plan_places(ctx, field)
+			case "timeInMinutes":
+				return ec.fieldContext_Plan_timeInMinutes(ctx, field)
+			case "description":
+				return ec.fieldContext_Plan_description(ctx, field)
+			case "transitions":
+				return ec.fieldContext_Plan_transitions(ctx, field)
+			case "authorId":
+				return ec.fieldContext_Plan_authorId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Plan", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PlansOutput_nextPageKey(ctx context.Context, field graphql.CollectedField, obj *model.PlansOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlansOutput_nextPageKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextPageKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlansOutput_nextPageKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlansOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PriceRange_priceRangeMin(ctx context.Context, field graphql.CollectedField, obj *model.PriceRange) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PriceRange_priceRangeMin(ctx, field)
 	if err != nil {
@@ -6926,7 +7056,7 @@ func (ec *executionContext) _Query_plans(ctx context.Context, field graphql.Coll
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Plans(rctx, fc.Args["pageKey"].(*string))
+		return ec.resolvers.Query().Plans(rctx, fc.Args["input"].(*model.PlansInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6938,9 +7068,9 @@ func (ec *executionContext) _Query_plans(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Plan)
+	res := resTmp.(*model.PlansOutput)
 	fc.Result = res
-	return ec.marshalNPlan2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanᚄ(ctx, field.Selections, res)
+	return ec.marshalNPlansOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlansOutput(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_plans(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -6951,22 +7081,12 @@ func (ec *executionContext) fieldContext_Query_plans(ctx context.Context, field 
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "id":
-				return ec.fieldContext_Plan_id(ctx, field)
-			case "name":
-				return ec.fieldContext_Plan_name(ctx, field)
-			case "places":
-				return ec.fieldContext_Plan_places(ctx, field)
-			case "timeInMinutes":
-				return ec.fieldContext_Plan_timeInMinutes(ctx, field)
-			case "description":
-				return ec.fieldContext_Plan_description(ctx, field)
-			case "transitions":
-				return ec.fieldContext_Plan_transitions(ctx, field)
-			case "authorId":
-				return ec.fieldContext_Plan_authorId(ctx, field)
+			case "plans":
+				return ec.fieldContext_PlansOutput_plans(ctx, field)
+			case "nextPageKey":
+				return ec.fieldContext_PlansOutput_nextPageKey(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type Plan", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type PlansOutput", field.Name)
 		},
 	}
 	defer func() {
@@ -10364,6 +10484,35 @@ func (ec *executionContext) unmarshalInputPlansByUserInput(ctx context.Context, 
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputPlansInput(ctx context.Context, obj interface{}) (model.PlansInput, error) {
+	var it model.PlansInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"pageKey"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "pageKey":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pageKey"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PageKey = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputReplacePlaceOfPlanCandidateInput(ctx context.Context, obj interface{}) (model.ReplacePlaceOfPlanCandidateInput, error) {
 	var it model.ReplacePlaceOfPlanCandidateInput
 	asMap := map[string]interface{}{}
@@ -11783,6 +11932,47 @@ func (ec *executionContext) _PlansByUserOutput(ctx context.Context, sel ast.Sele
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var plansOutputImplementors = []string{"PlansOutput"}
+
+func (ec *executionContext) _PlansOutput(ctx context.Context, sel ast.SelectionSet, obj *model.PlansOutput) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, plansOutputImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PlansOutput")
+		case "plans":
+			out.Values[i] = ec._PlansOutput_plans(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "nextPageKey":
+			out.Values[i] = ec._PlansOutput_nextPageKey(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -13421,6 +13611,20 @@ func (ec *executionContext) marshalNPlansByUserOutput2ᚖporotoᚗappᚋporoto�
 	return ec._PlansByUserOutput(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNPlansOutput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlansOutput(ctx context.Context, sel ast.SelectionSet, v model.PlansOutput) graphql.Marshaler {
+	return ec._PlansOutput(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPlansOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlansOutput(ctx context.Context, sel ast.SelectionSet, v *model.PlansOutput) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._PlansOutput(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNReplacePlaceOfPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐReplacePlaceOfPlanCandidateInput(ctx context.Context, v interface{}) (model.ReplacePlaceOfPlanCandidateInput, error) {
 	res, err := ec.unmarshalInputReplacePlaceOfPlanCandidateInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -13920,6 +14124,14 @@ func (ec *executionContext) marshalOPlanCandidate2ᚖporotoᚗappᚋporotoᚋpla
 		return graphql.Null
 	}
 	return ec._PlanCandidate(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOPlansInput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlansInput(ctx context.Context, v interface{}) (*model.PlansInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputPlansInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOPriceRange2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPriceRange(ctx context.Context, sel ast.SelectionSet, v *model.PriceRange) graphql.Marshaler {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1613,6 +1613,7 @@ type PlacesToReplaceForPlanCandidateOutput {
 
 input PlansInput {
     pageToken: String
+    limit: Int
 }
 
 type PlansOutput {
@@ -10491,7 +10492,7 @@ func (ec *executionContext) unmarshalInputPlansInput(ctx context.Context, obj in
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"pageToken"}
+	fieldsInOrder := [...]string{"pageToken", "limit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10507,6 +10508,15 @@ func (ec *executionContext) unmarshalInputPlansInput(ctx context.Context, obj in
 				return it, err
 			}
 			it.PageToken = data
+		case "limit":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Limit = data
 		}
 	}
 

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -210,8 +210,8 @@ type ComplexityRoot struct {
 	}
 
 	PlansOutput struct {
-		NextPageKey func(childComplexity int) int
-		Plans       func(childComplexity int) int
+		NextPageToken func(childComplexity int) int
+		Plans         func(childComplexity int) int
 	}
 
 	PriceRange struct {
@@ -949,12 +949,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PlansByUserOutput.Plans(childComplexity), true
 
-	case "PlansOutput.nextPageKey":
-		if e.complexity.PlansOutput.NextPageKey == nil {
+	case "PlansOutput.nextPageToken":
+		if e.complexity.PlansOutput.NextPageToken == nil {
 			break
 		}
 
-		return e.complexity.PlansOutput.NextPageKey(childComplexity), true
+		return e.complexity.PlansOutput.NextPageToken(childComplexity), true
 
 	case "PlansOutput.plans":
 		if e.complexity.PlansOutput.Plans == nil {
@@ -1612,12 +1612,12 @@ type PlacesToReplaceForPlanCandidateOutput {
 }
 
 input PlansInput {
-    pageKey: String
+    pageToken: String
 }
 
 type PlansOutput {
     plans: [Plan!]!
-    nextPageKey: String
+    nextPageToken: String
 }
 
 input PlansByLocationInput {
@@ -6397,8 +6397,8 @@ func (ec *executionContext) fieldContext_PlansOutput_plans(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _PlansOutput_nextPageKey(ctx context.Context, field graphql.CollectedField, obj *model.PlansOutput) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PlansOutput_nextPageKey(ctx, field)
+func (ec *executionContext) _PlansOutput_nextPageToken(ctx context.Context, field graphql.CollectedField, obj *model.PlansOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlansOutput_nextPageToken(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -6411,7 +6411,7 @@ func (ec *executionContext) _PlansOutput_nextPageKey(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.NextPageKey, nil
+		return obj.NextPageToken, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6425,7 +6425,7 @@ func (ec *executionContext) _PlansOutput_nextPageKey(ctx context.Context, field 
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_PlansOutput_nextPageKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_PlansOutput_nextPageToken(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "PlansOutput",
 		Field:      field,
@@ -7083,8 +7083,8 @@ func (ec *executionContext) fieldContext_Query_plans(ctx context.Context, field 
 			switch field.Name {
 			case "plans":
 				return ec.fieldContext_PlansOutput_plans(ctx, field)
-			case "nextPageKey":
-				return ec.fieldContext_PlansOutput_nextPageKey(ctx, field)
+			case "nextPageToken":
+				return ec.fieldContext_PlansOutput_nextPageToken(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PlansOutput", field.Name)
 		},
@@ -10491,22 +10491,22 @@ func (ec *executionContext) unmarshalInputPlansInput(ctx context.Context, obj in
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"pageKey"}
+	fieldsInOrder := [...]string{"pageToken"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "pageKey":
+		case "pageToken":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pageKey"))
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pageToken"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PageKey = data
+			it.PageToken = data
 		}
 	}
 
@@ -11971,8 +11971,8 @@ func (ec *executionContext) _PlansOutput(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "nextPageKey":
-			out.Values[i] = ec._PlansOutput_nextPageKey(ctx, field, obj)
+		case "nextPageToken":
+			out.Values[i] = ec._PlansOutput_nextPageToken(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -266,6 +266,7 @@ type PlansByUserOutput struct {
 
 type PlansInput struct {
 	PageToken *string `json:"pageToken,omitempty"`
+	Limit     *int    `json:"limit,omitempty"`
 }
 
 type PlansOutput struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -265,12 +265,12 @@ type PlansByUserOutput struct {
 }
 
 type PlansInput struct {
-	PageKey *string `json:"pageKey,omitempty"`
+	PageToken *string `json:"pageToken,omitempty"`
 }
 
 type PlansOutput struct {
-	Plans       []*Plan `json:"plans"`
-	NextPageKey *string `json:"nextPageKey,omitempty"`
+	Plans         []*Plan `json:"plans"`
+	NextPageToken *string `json:"nextPageToken,omitempty"`
 }
 
 type PriceRange struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -264,6 +264,15 @@ type PlansByUserOutput struct {
 	Author *User   `json:"author"`
 }
 
+type PlansInput struct {
+	PageKey *string `json:"pageKey,omitempty"`
+}
+
+type PlansOutput struct {
+	Plans       []*Plan `json:"plans"`
+	NextPageKey *string `json:"nextPageKey,omitempty"`
+}
+
 type PriceRange struct {
 	PriceRangeMin    int `json:"priceRangeMin"`
 	PriceRangeMax    int `json:"priceRangeMax"`

--- a/internal/interface/graphql/resolver/plan_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_query.resolvers.go
@@ -57,7 +57,10 @@ func (r *queryResolver) Plans(ctx context.Context, input *model.PlansInput) (*mo
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	plans, nextPageToken, err := service.FetchPlans(ctx, input.PageToken)
+	plans, nextPageToken, err := service.FetchPlans(ctx, plan.FetchPlansInput{
+		PageToken: input.PageToken,
+		Limit:     input.Limit,
+	})
 	if err != nil {
 		logger.Error("error while fetching plans", zap.Error(err))
 		return nil, fmt.Errorf("could not fetch plans")

--- a/internal/interface/graphql/resolver/plan_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_query.resolvers.go
@@ -7,13 +7,13 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"log"
-	"poroto.app/poroto/planner/internal/domain/utils"
 
+	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/plan"
 	"poroto.app/poroto/planner/internal/domain/services/user"
+	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
 )

--- a/internal/interface/graphql/resolver/plan_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_query.resolvers.go
@@ -42,20 +42,23 @@ func (r *queryResolver) Plan(ctx context.Context, id string) (*model.Plan, error
 }
 
 // Plans is the resolver for the plans field.
-func (r *queryResolver) Plans(ctx context.Context, pageKey *string) ([]*model.Plan, error) {
+func (r *queryResolver) Plans(ctx context.Context, input *model.PlansInput) (*model.PlansOutput, error) {
 	service, err := plan.NewService(ctx, r.DB)
 	if err != nil {
 		log.Println("error while initializing places api: ", err)
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	plans, err := service.FetchPlans(ctx, pageKey)
+	plans, err := service.FetchPlans(ctx, input.PageKey)
 	if err != nil {
 		log.Println(err)
 		return nil, fmt.Errorf("could not fetch plans")
 	}
 
-	return factory.PlansFromDomainModel(plans, nil), nil
+	return &model.PlansOutput{
+		Plans:       factory.PlansFromDomainModel(plans, nil),
+		NextPageKey: nil, // TODO: implement me!
+	}, nil
 }
 
 // PlansByLocation is the resolver for the plansByLocation field.

--- a/internal/interface/graphql/resolver/plan_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_query.resolvers.go
@@ -49,15 +49,15 @@ func (r *queryResolver) Plans(ctx context.Context, input *model.PlansInput) (*mo
 		return nil, fmt.Errorf("internal server error")
 	}
 
-	plans, err := service.FetchPlans(ctx, input.PageKey)
+	plans, _, err := service.FetchPlans(ctx, input.PageToken)
 	if err != nil {
 		log.Println(err)
 		return nil, fmt.Errorf("could not fetch plans")
 	}
 
 	return &model.PlansOutput{
-		Plans:       factory.PlansFromDomainModel(plans, nil),
-		NextPageKey: nil, // TODO: implement me!
+		Plans:         factory.PlansFromDomainModel(plans, nil),
+		NextPageToken: nil, // TODO: implement me!
 	}, nil
 }
 

--- a/internal/interface/graphql/schema/plan_query.graphqls
+++ b/internal/interface/graphql/schema/plan_query.graphqls
@@ -1,11 +1,20 @@
 extend type Query {
     plan(id: String!): Plan
 
-    plans(pageKey: String): [Plan!]!
+    plans(input: PlansInput): PlansOutput!
 
     plansByLocation(input: PlansByLocationInput!): PlansByLocationOutput!
 
     plansByUser(input: PlansByUserInput!): PlansByUserOutput!
+}
+
+input PlansInput {
+    pageKey: String
+}
+
+type PlansOutput {
+    plans: [Plan!]!
+    nextPageKey: String
 }
 
 input PlansByLocationInput {

--- a/internal/interface/graphql/schema/plan_query.graphqls
+++ b/internal/interface/graphql/schema/plan_query.graphqls
@@ -9,12 +9,12 @@ extend type Query {
 }
 
 input PlansInput {
-    pageKey: String
+    pageToken: String
 }
 
 type PlansOutput {
     plans: [Plan!]!
-    nextPageKey: String
+    nextPageToken: String
 }
 
 input PlansByLocationInput {

--- a/internal/interface/graphql/schema/plan_query.graphqls
+++ b/internal/interface/graphql/schema/plan_query.graphqls
@@ -10,6 +10,7 @@ extend type Query {
 
 input PlansInput {
     pageToken: String
+    limit: Int
 }
 
 type PlansOutput {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 今まで暗黙的にporotoで生成していたページトークンをplanner側で生成するようにした


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #400 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 複数プランを取得できるようにするため

### どのようにテストされているか
- TODO: poroto側の対応
- [ ] プラン作成できることを確認
- [ ] プランを保存できることを確認
- [ ] porotoで問題なく動作できることを確認
- [ ]

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```