### PR TITLE
過去に保存された場所をプランに含めるとエラーになるのを修正

### DIFF
--- a/internal/domain/services/plan/save.go
+++ b/internal/domain/services/plan/save.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/utils"
 	"time"
 
@@ -17,14 +18,10 @@ func (s Service) SavePlanFromPlanCandidate(ctx context.Context, planCandidateId 
 		return nil, err
 	}
 
-	var planToSave *models.Plan
-	for _, plan := range planCandidate.Plans {
-		if plan.Id == planId {
-			planToSave = &plan
-			break
-		}
-	}
-	if planToSave == nil {
+	planToSave, ok := array.Find(planCandidate.Plans, func(plan models.Plan) bool {
+		return plan.Id == planId
+	})
+	if !ok {
 		return nil, fmt.Errorf("plan(%v) not found in plan candidate(%v)", planId, planCandidateId)
 	}
 
@@ -62,9 +59,9 @@ func (s Service) SavePlanFromPlanCandidate(ctx context.Context, planCandidateId 
 	}
 
 	// プランを保存
-	if err := s.planRepository.Save(ctx, planToSave); err != nil {
+	if err := s.planRepository.Save(ctx, &planToSave); err != nil {
 		return nil, err
 	}
 
-	return planToSave, nil
+	return &planToSave, nil
 }

--- a/internal/infrastructure/rdb/factory/plan_place.go
+++ b/internal/infrastructure/rdb/factory/plan_place.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
@@ -12,7 +13,7 @@ func NewPlanPlaceSliceFromDomainMode(planPlaces []models.Place, planId string) g
 	var planPlaceSlice generated.PlanPlaceSlice
 	for i, place := range planPlaces {
 		planPlaceSlice = append(planPlaceSlice, &generated.PlanPlace{
-			ID:        place.Id,
+			ID:        uuid.New().String(),
 			PlaceID:   place.Id,
 			PlanID:    planId,
 			SortOrder: i,


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 過去にプランに含まれた場所と同じ場所を保存しようとするとエラーになるのを修正した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```