### PR TITLE
プラン取得時に作成者のデータを取得できるようにする

### DIFF
--- a/internal/domain/models/plan.go
+++ b/internal/domain/models/plan.go
@@ -5,10 +5,10 @@ import (
 )
 
 type Plan struct {
-	Id       string  `json:"id"`
-	Name     string  `json:"name"`
-	Places   []Place `json:"places"`
-	AuthorId *string `json:"author_id"`
+	Id     string  `json:"id"`
+	Name   string  `json:"name"`
+	Places []Place `json:"places"`
+	Author *User   `json:"author"`
 }
 
 // GetPlace 指定したIDの場所情報を取得する

--- a/internal/domain/services/plan/save.go
+++ b/internal/domain/services/plan/save.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/array"
-	"poroto.app/poroto/planner/internal/domain/utils"
 	"time"
 
 	"poroto.app/poroto/planner/internal/domain/models"
@@ -57,7 +56,7 @@ func (s Service) SavePlanFromPlanCandidate(ctx context.Context, planCandidateId 
 			return nil, fmt.Errorf("user not found")
 		}
 
-		planToSave.AuthorId = utils.StrPointer(user.Id)
+		planToSave.Author = user
 	}
 
 	// プランを保存

--- a/internal/infrastructure/rdb/factory/plan.go
+++ b/internal/infrastructure/rdb/factory/plan.go
@@ -11,9 +11,15 @@ func NewPlanEntityFromDomainModel(plan models.Plan) generated.Plan {
 	if plan.Id == "" {
 		plan.Id = uuid.New().String()
 	}
+
+	var userId *string
+	if plan.Author != nil {
+		userId = &plan.Author.Id
+	}
+
 	return generated.Plan{
 		ID:     plan.Id,
-		UserID: null.StringFromPtr(plan.AuthorId),
+		UserID: null.StringFromPtr(userId),
 		Name:   plan.Name,
 	}
 }
@@ -29,9 +35,9 @@ func NewPlanFromEntity(
 	}
 
 	return &models.Plan{
-		Id:       planEntity.ID,
-		Name:     planEntity.Name,
-		AuthorId: planEntity.UserID.Ptr(),
-		Places:   *planPlaces,
+		Id:   planEntity.ID,
+		Name: planEntity.Name,
+		// TODO: ユーザー情報を取得する
+		Places: *planPlaces,
 	}, nil
 }

