### PR TITLE
場所のカテゴリで保存された場所を検索できるようにする

### DIFF
--- a/internal/domain/repository/place.go
+++ b/internal/domain/repository/place.go
@@ -12,6 +12,9 @@ type PlaceRepository interface {
 
 	FindByLocation(ctx context.Context, location models.GeoLocation) ([]models.Place, error)
 
+	// FindByCategory は指定されたカテゴリの場所を取得する
+	FindByCategory(ctx context.Context, category models.LocationCategory, baseLocation models.GeoLocation, radius float64) (*[]models.Place, error)
+
 	FindByGooglePlaceID(ctx context.Context, googlePlaceID string) (*models.Place, error)
 
 	// FindByPlanCandidateId は models.PlanCandidate に紐づく models.Place を取得する

--- a/internal/domain/repository/place.go
+++ b/internal/domain/repository/place.go
@@ -10,7 +10,7 @@ type PlaceRepository interface {
 	// すでに models.GooglePlace が保存されている場合は、それに紐づく models.Place を取得する
 	SavePlacesFromGooglePlaces(ctx context.Context, googlePlaces ...models.GooglePlace) (*[]models.Place, error)
 
-	FindByLocation(ctx context.Context, location models.GeoLocation) ([]models.Place, error)
+	FindByLocation(ctx context.Context, location models.GeoLocation, radius float64) ([]models.Place, error)
 
 	// FindByCategory は指定されたカテゴリの場所を取得する
 	FindByCategory(ctx context.Context, category models.LocationCategory, baseLocation models.GeoLocation, radius float64) (*[]models.Place, error)

--- a/internal/domain/repository/place.go
+++ b/internal/domain/repository/place.go
@@ -12,8 +12,8 @@ type PlaceRepository interface {
 
 	FindByLocation(ctx context.Context, location models.GeoLocation, radius float64) ([]models.Place, error)
 
-	// FindByCategory は指定されたカテゴリの場所を取得する
-	FindByCategory(ctx context.Context, category models.LocationCategory, baseLocation models.GeoLocation, radius float64) (*[]models.Place, error)
+	// FindByGooglePlaceType は GooglePlaceType に紐づく Place を取得する
+	FindByGooglePlaceType(ctx context.Context, googlePlaceType string, baseLocation models.GeoLocation, radius float64) (*[]models.Place, error)
 
 	FindByGooglePlaceID(ctx context.Context, googlePlaceID string) (*models.Place, error)
 

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -15,14 +15,12 @@ import (
 // NearbySearchRadius NearbySearch で検索する際の半径
 // FilterSearchResultRadius 検索結果をフィルタリングするときの半径
 const (
-	NearbySearchRadius       = 2000
-	FilterSearchResultRadius = 1000
+	NearbySearchRadius = 5 * 1000
 )
 
 type SearchNearbyPlacesInput struct {
-	Location                 models.GeoLocation
-	Radius                   uint
-	FilterSearchResultRadius float64
+	Location models.GeoLocation
+	Radius   uint
 }
 
 // placeTypeWithCondition 検索する必要のあるカテゴリを表す
@@ -47,12 +45,8 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 		input.Radius = NearbySearchRadius
 	}
 
-	if input.FilterSearchResultRadius == 0 {
-		input.FilterSearchResultRadius = FilterSearchResultRadius
-	}
-
 	// キャッシュされた検索結果を取得
-	placesSaved, err := s.placeRepository.FindByLocation(ctx, input.Location, input.FilterSearchResultRadius)
+	placesSaved, err := s.placeRepository.FindByLocation(ctx, input.Location, float64(input.Radius))
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places from location: %w", err)
 	}

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -25,7 +25,7 @@ type SearchNearbyPlacesInput struct {
 
 // placeTypeWithCondition 検索する必要のあるカテゴリを表す
 // searchRange Nearby Search時の検索範囲（水族館等の施設の数が少ない場所を探すときは広い範囲を探す）
-// filterRange 周囲ににあるかどうかを確認するときの検索範囲 (カフェ等の施設の数が多い場所を探すときは狭い範囲を探す)
+// filterRange 周囲にあるかどうかを確認するときの検索範囲 (カフェ等の施設の数が多い場所を探すときは狭い範囲を探す)
 // ignorePlaceCount あるカテゴリの場所がこの数以上ある場合は、そのカテゴリの検索は行わない
 type placeTypeWithCondition struct {
 	placeType        maps.PlaceType

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -67,6 +67,7 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 
 	// 重複した場所を削除
 	placesSaved = array.DistinctBy(placesSaved, func(place models.Place) string { return place.Id })
+	s.logger.Info("successfully fetched saved places", zap.Int("places", len(placesSaved)))
 
 	// 検索する必要のあるカテゴリを取得
 	placeTypeToPlaces := groupByPlaceType(placesSaved, s.placeTypesToSearch())
@@ -175,14 +176,14 @@ func (s Service) placeTypesToSearch() []placeTypeWithCondition {
 		{
 			placeType:        maps.PlaceTypeCafe,
 			searchRange:      10 * 1000,
-			filterRange:      3 * 1000,
-			ignorePlaceCount: 1,
+			filterRange:      5 * 1000,
+			ignorePlaceCount: 3,
 		},
 		{
 			placeType:        maps.PlaceTypeRestaurant,
 			searchRange:      10 * 1000,
-			filterRange:      3 * 1000,
-			ignorePlaceCount: 1,
+			filterRange:      5 * 1000,
+			ignorePlaceCount: 5,
 		},
 		// 近くにあってもおかしくないレベル
 		{

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -144,7 +144,6 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 		}(ctx, ch, placeType)
 	}
 
-	// TODO：検索した場所の重複を削除する
 	var placesSearched []models.GooglePlace
 	for i := 0; i < len(placeTypesToSearch); i++ {
 		searchResults := <-ch
@@ -160,20 +159,9 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 	}
 
 	// 重複した場所を削除
-	var placesSearchedFiltered []models.GooglePlace
-	for _, place := range placesSearched {
-		isAlreadyAdded := false
-		for _, placeFiltered := range placesSearchedFiltered {
-			if place.PlaceId == placeFiltered.PlaceId {
-				isAlreadyAdded = true
-				break
-			}
-		}
-
-		if !isAlreadyAdded {
-			placesSearchedFiltered = append(placesSearchedFiltered, place)
-		}
-	}
+	placesSearchedFiltered := array.DistinctBy(placesSearched, func(place models.GooglePlace) string {
+		return place.PlaceId
+	})
 
 	return placesSearchedFiltered, nil
 }

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -53,7 +53,7 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 
 	// キャッシュされた検索結果を取得
 	// TODO: カテゴリごとに検索範囲を指定して取得できるようにする
-	placesSaved, err := s.placeRepository.FindByLocation(ctx, input.Location)
+	placesSaved, err := s.placeRepository.FindByLocation(ctx, input.Location, input.FilterSearchResultRadius)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places from location: %w", err)
 	}

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -22,9 +22,15 @@ type SearchNearbyPlacesInput struct {
 }
 
 // placeTypeWithCondition 検索する必要のあるカテゴリを表す
+//
 // searchRange Nearby Search時の検索範囲（水族館等の施設の数が少ない場所を探すときは広い範囲を探す）
+// この距離を指定すればぴったり20件取得できるという値を指定している(検索できる最大サイズは50kmまで)
+//
 // filterRange 周囲にあるかどうかを確認するときの検索範囲 (カフェ等の施設の数が多い場所を探すときは狭い範囲を探す)
+// 最低限この範囲にはあるはずという値を指定している
+//
 // ignorePlaceCount あるカテゴリの場所がこの数以上ある場合は、そのカテゴリの検索は行わない
+// このくらいはありそうという値を指定している
 type placeTypeWithCondition struct {
 	placeType        maps.PlaceType
 	searchRange      uint
@@ -166,11 +172,6 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 }
 
 func (s Service) placeTypesToSearch() []placeTypeWithCondition {
-	// そのカテゴリの場所が filterRange で指定している範囲の中に
-	// searchRange には、この距離を指定すればぴったり20件取得できるという値を指定している
-	// filterRange には最低限この範囲にはあるはずという値を指定している
-	// このくらいはありそうという値を ignorePlaceCount に指定している
-	// また、検索できる最大サイズは50kmまで
 	return []placeTypeWithCondition{
 		// 付近になければ、一度も検索していないことを怪しむレベル
 		{

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -12,15 +12,13 @@ import (
 	googleplaces "poroto.app/poroto/planner/internal/infrastructure/api/google/places"
 )
 
-// NearbySearchRadius NearbySearch で検索する際の半径
-// FilterSearchResultRadius 検索結果をフィルタリングするときの半径
+// nearbySearchRadius すでに保存された場所から近くにある場所を検索するときの検索範囲
 const (
-	NearbySearchRadius = 5 * 1000
+	nearbySearchRadius = 5 * 1000
 )
 
 type SearchNearbyPlacesInput struct {
 	Location models.GeoLocation
-	Radius   uint
 }
 
 // placeTypeWithCondition 検索する必要のあるカテゴリを表す
@@ -41,12 +39,8 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 		panic("location is not specified")
 	}
 
-	if input.Radius == 0 {
-		input.Radius = NearbySearchRadius
-	}
-
 	// キャッシュされた検索結果を取得
-	placesSaved, err := s.placeRepository.FindByLocation(ctx, input.Location, float64(input.Radius))
+	placesSaved, err := s.placeRepository.FindByLocation(ctx, input.Location, float64(nearbySearchRadius))
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places from location: %w", err)
 	}

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -188,20 +188,20 @@ func (s Service) placeTypesToSearch() []placeTypeWithCondition {
 		{
 			placeType:        maps.PlaceTypeCafe,
 			searchRange:      3 * 1000,
-			filterRange:      1 * 1000,
-			ignorePlaceCount: 1,
+			filterRange:      3 * 1000,
+			ignorePlaceCount: 5,
 		},
 		{
 			placeType:        maps.PlaceTypeRestaurant,
 			searchRange:      3 * 1000,
-			filterRange:      1 * 1000,
-			ignorePlaceCount: 1,
+			filterRange:      3 * 1000,
+			ignorePlaceCount: 5,
 		},
 		{
 			placeType:        maps.PlaceTypeBakery,
 			searchRange:      3 * 1000,
-			filterRange:      1 * 1000,
-			ignorePlaceCount: 1,
+			filterRange:      5 * 1000,
+			ignorePlaceCount: 3,
 		},
 		{
 			placeType:        maps.PlaceTypeTouristAttraction,

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -284,7 +284,7 @@ func (p PlaceRepository) FindByLocation(ctx context.Context, location models.Geo
 	return places, nil
 }
 
-func (p PlaceRepository) FindByCategory(ctx context.Context, category models.LocationCategory, baseLocation models.GeoLocation, radius float64) (*[]models.Place, error) {
+func (p PlaceRepository) FindByGooglePlaceType(ctx context.Context, googlePlaceType string, baseLocation models.GeoLocation, radius float64) (*[]models.Place, error) {
 	googlePlaceEntities, err := generated.GooglePlaces(
 		qm.InnerJoin(fmt.Sprintf(
 			"%s on %s.%s = %s.%s",
@@ -294,10 +294,7 @@ func (p PlaceRepository) FindByCategory(ctx context.Context, category models.Loc
 			generated.TableNames.GooglePlaces,
 			generated.GooglePlaceColumns.GooglePlaceID,
 		)),
-		qm.WhereIn(
-			fmt.Sprintf("%s.%s in ?", generated.TableNames.GooglePlaceTypes, generated.GooglePlaceTypeColumns.Type),
-			toInterfaceArray(category.SubCategories)...,
-		),
+		qm.Where(fmt.Sprintf("%s.%s = ?", generated.TableNames.GooglePlaceTypes, generated.GooglePlaceTypeColumns.Type), googlePlaceType),
 		qm.Where("ST_Distance_Sphere(POINT(?, ?), location) < ?", baseLocation.Longitude, baseLocation.Latitude, radius),
 		qm.Load(generated.GooglePlaceRels.Place),
 		qm.Load(generated.GooglePlaceRels.GooglePlaceTypes),

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -599,7 +599,7 @@ func countPlaceLikeCounts(ctx context.Context, exec boil.ContextExecutor, placeI
 		qm.From(generated.TableNames.PlanCandidateSetLikePlaces),
 		qm.WhereIn(
 			fmt.Sprintf("%s IN ?", generated.PlanCandidateSetLikePlaceColumns.PlaceID),
-			array.Map(placeIds, func(placeId string) interface{} { return placeId })...,
+			toInterfaceArray(placeIds)...,
 		),
 		qm.GroupBy(generated.PlanCandidateSetLikePlaceTableColumns.PlaceID),
 	).Bind(ctx, exec, &planCandidateSetPlaceLikeCounts); err != nil {

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -16,10 +16,6 @@ import (
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
 )
 
-const (
-	defaultMaxDistance = 1000 * 5
-)
-
 type PlaceRepository struct {
 	db     *sql.DB
 	logger zap.Logger
@@ -232,9 +228,9 @@ func (p PlaceRepository) SavePlacesFromGooglePlaces(ctx context.Context, googleP
 	return &places, nil
 }
 
-func (p PlaceRepository) FindByLocation(ctx context.Context, location models.GeoLocation) ([]models.Place, error) {
+func (p PlaceRepository) FindByLocation(ctx context.Context, location models.GeoLocation, radius float64) ([]models.Place, error) {
 	googlePlaceEntities, err := generated.GooglePlaces(
-		qm.Where("ST_Distance_Sphere(POINT(?, ?), location) < ?", location.Longitude, location.Latitude, defaultMaxDistance),
+		qm.Where("ST_Distance_Sphere(POINT(?, ?), location) < ?", location.Longitude, location.Latitude, radius),
 		qm.Load(generated.GooglePlaceRels.Place),
 		qm.Load(generated.GooglePlaceRels.GooglePlaceTypes),
 		qm.Load(generated.GooglePlaceRels.GooglePlacePhotoReferences),

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -605,12 +605,12 @@ func TestPlaceRepository_SavePlacesFromGooglePlace_DuplicatedValue(t *testing.T)
 
 func TestPlaceRepository_FindByCategory(t *testing.T) {
 	cases := []struct {
-		name           string
-		savedPlaces    []models.Place
-		category       models.LocationCategory
-		baseLocation   models.GeoLocation
-		radius         float64
-		expectedPlaces []models.Place
+		name            string
+		savedPlaces     []models.Place
+		googlePlaceType string
+		baseLocation    models.GeoLocation
+		radius          float64
+		expectedPlaces  []models.Place
 	}{
 		{
 			name: "valid",
@@ -623,12 +623,12 @@ func TestPlaceRepository_FindByCategory(t *testing.T) {
 							Latitude:  35.692247367825,
 							Longitude: 139.703036771,
 						},
-						Types: models.CategoryShopping.SubCategories,
+						Types: []string{"book_store", "point_of_interest", "store", "establishment"},
 					},
 				},
 			},
-			category: models.CategoryShopping,
-			radius:   5000,
+			googlePlaceType: "book_store",
+			radius:          5000,
 			baseLocation: models.GeoLocation{
 				// 新宿駅
 				Latitude:  35.6896,
@@ -647,13 +647,13 @@ func TestPlaceRepository_FindByCategory(t *testing.T) {
 							Latitude:  35.692247367825,
 							Longitude: 139.703036771,
 						},
-						Types: models.CategoryShopping.SubCategories,
+						Types: []string{"book_store", "point_of_interest", "store", "establishment"},
 					},
 				},
 			},
 		},
 		{
-			name: "filter by category",
+			name: "filter by googlePlaceType",
 			savedPlaces: []models.Place{
 				{
 					Id: "kinokuniya-shoten",
@@ -663,12 +663,12 @@ func TestPlaceRepository_FindByCategory(t *testing.T) {
 							Latitude:  35.692247367825,
 							Longitude: 139.703036771,
 						},
-						Types: models.CategoryShopping.SubCategories,
+						Types: []string{"book_store", "point_of_interest", "store", "establishment"},
 					},
 				},
 			},
-			category: models.CategoryCafe,
-			radius:   5000,
+			googlePlaceType: "cafe",
+			radius:          5000,
 			baseLocation: models.GeoLocation{
 				// 新宿駅
 				Latitude:  35.6896,
@@ -687,12 +687,12 @@ func TestPlaceRepository_FindByCategory(t *testing.T) {
 							Latitude:  35.692247367825,
 							Longitude: 139.703036771,
 						},
-						Types: models.CategoryShopping.SubCategories,
+						Types: []string{"book_store", "point_of_interest", "store", "establishment"},
 					},
 				},
 			},
-			category: models.CategoryShopping,
-			radius:   1000,
+			googlePlaceType: "book_store",
+			radius:          1000,
 			baseLocation: models.GeoLocation{
 				// 代々木上原駅
 				Latitude:  35.669017114155,
@@ -722,7 +722,7 @@ func TestPlaceRepository_FindByCategory(t *testing.T) {
 				t.Fatalf("error while saving places: %v", err)
 			}
 
-			actualPlaces, err := placeRepository.FindByCategory(testContext, c.category, c.baseLocation, c.radius)
+			actualPlaces, err := placeRepository.FindByGooglePlaceType(testContext, c.googlePlaceType, c.baseLocation, c.radius)
 			if err != nil {
 				t.Fatalf("error while finding places: %v", err)
 			}

--- a/internal/infrastructure/rdb/query_mods.go
+++ b/internal/infrastructure/rdb/query_mods.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 )
 
+func toInterfaceArray[T any](arr []T) []interface{} {
+	var result []interface{}
+	for _, a := range arr {
+		result = append(result, a)
+	}
+	return result
+}
+
 func concatQueryMod(qms ...[]qm.QueryMod) []qm.QueryMod {
 	return array.Flatten(qms)
 }


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- NearbySearchをする前にキャッシュを確認する処理内で、カテゴリごとに検索範囲を指定している。
- このときにDBに保存されたキャッシュを取得するときに、カテゴリと距離を指定して検索できるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 単純に付近にお店がない場合にNearbySearchが走ってしまうため
- 検索範囲を広めに持つことで余分なAPI呼び出しがされないようにした

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/place_repository_find_by_category
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```