### PR TITLE
プランの開始地点となる場所を10箇所ほど選択し、プランが1件も作成できないという現象を減らす

### DIFF
--- a/internal/domain/services/placefilter/filter_default_ignore.go
+++ b/internal/domain/services/placefilter/filter_default_ignore.go
@@ -7,14 +7,19 @@ const (
 )
 
 type FilterDefaultIgnoreInput struct {
-	Places        []models.Place
-	StartLocation models.GeoLocation
+	Places              []models.Place
+	StartLocation       models.GeoLocation
+	IgnoreDistanceRange float64
 }
 
 // FilterDefaultIgnore はプラン作成時に共通して無視する場所をフィルタリングする
 func FilterDefaultIgnore(input FilterDefaultIgnoreInput) []models.Place {
 	if input.StartLocation.IsZero() {
 		panic("StartLocation is empty")
+	}
+
+	if input.IgnoreDistanceRange == 0 {
+		input.IgnoreDistanceRange = ignorePlaceDistanceRange
 	}
 
 	placesFiltered := input.Places
@@ -30,7 +35,7 @@ func FilterDefaultIgnore(input FilterDefaultIgnoreInput) []models.Place {
 	placesFiltered = FilterCompany(placesFiltered)
 
 	// 1.5km圏外の場所は無視する
-	placesFiltered = FilterWithinDistanceRange(placesFiltered, input.StartLocation, 0, ignorePlaceDistanceRange)
+	placesFiltered = FilterWithinDistanceRange(placesFiltered, input.StartLocation, 0, input.IgnoreDistanceRange)
 
 	// 画像がない場所は無視する
 	placesFiltered = FilterByHasPhoto(placesFiltered)

--- a/internal/domain/services/plangen/create_plan_places.go
+++ b/internal/domain/services/plangen/create_plan_places.go
@@ -41,17 +41,11 @@ func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesPa
 
 	placesFiltered := params.Places
 	placesFiltered = placefilter.FilterDefaultIgnore(placefilter.FilterDefaultIgnoreInput{
-		Places:        placesFiltered,
-		StartLocation: params.LocationStart,
+		Places:              placesFiltered,
+		StartLocation:       params.LocationStart,
+		IgnoreDistanceRange: placeDistanceRangeInPlan,
 	})
-
-	// 開始地点となる場所から1500m圏内の場所に絞る
-	placesFiltered = placefilter.FilterWithinDistanceRange(
-		placesFiltered,
-		params.PlaceStart.Location,
-		0,
-		placeDistanceRangeInPlan,
-	)
+	s.logger.Debug("places after filtering by distance", zap.Int("places", len(placesFiltered)))
 
 	// ユーザーが拒否した場所は取り除く
 	if params.CategoryNamesDisliked != nil {

--- a/internal/domain/services/plangen/create_plan_places.go
+++ b/internal/domain/services/plangen/create_plan_places.go
@@ -51,6 +51,7 @@ func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesPa
 	if params.CategoryNamesDisliked != nil {
 		categoriesDisliked := models.GetCategoriesFromSubCategories(*params.CategoryNamesDisliked)
 		placesFiltered = placefilter.FilterByCategory(placesFiltered, categoriesDisliked, false)
+		s.logger.Debug("places after filtering by disliked categories", zap.Int("places", len(placesFiltered)))
 	}
 
 	// 他のプランに含まれている場所を除外する
@@ -66,6 +67,7 @@ func (s Service) createPlanPlaces(ctx context.Context, params CreatePlanPlacesPa
 		}
 		return true
 	})
+	s.logger.Debug("places after filtering by other plans", zap.Int("places", len(placesFiltered)))
 
 	// レビューの高い順でソート
 	placesSorted := models.SortPlacesByRating(placesFiltered)

--- a/internal/domain/services/plangen/select_base_place.go
+++ b/internal/domain/services/plangen/select_base_place.go
@@ -1,6 +1,7 @@
 package plangen
 
 import (
+	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
 	"sort"
@@ -40,17 +41,21 @@ func (s Service) SelectBasePlace(input SelectBasePlaceInput) []models.Place {
 		Places:        places,
 		StartLocation: input.BaseLocation,
 	})
+	s.logger.Debug("places after filtering default ignore", zap.Int("places", len(places)))
 
 	// レビューが低い、またはレビュー数が少ない場所を除外する
 	places = placefilter.FilterByRating(places, 3.0, 10)
+	s.logger.Debug("places after filtering by rating", zap.Int("places", len(places)))
 
 	// スタート地点から800m圏外の場所を除外する
 	places = placefilter.FilterWithinDistanceRange(places, input.BaseLocation, 0, float64(input.Radius))
+	s.logger.Debug("places after filtering by distance", zap.Int("places", len(places)))
 
 	// ユーザーが拒否した場所は取り除く
 	if input.CategoryNamesDisliked != nil {
 		categoriesDisliked := models.GetCategoriesFromSubCategories(*input.CategoryNamesDisliked)
 		places = placefilter.FilterByCategory(places, categoriesDisliked, false)
+		s.logger.Debug("places after filtering by disliked categories", zap.Int("places", len(places)))
 	}
 
 	// カテゴリごとにレビューの高い場所から選択する

--- a/internal/domain/services/plangen/select_base_place.go
+++ b/internal/domain/services/plangen/select_base_place.go
@@ -37,19 +37,9 @@ func (s Service) SelectBasePlace(input SelectBasePlaceInput) []models.Place {
 
 	places := input.Places
 
-	places = placefilter.FilterDefaultIgnore(placefilter.FilterDefaultIgnoreInput{
-		Places:        places,
-		StartLocation: input.BaseLocation,
-	})
-	s.logger.Debug("places after filtering default ignore", zap.Int("places", len(places)))
-
 	// レビューが低い、またはレビュー数が少ない場所を除外する
 	places = placefilter.FilterByRating(places, 3.0, 10)
 	s.logger.Debug("places after filtering by rating", zap.Int("places", len(places)))
-
-	// スタート地点から800m圏外の場所を除外する
-	places = placefilter.FilterWithinDistanceRange(places, input.BaseLocation, 0, float64(input.Radius))
-	s.logger.Debug("places after filtering by distance", zap.Int("places", len(places)))
 
 	// ユーザーが拒否した場所は取り除く
 	if input.CategoryNamesDisliked != nil {
@@ -57,6 +47,21 @@ func (s Service) SelectBasePlace(input SelectBasePlaceInput) []models.Place {
 		places = placefilter.FilterByCategory(places, categoriesDisliked, false)
 		s.logger.Debug("places after filtering by disliked categories", zap.Int("places", len(places)))
 	}
+
+	for filterDistance := 800; filterDistance < 2000; filterDistance += 200 {
+		// 距離によって1件も場所が取得できない場合は、距離を広げて再度取得する
+		placesFiltered := placefilter.FilterDefaultIgnore(placefilter.FilterDefaultIgnoreInput{
+			Places:              places,
+			StartLocation:       input.BaseLocation,
+			IgnoreDistanceRange: float64(filterDistance),
+		})
+
+		if len(placesFiltered) >= 10 {
+			places = placesFiltered
+			break
+		}
+	}
+	s.logger.Debug("places after filtering default ignore", zap.Int("places", len(places)))
 
 	// カテゴリごとにレビューの高い場所から選択する
 	placesSelected := selectByReview(places)

--- a/internal/domain/services/plangen/select_base_place_test.go
+++ b/internal/domain/services/plangen/select_base_place_test.go
@@ -21,6 +21,7 @@ func TestService_SelectBasePlace(t *testing.T) {
 					Latitude:  35.690817373071,
 					Longitude: 139.7065625287,
 				},
+				MaxBasePlaceCount: 1,
 				Places: []models.Place{
 					{
 						Id:       "takashimaya",

--- a/internal/domain/utils/logger.go
+++ b/internal/domain/utils/logger.go
@@ -40,6 +40,7 @@ func NewLogger(option LoggerOption) (*zap.Logger, error) {
 		dc.Encoding = "console"
 		dc.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		dc.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		dc.DisableStacktrace = true
 		dc.Level = zap.NewAtomicLevelAt(*option.LogLevel)
 
 		l, err := dc.Build()

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -67,6 +67,7 @@ func (r *mutationResolver) CreatePlanByLocation(ctx context.Context, input model
 			CategoryNamesDisliked:        &input.CategoriesDisliked,
 			FreeTime:                     input.FreeTime,
 			CreateBasedOnCurrentLocation: createBasedOnCurrentLocation,
+			ShouldOpenWhileTraveling:     false,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プラン作成のために基準となる３箇所が選択されるが、すべての場所が何らかの条件に合わなくなるとプランができなくなってしまう。
- そこで、基準となる場所を10箇所程度選択し、プランが作成できるまでループするようにした。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #409 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- プランが一つしかできない or 一つもできない事態を防ぐため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 駅等ではなく、住宅地など、最寄りの場所が少ない地点からプランを作成

```shell
# planner
export BRANCH_PLANNER=feature/create_plan_base_locations
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```