--- a/internal/infrastructure/rdb/factory/plan.go
+++ b/internal/infrastructure/rdb/factory/plan.go
@@ -28,6 +28,7 @@ func NewPlanFromEntity(
 	planEntity generated.Plan,
 	planPlaceSlice generated.PlanPlaceSlice,
 	places []models.Place,
+	author *models.User,
 ) (*models.Plan, error) {
 	planPlaces, err := NewPlanPlacesFromEntities(planPlaceSlice, places, planEntity.ID)
 	if err != nil {
@@ -35,9 +36,9 @@ func NewPlanFromEntity(
 	}
 
 	return &models.Plan{
-		Id:   planEntity.ID,
-		Name: planEntity.Name,
-		// TODO: ユーザー情報を取得する
+		Id:     planEntity.ID,
+		Name:   planEntity.Name,
 		Places: *planPlaces,
+		Author: author,
 	}, nil
 }

--- a/internal/infrastructure/rdb/factory/plan_candidate.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate.go
@@ -23,6 +23,7 @@ func NewPlanCandidatesFromEntities(
 	planCandidatePlaces generated.PlanCandidatePlaceSlice,
 	planCandidateSetId string,
 	places []models.Place,
+	author *models.User,
 ) (*[]models.Plan, error) {
 	planCandidateEntities := array.MapAndFilter(planCandidateSlice, func(planCandidate *generated.PlanCandidate) (generated.PlanCandidate, bool) {
 		if planCandidate == nil {
@@ -42,7 +43,7 @@ func NewPlanCandidatesFromEntities(
 	})
 
 	plans, err := array.MapWithErr(planCandidateEntitiesOrdered, func(planCandidateEntity generated.PlanCandidate) (*models.Plan, error) {
-		plan, err := NewPlanCandidateFromEntity(planCandidateEntity, planCandidatePlaces, places)
+		plan, err := NewPlanCandidateFromEntity(planCandidateEntity, planCandidatePlaces, places, author)
 		if err != nil {
 			return nil, err
 		}
@@ -61,6 +62,7 @@ func NewPlanCandidateFromEntity(
 	planCandidateEntity generated.PlanCandidate,
 	planCandidatePlaces generated.PlanCandidatePlaceSlice,
 	places []models.Place,
+	author *models.User,
 ) (*models.Plan, error) {
 	planCandidateEntities := array.MapAndFilter(planCandidatePlaces, func(planCandidatePlace *generated.PlanCandidatePlace) (generated.PlanCandidatePlace, bool) {
 		if planCandidatePlace == nil {
@@ -97,6 +99,6 @@ func NewPlanCandidateFromEntity(
 		Id:     planCandidateEntity.ID,
 		Name:   planCandidateEntity.Name,
 		Places: *placesOrdered,
-		// TODO: ユーザー情報を取得する
+		Author: author,
 	}, nil
 }

--- a/internal/infrastructure/rdb/factory/plan_candidate.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate.go
@@ -94,9 +94,9 @@ func NewPlanCandidateFromEntity(
 	}
 
 	return &models.Plan{
-		Id:       planCandidateEntity.ID,
-		Name:     planCandidateEntity.Name,
-		Places:   *placesOrdered,
-		AuthorId: nil, // TODO: implement me
+		Id:     planCandidateEntity.ID,
+		Name:   planCandidateEntity.Name,
+		Places: *placesOrdered,
+		// TODO: ユーザー情報を取得する
 	}, nil
 }

--- a/internal/infrastructure/rdb/factory/plan_candidate_set.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate_set.go
@@ -16,6 +16,7 @@ func NewPlanCandidateSetFromEntity(
 	planCandidatePlaces generated.PlanCandidatePlaceSlice,
 	planCandidateSetLikePlaceSlice generated.PlanCandidateSetLikePlaceSlice,
 	places []models.Place,
+	author *models.User,
 ) (*models.PlanCandidate, error) {
 	planCandidateSetMetaData, err := NewPlanCandidateMetaDataFromEntity(planCandidateSetMetaDataSlice, planCandidateSetCategorySlice, planCandidateSetEntity.ID)
 	if err != nil {
@@ -35,6 +36,7 @@ func NewPlanCandidateSetFromEntity(
 		planCandidatePlaces,
 		planCandidateSetEntity.ID,
 		places,
+		author,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/infrastructure/rdb/factory/plan_test.go
+++ b/internal/infrastructure/rdb/factory/plan_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/volatiletech/null/v8"
 	"poroto.app/poroto/planner/internal/domain/models"
-	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
 	"testing"
 )
@@ -18,13 +17,16 @@ func TestNewPlanEntityFromDomainModel(t *testing.T) {
 		{
 			name: "should return a valid entity",
 			plan: models.Plan{
-				Id:       "ec7c607d-454a-4644-929a-c3b1e078842d",
-				AuthorId: utils.ToPointer("339809cf-d515-4a64-bbcd-c6a899051273"),
-				Name:     "plan title",
+				Id: "ec7c607d-454a-4644-929a-c3b1e078842d",
+				Author: &models.User{
+					Id:          "28a52fdd-c252-4e32-a918-fcab5ed88ad8",
+					FirebaseUID: "firebase-test-user",
+				},
+				Name: "plan title",
 			},
 			expected: generated.Plan{
 				ID:     "ec7c607d-454a-4644-929a-c3b1e078842d",
-				UserID: null.StringFrom("339809cf-d515-4a64-bbcd-c6a899051273"),
+				UserID: null.StringFrom("28a52fdd-c252-4e32-a918-fcab5ed88ad8"),
 				Name:   "plan title",
 			},
 		},
@@ -49,9 +51,12 @@ func TestNewPlanEntityFromDomainModel_EmptyID(t *testing.T) {
 		{
 			name: "should generate valid id if id is empty",
 			plan: models.Plan{
-				Id:       "",
-				AuthorId: utils.ToPointer("339809cf-d515-4a64-bbcd-c6a899051273"),
-				Name:     "plan title",
+				Id: "",
+				Author: &models.User{
+					Id:          "339809cf-d515-4a64-bbcd-c6a899051273",
+					FirebaseUID: "firebase-test-user",
+				},
+				Name: "plan title",
 			},
 		},
 	}
@@ -74,6 +79,7 @@ func TestNewPlanFromEntity(t *testing.T) {
 		planEntity     generated.Plan
 		planPlaceSlice generated.PlanPlaceSlice
 		places         []models.Place
+		author         *models.User
 		expected       *models.Plan
 	}{
 		{
@@ -99,10 +105,17 @@ func TestNewPlanFromEntity(t *testing.T) {
 				{Id: "ec7c607d-454a-4644-929a-c3b1e078842d"},
 				{Id: "339809cf-d515-4a64-bbcd-c6a899051273"},
 			},
+			author: &models.User{
+				Id:          "339809cf-d515-4a64-bbcd-c6a899051273",
+				FirebaseUID: "firebase-test-user",
+			},
 			expected: &models.Plan{
-				Id:       "ec7c607d-454a-4644-929a-c3b1e078842d",
-				Name:     "plan title",
-				AuthorId: utils.ToPointer("339809cf-d515-4a64-bbcd-c6a899051273"),
+				Id:   "ec7c607d-454a-4644-929a-c3b1e078842d",
+				Name: "plan title",
+				Author: &models.User{
+					Id:          "339809cf-d515-4a64-bbcd-c6a899051273",
+					FirebaseUID: "firebase-test-user",
+				},
 				Places: []models.Place{
 					{Id: "339809cf-d515-4a64-bbcd-c6a899051273"},
 					{Id: "ec7c607d-454a-4644-929a-c3b1e078842d"},
@@ -115,7 +128,7 @@ func TestNewPlanFromEntity(t *testing.T) {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			actual, err := NewPlanFromEntity(c.planEntity, c.planPlaceSlice, c.places)
+			actual, err := NewPlanFromEntity(c.planEntity, c.planPlaceSlice, c.places, c.author)
 			if err != nil {
 				t.Errorf("error should be nil, got: %v", err)
 			}

--- a/internal/infrastructure/rdb/factory/user.go
+++ b/internal/infrastructure/rdb/factory/user.go
@@ -17,7 +17,7 @@ func NewUserEntityFromUser(user models.User) generated.User {
 	}
 }
 
-func NewUserFromUserEntity(userEntity *generated.User) *models.User {
+func NewUserFromUserEntity(userEntity generated.User) *models.User {
 	return &models.User{
 		Id:          userEntity.ID,
 		FirebaseUID: userEntity.FirebaseUID,

--- a/internal/infrastructure/rdb/mock_test.go
+++ b/internal/infrastructure/rdb/mock_test.go
@@ -97,18 +97,6 @@ func savePlaces(ctx context.Context, db *sql.DB, places []models.Place) error {
 	return nil
 }
 
-func saveUsers(ctx context.Context, db *sql.DB, users []models.User) error {
-	for _, user := range users {
-		userEntity := generated.User{
-			ID: user.Id,
-		}
-		if err := userEntity.Insert(ctx, db, boil.Infer()); err != nil {
-			return fmt.Errorf("failed to insert user: %v", err)
-		}
-	}
-	return nil
-}
-
 func savePlans(ctx context.Context, db *sql.DB, plans []models.Plan) error {
 	for _, plan := range plans {
 		planEntity := factory.NewPlanEntityFromDomainModel(plan)

--- a/internal/infrastructure/rdb/plan.go
+++ b/internal/infrastructure/rdb/plan.go
@@ -100,6 +100,7 @@ func (p PlanRepository) SortedByCreatedAt(ctx context.Context, queryCursor *repo
 		qm.Load(generated.PlanRels.PlanPlaces),
 		qm.OrderBy(fmt.Sprintf("%s %s, %s %s", generated.PlanColumns.CreatedAt, "desc", generated.PlanColumns.ID, "desc")),
 		qm.Limit(limit),
+		qm.Load(generated.PlanRels.User),
 	}
 
 	if queryCursor != nil {
@@ -171,10 +172,16 @@ func (p PlanRepository) SortedByCreatedAt(ctx context.Context, queryCursor *repo
 	}
 
 	plans, err := array.MapWithErr(planEntities, func(planEntity *generated.Plan) (*models.Plan, error) {
+		var author *models.User
+		if planEntity.R.User != nil {
+			author = factory.NewUserFromUserEntity(*planEntity.R.User)
+		}
+
 		return factory.NewPlanFromEntity(
 			*planEntity,
 			planEntity.R.PlanPlaces,
 			array.Flatten(*places),
+			author,
 		)
 	})
 	if err != nil {
@@ -195,6 +202,7 @@ func (p PlanRepository) Find(ctx context.Context, planId string) (*models.Plan, 
 		[]qm.QueryMod{
 			generated.PlanWhere.ID.EQ(planId),
 			qm.Load(generated.PlanRels.PlanPlaces),
+			qm.Load(generated.PlanRels.User),
 		},
 		placeQueryModes(generated.PlanRels.PlanPlaces, generated.PlanPlaceRels.Place),
 	)...).One(ctx, p.db)
@@ -243,10 +251,16 @@ func (p PlanRepository) Find(ctx context.Context, planId string) (*models.Plan, 
 		return nil, fmt.Errorf("failed to map plan places: %w", err)
 	}
 
+	var author *models.User
+	if planEntity.R.User != nil {
+		author = factory.NewUserFromUserEntity(*planEntity.R.User)
+	}
+
 	plan, err := factory.NewPlanFromEntity(
 		*planEntity,
 		planEntity.R.PlanPlaces,
 		*places,
+		author,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map plan: %w", err)
@@ -261,6 +275,7 @@ func (p PlanRepository) FindByAuthorId(ctx context.Context, authorId string) (*[
 			generated.PlanWhere.UserID.EQ(null.StringFrom(authorId)),
 			qm.Load(generated.PlanRels.PlanPlaces),
 			qm.OrderBy(fmt.Sprintf("%s %s", generated.PlanColumns.CreatedAt, "desc")),
+			qm.Load(generated.PlanRels.User),
 		},
 		placeQueryModes(generated.PlanRels.PlanPlaces, generated.PlanPlaceRels.Place),
 	)...).All(ctx, p.db)
@@ -320,10 +335,16 @@ func (p PlanRepository) FindByAuthorId(ctx context.Context, authorId string) (*[
 	}
 
 	plans, err := array.MapWithErr(planEntities, func(planEntity *generated.Plan) (*models.Plan, error) {
+		var author *models.User
+		if planEntity.R.User != nil {
+			author = factory.NewUserFromUserEntity(*planEntity.R.User)
+		}
+
 		return factory.NewPlanFromEntity(
 			*planEntity,
 			planEntity.R.PlanPlaces,
 			array.Flatten(*places),
+			author,
 		)
 	})
 	if err != nil {
@@ -349,6 +370,7 @@ func (p PlanRepository) SortedByLocation(ctx context.Context, location models.Ge
 			qm.OrderBy(fmt.Sprintf("%s %s", generated.PlanColumns.CreatedAt, "desc")),
 			qm.Limit(limit),
 			qm.Load(generated.PlanRels.PlanPlaces),
+			qm.Load(generated.PlanRels.User),
 		},
 		placeQueryModes(generated.PlanRels.PlanPlaces, generated.PlanPlaceRels.Place),
 	)...).All(ctx, p.db)
@@ -408,10 +430,16 @@ func (p PlanRepository) SortedByLocation(ctx context.Context, location models.Ge
 	}
 
 	plans, err := array.MapWithErr(planEntities, func(planEntity *generated.Plan) (*models.Plan, error) {
+		var author *models.User
+		if planEntity.R.User != nil {
+			author = factory.NewUserFromUserEntity(*planEntity.R.User)
+		}
+
 		return factory.NewPlanFromEntity(
 			*planEntity,
 			planEntity.R.PlanPlaces,
 			array.Flatten(*places),
+			author,
 		)
 	})
 	if err != nil {

--- a/internal/infrastructure/rdb/plan_candidate.go
+++ b/internal/infrastructure/rdb/plan_candidate.go
@@ -127,6 +127,7 @@ func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateId strin
 		planCandidateSetEntity.R.PlanCandidatePlaces,
 		planCandidateSetEntity.R.PlanCandidateSetLikePlaces,
 		places,
+		nil, // TODO: ユーザー情報を取得できるようにする
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plan candidate: %w", err)
@@ -196,7 +197,8 @@ func (p PlanCandidateRepository) FindPlan(ctx context.Context, planCandidateId s
 		places = append(places, *place)
 	}
 
-	plan, err := factory.NewPlanCandidateFromEntity(*planCandidate, planCandidate.R.PlanCandidatePlaces, places)
+	// TODO: ユーザー情報を取得できるようにする
+	plan, err := factory.NewPlanCandidateFromEntity(*planCandidate, planCandidate.R.PlanCandidatePlaces, places, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plan candidate: %w", err)
 	}

--- a/internal/infrastructure/rdb/plan_test.go
+++ b/internal/infrastructure/rdb/plan_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 	"poroto.app/poroto/planner/internal/domain/models"
@@ -31,9 +32,8 @@ func TestPlanRepository_Save(t *testing.T) {
 				},
 			},
 			plan: models.Plan{
-				Id:       uuid.New().String(),
-				Name:     "plan title",
-				AuthorId: nil,
+				Id:   uuid.New().String(),
+				Name: "plan title",
 				Places: []models.Place{
 					{
 						Id: "f2c98d68-3904-455b-8832-a0f723a96735",
@@ -105,12 +105,19 @@ func TestPlanRepository_Save(t *testing.T) {
 func TestPlanRepository_Find(t *testing.T) {
 	cases := []struct {
 		name        string
+		savedUsers  generated.UserSlice
 		savedPlaces []models.Place
 		savedPlan   models.Plan
 		expected    models.Plan
 	}{
 		{
 			name: "should find plan",
+			savedUsers: generated.UserSlice{
+				{
+					ID:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					FirebaseUID: "firebase_uid_1",
+				},
+			},
 			savedPlaces: []models.Place{
 				{
 					Id: "f2c98d68-3904-455b-8832-a0f723a96735",
@@ -132,6 +139,10 @@ func TestPlanRepository_Find(t *testing.T) {
 					{Id: "f2c98d68-3904-455b-8832-a0f723a96735"},
 					{Id: "c61a8b42-2c07-4957-913d-6930f0d881ec"},
 				},
+				Author: &models.User{
+					Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					FirebaseUID: "firebase_uid_1",
+				},
 			},
 			expected: models.Plan{
 				Id:   "f2c98d68-3904-455b-8832-a0f723a96735",
@@ -149,6 +160,10 @@ func TestPlanRepository_Find(t *testing.T) {
 							PlaceId: "CwVXAAAAQwXg3w8QKxQZ6Q0X3Z4",
 						},
 					},
+				},
+				Author: &models.User{
+					Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					FirebaseUID: "firebase_uid_1",
 				},
 			},
 		},
@@ -182,6 +197,11 @@ func TestPlanRepository_Find(t *testing.T) {
 				}
 			})
 
+			// 事前に User を保存
+			if _, err := c.savedUsers.InsertAll(textContext, planRepository.GetDB(), boil.Infer()); err != nil {
+				t.Errorf("error saving user: %v", err)
+			}
+
 			// 事前に Place を保存
 			if err := savePlaces(textContext, planRepository.GetDB(), c.savedPlaces); err != nil {
 				t.Errorf("error saving places: %v", err)
@@ -207,15 +227,20 @@ func TestPlanRepository_Find(t *testing.T) {
 func TestPlanRepository_FindByAuthorId(t *testing.T) {
 	cases := []struct {
 		name        string
-		savedUser   models.User
+		savedUsers  generated.UserSlice
 		savedPlaces []models.Place
 		savedPlans  []models.Plan
 		authorId    string
 		expected    []models.Plan
 	}{
 		{
-			name:      "should find plans by author id",
-			savedUser: models.User{Id: "c61a8b42-2c07-4957-913d-6930f0d881ec"},
+			name: "should find plans by author id",
+			savedUsers: generated.UserSlice{
+				{
+					ID:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					FirebaseUID: "firebase_uid_1",
+				},
+			},
 			savedPlaces: []models.Place{
 				{
 					Id:     "f2c98d68-3904-455b-8832-a0f723a96735",
@@ -236,30 +261,35 @@ func TestPlanRepository_FindByAuthorId(t *testing.T) {
 			},
 			savedPlans: []models.Plan{
 				{
-					Id:       "f2c98d68-3904-455b-8832-a0f723a96735",
-					AuthorId: toPointer("c61a8b42-2c07-4957-913d-6930f0d881ec"),
-					Name:     "plan title 1",
+					Id:   "f2c98d68-3904-455b-8832-a0f723a96735",
+					Name: "plan title 1",
 					Places: []models.Place{
 						{Id: "f2c98d68-3904-455b-8832-a0f723a96735"},
 						{Id: "c61a8b42-2c07-4957-913d-6930f0d881ec"},
 					},
+					Author: &models.User{
+						Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+						FirebaseUID: "firebase_uid_1",
+					},
 				},
 				{
-					Id:       "c61a8b42-2c07-4957-913d-6930f0d881ec",
-					AuthorId: toPointer("c61a8b42-2c07-4957-913d-6930f0d881ec"),
-					Name:     "plan title 2",
+					Id:   "c61a8b42-2c07-4957-913d-6930f0d881ec",
+					Name: "plan title 2",
 					Places: []models.Place{
 						{Id: "82cc1884-ac59-11ee-a506-0242ac120002"},
 						{Id: "c72a3614-ac59-11ee-a506-0242ac120002"},
 					},
+					Author: &models.User{
+						Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+						FirebaseUID: "firebase_uid_1",
+					},
 				},
 			},
-			authorId: "c61a8b42-2c07-4957-913d-6930f0d881ec",
+			authorId: "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
 			expected: []models.Plan{
 				{
-					Id:       "f2c98d68-3904-455b-8832-a0f723a96735",
-					AuthorId: toPointer("c61a8b42-2c07-4957-913d-6930f0d881ec"),
-					Name:     "plan title 1",
+					Id:   "f2c98d68-3904-455b-8832-a0f723a96735",
+					Name: "plan title 1",
 					Places: []models.Place{
 						{
 							Id:     "f2c98d68-3904-455b-8832-a0f723a96735",
@@ -270,11 +300,14 @@ func TestPlanRepository_FindByAuthorId(t *testing.T) {
 							Google: models.GooglePlace{PlaceId: "CwVXAAAAQwXg3w8QKxQZ6Q0X3Z4"},
 						},
 					},
+					Author: &models.User{
+						Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+						FirebaseUID: "firebase_uid_1",
+					},
 				},
 				{
-					Id:       "c61a8b42-2c07-4957-913d-6930f0d881ec",
-					AuthorId: toPointer("c61a8b42-2c07-4957-913d-6930f0d881ec"),
-					Name:     "plan title 2",
+					Id:   "c61a8b42-2c07-4957-913d-6930f0d881ec",
+					Name: "plan title 2",
 					Places: []models.Place{
 						{
 							Id:     "82cc1884-ac59-11ee-a506-0242ac120002",
@@ -285,8 +318,38 @@ func TestPlanRepository_FindByAuthorId(t *testing.T) {
 							Google: models.GooglePlace{PlaceId: "ChQFzO1BvHaLJXCyWVZ8Uie3smn2wQ"},
 						},
 					},
+					Author: &models.User{
+						Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+						FirebaseUID: "firebase_uid_1",
+					},
 				},
 			},
+		},
+		{
+			name: "should not find plans by author id",
+			savedUsers: generated.UserSlice{
+				{
+					ID:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					FirebaseUID: "firebase_uid_1",
+				},
+			},
+			savedPlaces: []models.Place{
+				{
+					Id:     "f2c98d68-3904-455b-8832-a0f723a96735",
+					Google: models.GooglePlace{PlaceId: "ChIJN1t_tDeuEmsRUsoyG83frY4"},
+				},
+			},
+			savedPlans: []models.Plan{
+				{
+					Id:   "f2c98d68-3904-455b-8832-a0f723a96735",
+					Name: "plan title 1",
+					Places: []models.Place{
+						{Id: "f2c98d68-3904-455b-8832-a0f723a96735"},
+					},
+				},
+			},
+			authorId: "28a52fdd-c252-4e32-a918-fcab5ed88ad8",
+			expected: []models.Plan{},
 		},
 	}
 
@@ -311,7 +374,7 @@ func TestPlanRepository_FindByAuthorId(t *testing.T) {
 			}
 
 			// 事前に User を保存
-			if err := saveUsers(textContext, planRepository.GetDB(), []models.User{c.savedUser}); err != nil {
+			if _, err := c.savedUsers.InsertAll(textContext, planRepository.GetDB(), boil.Infer()); err != nil {
 				t.Errorf("error saving user: %v", err)
 			}
 
@@ -342,6 +405,7 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 		savedPlanSlice      generated.PlanSlice
 		savedPlanPlaceSlice generated.PlanPlaceSlice
 		savedPlaces         []models.Place
+		savedUsers          generated.UserSlice
 		queryCursor         *repository.SortedByCreatedAtQueryCursor
 		limit               int
 		expected            []models.Plan
@@ -362,12 +426,24 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 				{
 					ID:        "f2c98d68-3904-455b-8832-a0f723a96735",
 					Name:      "plan title 1",
+					UserID:    null.StringFrom("8fde8eff-4b18-4276-b71f-2fec30ea65c8"),
 					CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					ID:        "c61a8b42-2c07-4957-913d-6930f0d881ec",
 					Name:      "plan title 2",
+					UserID:    null.StringFrom("28a52fdd-c252-4e32-a918-fcab5ed88ad8"),
 					CreatedAt: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			savedUsers: generated.UserSlice{
+				{
+					ID:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					FirebaseUID: "firebase_uid_1",
+				},
+				{
+					ID:          "28a52fdd-c252-4e32-a918-fcab5ed88ad8",
+					FirebaseUID: "firebase_uid_2",
 				},
 			},
 			savedPlanPlaceSlice: generated.PlanPlaceSlice{
@@ -396,6 +472,10 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 							Google: models.GooglePlace{PlaceId: "CwVXAAAAQwXg3w8QKxQZ6Q0X3Z4"},
 						},
 					},
+					Author: &models.User{
+						Id:          "28a52fdd-c252-4e32-a918-fcab5ed88ad8",
+						FirebaseUID: "firebase_uid_2",
+					},
 				},
 				{
 					Id:   "f2c98d68-3904-455b-8832-a0f723a96735",
@@ -405,6 +485,10 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 							Id:     "f2c98d68-3904-455b-8832-a0f723a96735",
 							Google: models.GooglePlace{PlaceId: "ChIJN1t_tDeuEmsRUsoyG83frY4"},
 						},
+					},
+					Author: &models.User{
+						Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+						FirebaseUID: "firebase_uid_1",
 					},
 				},
 			},
@@ -452,6 +536,11 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 				}
 			})
 
+			// 事前に User を保存
+			if _, err := c.savedUsers.InsertAll(textContext, planRepository.GetDB(), boil.Infer()); err != nil {
+				t.Errorf("error saving user: %v", err)
+			}
+
 			// 事前に Place を保存
 			if err := savePlaces(textContext, planRepository.GetDB(), c.savedPlaces); err != nil {
 				t.Errorf("error saving places: %v", err)
@@ -486,6 +575,7 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 func TestPlanRepository_SortedByLocation(t *testing.T) {
 	cases := []struct {
 		name        string
+		savedUsers  generated.UserSlice
 		savedPlaces []models.Place
 		savedPlans  []models.Plan
 		location    models.GeoLocation
@@ -494,6 +584,16 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 	}{
 		{
 			name: "should find plans sorted by location",
+			savedUsers: generated.UserSlice{
+				{
+					ID:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					FirebaseUID: "firebase_uid_1",
+				},
+				{
+					ID:          "28a52fdd-c252-4e32-a918-fcab5ed88ad8",
+					FirebaseUID: "firebase_uid_2",
+				},
+			},
 			savedPlaces: []models.Place{
 				{
 					Id:   "f2c98d68-3904-455b-8832-a0f723a96735",
@@ -523,6 +623,10 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 							Location: models.GeoLocation{Latitude: 35.687684359569, Longitude: 139.70220602474},
 						},
 					},
+					Author: &models.User{
+						Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+						FirebaseUID: "firebase_uid_1",
+					},
 				},
 				{
 					Id:   "9c93c944-ac8e-11ee-a506-0242ac120003",
@@ -533,6 +637,10 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 							Name:     "札幌市時計台",
 							Location: models.GeoLocation{Latitude: 43.062558697622, Longitude: 141.35355044447},
 						},
+					},
+					Author: &models.User{
+						Id:          "28a52fdd-c252-4e32-a918-fcab5ed88ad8",
+						FirebaseUID: "firebase_uid_2",
 					},
 				},
 			},
@@ -553,6 +661,10 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 							},
 						},
 					},
+					Author: &models.User{
+						Id:          "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+						FirebaseUID: "firebase_uid_1",
+					},
 				},
 			},
 		},
@@ -571,6 +683,11 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 					t.Errorf("error cleaning up: %v", err)
 				}
 			})
+
+			// 事前に User を保存
+			if _, err := c.savedUsers.InsertAll(textContext, planRepository.GetDB(), boil.Infer()); err != nil {
+				t.Errorf("error saving user: %v", err)
+			}
 
 			// 事前に Place を保存
 			if err := savePlaces(textContext, planRepository.GetDB(), c.savedPlaces); err != nil {

--- a/internal/infrastructure/rdb/user.go
+++ b/internal/infrastructure/rdb/user.go
@@ -62,7 +62,7 @@ func (u UserRepository) Find(ctx context.Context, id string) (*models.User, erro
 		return nil, nil
 	}
 
-	return factory.NewUserFromUserEntity(userEntity), nil
+	return factory.NewUserFromUserEntity(*userEntity), nil
 }
 
 func (u UserRepository) FindByFirebaseUID(ctx context.Context, firebaseUID string) (*models.User, error) {
@@ -78,5 +78,5 @@ func (u UserRepository) FindByFirebaseUID(ctx context.Context, firebaseUID strin
 		return nil, nil
 	}
 
-	return factory.NewUserFromUserEntity(userEntity), nil
+	return factory.NewUserFromUserEntity(*userEntity), nil
 }

--- a/internal/interface/graphql/factory/plan.go
+++ b/internal/interface/graphql/factory/plan.go
@@ -53,11 +53,8 @@ func PlanFromDomainModel(plan models.Plan, startLocation *models.GeoLocation) (*
 	}
 
 	var author *graphql.User
-	if plan.AuthorId != nil {
-		// TODO: すべてのユーザーデータを取得する
-		author = &graphql.User{
-			ID: *plan.AuthorId,
-		}
+	if plan.Author != nil {
+		author = UserFromDomainModel(plan.Author)
 	}
 
 	return &graphql.Plan{


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プランを作成したユーザーの名前、プロフィール画像を取得できるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #414 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- プランの作者の情報を調べられるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] `plan`クエリで作者のデータを取得できることを確認（Postman）
- [x] `plans`クエリで作者のデータを取得できることを確認（Postman）
- [x] `planByLocation`クエリで作者のデータを取得できることを確認（Postman）
- [x] `plansByUser`クエリで作者のデータを取得できることを確認（Postman）

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```