### PR TITLE
[スキーマ変更]画像投稿Mutationに画像サイズを指定するプロパティを追加

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1607,6 +1607,8 @@ input UploadPlacePhotoInPlanInput {
     planId: String!
     placeId: String!
     photoUrl: String!
+    width: Int!
+    height: Int!
 }
 
 type UploadPlacePhotoInPlanOutput {
@@ -10710,7 +10712,7 @@ func (ec *executionContext) unmarshalInputUploadPlacePhotoInPlanInput(ctx contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"userId", "planId", "placeId", "photoUrl"}
+	fieldsInOrder := [...]string{"userId", "planId", "placeId", "photoUrl", "width", "height"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10753,6 +10755,24 @@ func (ec *executionContext) unmarshalInputUploadPlacePhotoInPlanInput(ctx contex
 				return it, err
 			}
 			it.PhotoURL = data
+		case "width":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("width"))
+			data, err := ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Width = data
+		case "height":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("height"))
+			data, err := ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Height = data
 		}
 	}
 

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -317,6 +317,8 @@ type UploadPlacePhotoInPlanInput struct {
 	PlanID   string `json:"planId"`
 	PlaceID  string `json:"placeId"`
 	PhotoURL string `json:"photoUrl"`
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
 }
 
 type UploadPlacePhotoInPlanOutput struct {

--- a/internal/interface/graphql/schema/plan_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_mutation.graphqls
@@ -8,6 +8,8 @@ input UploadPlacePhotoInPlanInput {
     planId: String!
     placeId: String!
     photoUrl: String!
+    width: Int!
+    height: Int!
 }
 
 type UploadPlacePhotoInPlanOutput {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
画像投稿Muationの修正

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
画像サイズを固定値でなく個々に適切なサイズを指定できるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/graphql_modify_upload_photo_mutation
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```