### PR TITLE
[スキーマ変更]プランに場所を追加するときにカテゴリごとに候補となる場所を閲覧できるようにする

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -58,6 +58,11 @@ type ComplexityRoot struct {
 		Places func(childComplexity int) int
 	}
 
+	CategoryGroupedPlaces struct {
+		Category func(childComplexity int) int
+		Places   func(childComplexity int) int
+	}
+
 	ChangePlacesOrderInPlanCandidateOutput struct {
 		Plan func(childComplexity int) int
 	}
@@ -164,7 +169,8 @@ type ComplexityRoot struct {
 	}
 
 	PlacesToAddForPlanCandidateOutput struct {
-		Places func(childComplexity int) int
+		Places                  func(childComplexity int) int
+		PlacesGroupedByCategory func(childComplexity int) int
 	}
 
 	PlacesToReplaceForPlanCandidateOutput struct {
@@ -329,6 +335,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AvailablePlacesForPlan.Places(childComplexity), true
+
+	case "CategoryGroupedPlaces.category":
+		if e.complexity.CategoryGroupedPlaces.Category == nil {
+			break
+		}
+
+		return e.complexity.CategoryGroupedPlaces.Category(childComplexity), true
+
+	case "CategoryGroupedPlaces.places":
+		if e.complexity.CategoryGroupedPlaces.Places == nil {
+			break
+		}
+
+		return e.complexity.CategoryGroupedPlaces.Places(childComplexity), true
 
 	case "ChangePlacesOrderInPlanCandidateOutput.plan":
 		if e.complexity.ChangePlacesOrderInPlanCandidateOutput.Plan == nil {
@@ -790,6 +810,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PlacesToAddForPlanCandidateOutput.Places(childComplexity), true
+
+	case "PlacesToAddForPlanCandidateOutput.placesGroupedByCategory":
+		if e.complexity.PlacesToAddForPlanCandidateOutput.PlacesGroupedByCategory == nil {
+			break
+		}
+
+		return e.complexity.PlacesToAddForPlanCandidateOutput.PlacesGroupedByCategory(childComplexity), true
 
 	case "PlacesToReplaceForPlanCandidateOutput.places":
 		if e.complexity.PlacesToReplaceForPlanCandidateOutput.Places == nil {
@@ -1317,6 +1344,11 @@ type PriceRange {
 type PlaceCategory {
     id: String!
     name: String!
+}
+
+type CategoryGroupedPlaces {
+    category: PlaceCategory!
+    places: [Place!]!
 }`, BuiltIn: false},
 	{Name: "../schema/plan_candidate_mutation.graphqls", Input: `extend type Mutation {
     createPlanByLocation(input: CreatePlanByLocationInput!): CreatePlanByLocationOutput!
@@ -1521,6 +1553,7 @@ input PlacesToAddForPlanCandidateInput {
 
 type PlacesToAddForPlanCandidateOutput {
     places: [Place!]!
+    placesGroupedByCategory: [CategoryGroupedPlaces!]!
 }
 
 input PlacesToReplaceForPlanCandidateInput {
@@ -2260,6 +2293,122 @@ func (ec *executionContext) _AvailablePlacesForPlan_places(ctx context.Context, 
 func (ec *executionContext) fieldContext_AvailablePlacesForPlan_places(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AvailablePlacesForPlan",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Place_id(ctx, field)
+			case "googlePlaceId":
+				return ec.fieldContext_Place_googlePlaceId(ctx, field)
+			case "name":
+				return ec.fieldContext_Place_name(ctx, field)
+			case "location":
+				return ec.fieldContext_Place_location(ctx, field)
+			case "images":
+				return ec.fieldContext_Place_images(ctx, field)
+			case "estimatedStayDuration":
+				return ec.fieldContext_Place_estimatedStayDuration(ctx, field)
+			case "googleReviews":
+				return ec.fieldContext_Place_googleReviews(ctx, field)
+			case "categories":
+				return ec.fieldContext_Place_categories(ctx, field)
+			case "priceRange":
+				return ec.fieldContext_Place_priceRange(ctx, field)
+			case "likeCount":
+				return ec.fieldContext_Place_likeCount(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Place", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CategoryGroupedPlaces_category(ctx context.Context, field graphql.CollectedField, obj *model.CategoryGroupedPlaces) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CategoryGroupedPlaces_category(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Category, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PlaceCategory)
+	fc.Result = res
+	return ec.marshalNPlaceCategory2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlaceCategory(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CategoryGroupedPlaces_category(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CategoryGroupedPlaces",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_PlaceCategory_id(ctx, field)
+			case "name":
+				return ec.fieldContext_PlaceCategory_name(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PlaceCategory", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CategoryGroupedPlaces_places(ctx context.Context, field graphql.CollectedField, obj *model.CategoryGroupedPlaces) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CategoryGroupedPlaces_places(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Places, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Place)
+	fc.Result = res
+	return ec.marshalNPlace2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlaceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CategoryGroupedPlaces_places(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CategoryGroupedPlaces",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -5192,6 +5341,56 @@ func (ec *executionContext) fieldContext_PlacesToAddForPlanCandidateOutput_place
 	return fc, nil
 }
 
+func (ec *executionContext) _PlacesToAddForPlanCandidateOutput_placesGroupedByCategory(ctx context.Context, field graphql.CollectedField, obj *model.PlacesToAddForPlanCandidateOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlacesToAddForPlanCandidateOutput_placesGroupedByCategory(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PlacesGroupedByCategory, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CategoryGroupedPlaces)
+	fc.Result = res
+	return ec.marshalNCategoryGroupedPlaces2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCategoryGroupedPlacesᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlacesToAddForPlanCandidateOutput_placesGroupedByCategory(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlacesToAddForPlanCandidateOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "category":
+				return ec.fieldContext_CategoryGroupedPlaces_category(ctx, field)
+			case "places":
+				return ec.fieldContext_CategoryGroupedPlaces_places(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CategoryGroupedPlaces", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PlacesToReplaceForPlanCandidateOutput_places(ctx context.Context, field graphql.CollectedField, obj *model.PlacesToReplaceForPlanCandidateOutput) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PlacesToReplaceForPlanCandidateOutput_places(ctx, field)
 	if err != nil {
@@ -6608,6 +6807,8 @@ func (ec *executionContext) fieldContext_Query_placesToAddForPlanCandidate(ctx c
 			switch field.Name {
 			case "places":
 				return ec.fieldContext_PlacesToAddForPlanCandidateOutput_places(ctx, field)
+			case "placesGroupedByCategory":
+				return ec.fieldContext_PlacesToAddForPlanCandidateOutput_placesGroupedByCategory(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PlacesToAddForPlanCandidateOutput", field.Name)
 		},
@@ -10462,6 +10663,50 @@ func (ec *executionContext) _AvailablePlacesForPlan(ctx context.Context, sel ast
 	return out
 }
 
+var categoryGroupedPlacesImplementors = []string{"CategoryGroupedPlaces"}
+
+func (ec *executionContext) _CategoryGroupedPlaces(ctx context.Context, sel ast.SelectionSet, obj *model.CategoryGroupedPlaces) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, categoryGroupedPlacesImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CategoryGroupedPlaces")
+		case "category":
+			out.Values[i] = ec._CategoryGroupedPlaces_category(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "places":
+			out.Values[i] = ec._CategoryGroupedPlaces_places(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var changePlacesOrderInPlanCandidateOutputImplementors = []string{"ChangePlacesOrderInPlanCandidateOutput"}
 
 func (ec *executionContext) _ChangePlacesOrderInPlanCandidateOutput(ctx context.Context, sel ast.SelectionSet, obj *model.ChangePlacesOrderInPlanCandidateOutput) graphql.Marshaler {
@@ -11307,6 +11552,11 @@ func (ec *executionContext) _PlacesToAddForPlanCandidateOutput(ctx context.Conte
 			out.Values[i] = graphql.MarshalString("PlacesToAddForPlanCandidateOutput")
 		case "places":
 			out.Values[i] = ec._PlacesToAddForPlanCandidateOutput_places(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "placesGroupedByCategory":
+			out.Values[i] = ec._PlacesToAddForPlanCandidateOutput_placesGroupedByCategory(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -12594,6 +12844,60 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNCategoryGroupedPlaces2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCategoryGroupedPlacesᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CategoryGroupedPlaces) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNCategoryGroupedPlaces2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCategoryGroupedPlaces(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNCategoryGroupedPlaces2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCategoryGroupedPlaces(ctx context.Context, sel ast.SelectionSet, v *model.CategoryGroupedPlaces) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CategoryGroupedPlaces(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNChangePlacesOrderInPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐChangePlacesOrderInPlanCandidateInput(ctx context.Context, v interface{}) (model.ChangePlacesOrderInPlanCandidateInput, error) {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -38,6 +38,11 @@ type AvailablePlacesForPlanInput struct {
 	Session string `json:"session"`
 }
 
+type CategoryGroupedPlaces struct {
+	Category *PlaceCategory `json:"category"`
+	Places   []*Place       `json:"places"`
+}
+
 type ChangePlacesOrderInPlanCandidateInput struct {
 	Session          string   `json:"session"`
 	PlanID           string   `json:"planId"`
@@ -195,7 +200,8 @@ type PlacesToAddForPlanCandidateInput struct {
 }
 
 type PlacesToAddForPlanCandidateOutput struct {
-	Places []*Place `json:"places"`
+	Places                  []*Place                 `json:"places"`
+	PlacesGroupedByCategory []*CategoryGroupedPlaces `json:"placesGroupedByCategory"`
 }
 
 type PlacesToReplaceForPlanCandidateInput struct {

--- a/internal/interface/graphql/schema/place_type.graphqls
+++ b/internal/interface/graphql/schema/place_type.graphqls
@@ -37,3 +37,8 @@ type PlaceCategory {
     id: String!
     name: String!
 }
+
+type CategoryGroupedPlaces {
+    category: PlaceCategory!
+    places: [Place!]!
+}

--- a/internal/interface/graphql/schema/plan_candidate_query.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_query.graphqls
@@ -47,6 +47,7 @@ input PlacesToAddForPlanCandidateInput {
 
 type PlacesToAddForPlanCandidateOutput {
     places: [Place!]!
+    placesGroupedByCategory: [CategoryGroupedPlaces!]!
 }
 
 input PlacesToReplaceForPlanCandidateInput {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 複数の場所をカテゴリごとにグループ化して表示して表示できるようにスキーマを修正

![image](https://github.com/poroto-app/planner/assets/55840281/4198789f-44e5-43c3-bde9-33559ced79cb)

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 「もう飲食店を含めなくていいから別の場所を含めたい」というような状況に対応できるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/graphql_fetch_places_by_categories
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```