### PR TITLE
ユーザが撮影した写真をDBに保存できるようにする

### DIFF
--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
+
 	"github.com/friendsofgo/errors"
+	"github.com/google/uuid"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
@@ -569,6 +572,32 @@ func (p PlaceRepository) SaveGooglePlaceDetail(ctx context.Context, googlePlaceI
 		return fmt.Errorf("failed to run transaction: %w", err)
 	}
 
+	return nil
+}
+
+func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, placeId string, photoUrl string) error {
+	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
+		if ok, err := generated.PlacePhotos(generated.PlacePhotoWhere.PhotoURL.EQ(photoUrl)).Exists(ctx, tx); ok && err == nil {
+			// すでに保存済みの場合はスキップ
+			return nil
+		}
+		placePhoto := generated.PlacePhoto{
+			ID:        uuid.New().String(),
+			PlaceID:   placeId,
+			UserID:    userId,
+			PhotoURL:  photoUrl,
+			Width:     2000,
+			Height:    2000,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		if err := placePhoto.Insert(ctx, tx, boil.Infer()); err != nil {
+			return fmt.Errorf("failed to insert place photo: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to run transaction: %w", err)
+	}
 	return nil
 }
 

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -54,13 +54,13 @@ func (p PlaceRepository) SavePlacesFromGooglePlaces(ctx context.Context, googleP
 		}
 
 		googlePlacesNotSaved := array.Filter(googlePlace, func(googlePlace models.GooglePlace) bool {
-			_, ok := array.Find(googlePlaceSliceSaved, func(savedGooglePlace *generated.GooglePlace) bool {
+			_, found := array.Find(googlePlaceSliceSaved, func(savedGooglePlace *generated.GooglePlace) bool {
 				if savedGooglePlace == nil {
 					return false
 				}
 				return savedGooglePlace.GooglePlaceID == googlePlace.PlaceId
 			})
-			return !ok
+			return !found
 		})
 
 		if len(googlePlacesNotSaved) == 0 {
@@ -451,13 +451,13 @@ func (p PlaceRepository) SaveGooglePlacePhotos(ctx context.Context, googlePlaceI
 
 		googlePlacePhotoSlicesNotSaved := array.MapAndFilter(photos, func(googlePlacePhoto models.GooglePlacePhoto) (*generated.GooglePlacePhotoSlice, bool) {
 			// すでに保存されている場合はスキップ
-			if _, ok := array.Find(googlePlaceEntity.R.GooglePlacePhotos, func(savedGooglePlacePhotoEntity *generated.GooglePlacePhoto) bool {
+			if _, found := array.Find(googlePlaceEntity.R.GooglePlacePhotos, func(savedGooglePlacePhotoEntity *generated.GooglePlacePhoto) bool {
 				if savedGooglePlacePhotoEntity == nil {
 					return false
 				}
 				alreadySaved := savedGooglePlacePhotoEntity.Width == googlePlacePhoto.Width && savedGooglePlacePhotoEntity.Height == googlePlacePhoto.Height
 				return alreadySaved
-			}); ok {
+			}); found {
 				p.logger.Debug(
 					"skip google place photo because already exists",
 					zap.String("photo_reference", googlePlacePhoto.PhotoReference),
@@ -529,7 +529,7 @@ func (p PlaceRepository) SaveGooglePlaceDetail(ctx context.Context, googlePlaceI
 				return false
 			}
 
-			_, ok := array.Find(googlePlaceEntity.R.GooglePlacePhotoReferences, func(savedGooglePlacePhotoReferenceEntity *generated.GooglePlacePhotoReference) bool {
+			_, found := array.Find(googlePlaceEntity.R.GooglePlacePhotoReferences, func(savedGooglePlacePhotoReferenceEntity *generated.GooglePlacePhotoReference) bool {
 				if savedGooglePlacePhotoReferenceEntity == nil {
 					return false
 				}
@@ -537,7 +537,7 @@ func (p PlaceRepository) SaveGooglePlaceDetail(ctx context.Context, googlePlaceI
 			})
 
 			// すでに保存済みのものはスキップ
-			return !ok
+			return !found
 		})
 		if err := googlePlaceEntity.AddGooglePlacePhotoReferences(ctx, tx, true, googlePlacePhotoReferenceSlice...); err != nil {
 			return fmt.Errorf("failed to insert google place photo reference: %w", err)
@@ -545,13 +545,13 @@ func (p PlaceRepository) SaveGooglePlaceDetail(ctx context.Context, googlePlaceI
 
 		// HTMLAttributionを保存
 		for _, googlePlacePhotoReference := range googlePlaceDetail.PhotoReferences {
-			googlePlacePhotoReferenceEntity, ok := array.Find(googlePlaceEntity.R.GooglePlacePhotoReferences, func(savedGooglePlacePhotoReferenceEntity *generated.GooglePlacePhotoReference) bool {
+			googlePlacePhotoReferenceEntity, found := array.Find(googlePlaceEntity.R.GooglePlacePhotoReferences, func(savedGooglePlacePhotoReferenceEntity *generated.GooglePlacePhotoReference) bool {
 				if savedGooglePlacePhotoReferenceEntity == nil {
 					return false
 				}
 				return savedGooglePlacePhotoReferenceEntity.PhotoReference == googlePlacePhotoReference.PhotoReference
 			})
-			if !ok || googlePlacePhotoReferenceEntity == nil {
+			if !found || googlePlacePhotoReferenceEntity == nil {
 				return fmt.Errorf("failed to find google place photo reference entity")
 			}
 
@@ -576,31 +576,29 @@ func (p PlaceRepository) SaveGooglePlaceDetail(ctx context.Context, googlePlaceI
 
 func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, placeId string, photoUrl string, width int, height int) error {
 	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
-		var ok bool
-		var err error
-		ok, err = generated.PlacePhotos(generated.PlacePhotoWhere.PhotoURL.EQ(photoUrl)).Exists(ctx, tx)
+		found, err := generated.PlacePhotos(generated.PlacePhotoWhere.PhotoURL.EQ(photoUrl)).Exists(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("error while checking place photo exists: %w", err)
 		}
-		if ok {
+		if found {
 			// 画像のアドレスを示すURLがすでに保存済みの場合はスキップ
 			return nil
 		}
 
-		ok, err = generated.Users(generated.UserWhere.ID.EQ(userId)).Exists(ctx, tx)
+		found, err = generated.Users(generated.UserWhere.ID.EQ(userId)).Exists(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("error while checking user exists: %w", err)
 		}
-		if !ok {
+		if !found {
 			// userが存在しない場合はエラー
 			return fmt.Errorf("user not found: %s", userId)
 		}
 
-		ok, err = generated.Places(generated.PlaceWhere.ID.EQ(placeId)).Exists(ctx, tx)
+		found, err = generated.Places(generated.PlaceWhere.ID.EQ(placeId)).Exists(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("error while checking place exists: %w", err)
 		}
-		if !ok {
+		if !found {
 			// placeが存在しない場合はエラー
 			return fmt.Errorf("place not found: %s", placeId)
 		}

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/friendsofgo/errors"
 	"github.com/google/uuid"
@@ -575,21 +574,19 @@ func (p PlaceRepository) SaveGooglePlaceDetail(ctx context.Context, googlePlaceI
 	return nil
 }
 
-func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, placeId string, photoUrl string) error {
+func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, placeId string, photoUrl string, width int, height int) error {
 	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
 		if ok, err := generated.PlacePhotos(generated.PlacePhotoWhere.PhotoURL.EQ(photoUrl)).Exists(ctx, tx); ok && err == nil {
 			// すでに保存済みの場合はスキップ
 			return nil
 		}
 		placePhoto := generated.PlacePhoto{
-			ID:        uuid.New().String(),
-			PlaceID:   placeId,
-			UserID:    userId,
-			PhotoURL:  photoUrl,
-			Width:     2000,
-			Height:    2000,
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
+			ID:       uuid.New().String(),
+			PlaceID:  placeId,
+			UserID:   userId,
+			PhotoURL: photoUrl,
+			Width:    width,
+			Height:   height,
 		}
 		if err := placePhoto.Insert(ctx, tx, boil.Infer()); err != nil {
 			return fmt.Errorf("failed to insert place photo: %w", err)

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -577,7 +577,7 @@ func (p PlaceRepository) SaveGooglePlaceDetail(ctx context.Context, googlePlaceI
 func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, placeId string, photoUrl string, width int, height int) error {
 	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
 		if ok, err := generated.PlacePhotos(generated.PlacePhotoWhere.PhotoURL.EQ(photoUrl)).Exists(ctx, tx); ok && err == nil {
-			// すでに保存済みの場合はスキップ
+			// 画像のアドレスを示すURLがすでに保存済みの場合はスキップ
 			return nil
 		}
 		if ok, err := generated.Users(generated.UserWhere.ID.EQ(userId)).Exists(ctx, tx); !ok && err == nil {

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -591,8 +591,8 @@ func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, pla
 		if err != nil {
 			return fmt.Errorf("error while checking user exists: %w", err)
 		}
-		if ok {
-			// userが存在しない場合はスキップ
+		if !ok {
+			// userが存在しない場合はエラー
 			return fmt.Errorf("user not found: %s", userId)
 		}
 
@@ -600,8 +600,8 @@ func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, pla
 		if err != nil {
 			return fmt.Errorf("error while checking place exists: %w", err)
 		}
-		if ok {
-			// placeが存在しない場合はスキップ
+		if !ok {
+			// placeが存在しない場合はエラー
 			return fmt.Errorf("place not found: %s", placeId)
 		}
 
@@ -618,7 +618,7 @@ func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, pla
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to run transaction: %w", err)
+		return fmt.Errorf("failed to save place photos: %w", err)
 	}
 	return nil
 }

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -585,24 +585,6 @@ func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, pla
 			return nil
 		}
 
-		found, err = generated.Users(generated.UserWhere.ID.EQ(userId)).Exists(ctx, tx)
-		if err != nil {
-			return fmt.Errorf("error while checking user exists: %w", err)
-		}
-		if !found {
-			// userが存在しない場合はエラー
-			return fmt.Errorf("user not found: %s", userId)
-		}
-
-		found, err = generated.Places(generated.PlaceWhere.ID.EQ(placeId)).Exists(ctx, tx)
-		if err != nil {
-			return fmt.Errorf("error while checking place exists: %w", err)
-		}
-		if !found {
-			// placeが存在しない場合はエラー
-			return fmt.Errorf("place not found: %s", placeId)
-		}
-
 		placePhoto := generated.PlacePhoto{
 			ID:       uuid.New().String(),
 			PlaceID:  placeId,

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -580,6 +580,14 @@ func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, pla
 			// すでに保存済みの場合はスキップ
 			return nil
 		}
+		if ok, err := generated.Users(generated.UserWhere.ID.EQ(userId)).Exists(ctx, tx); !ok && err == nil {
+			// userが存在しない場合はスキップ
+			return nil
+		}
+		if ok, err := generated.Places(generated.PlaceWhere.ID.EQ(placeId)).Exists(ctx, tx); !ok && err == nil {
+			// placeが存在しない場合はスキップ
+			return nil
+		}
 		placePhoto := generated.PlacePhoto{
 			ID:       uuid.New().String(),
 			PlaceID:  placeId,

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -1414,14 +1414,13 @@ func TestPlaceRepository_SaveGooglePlacePhotos(t *testing.T) {
 
 func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 	cases := []struct {
-		name            string
-		userId          string
-		placeId         string
-		photoUrl        string
-		width           int
-		height          int
-		savedPlacePhoto *generated.PlacePhoto
-		isSaved         bool
+		name     string
+		userId   string
+		placeId  string
+		photoUrl string
+		width    int
+		height   int
+		isSaved  bool
 	}{
 		{
 			name:     "save place photo",
@@ -1497,7 +1496,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 				t.Fatalf("error while saving place photo: %v", err)
 			}
 
-			isPlacePhotoSaved, err := generated.
+			isSaved, err := generated.
 				PlacePhotos(
 					generated.PlacePhotoWhere.UserID.EQ(c.userId),
 					generated.PlacePhotoWhere.PlaceID.EQ(c.placeId),
@@ -1506,7 +1505,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error while checking photo existence: %v", err)
 			}
-			if c.isSaved != isPlacePhotoSaved {
+			if c.isSaved != isSaved {
 				t.Fatalf("place photo is not saved")
 			}
 		})

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -1443,7 +1443,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 			preSavedPlacePhoto: generated.PlacePhoto{
 				UserID:   "3b9c288c-3ae6-41be-b375-c5aa6082114d",
 				PlaceID:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
-				PhotoURL: "https://example.com/other-photo.jpg",
+				PhotoURL: "another-photo.jpg",
 			},
 			isSaved: true,
 		},
@@ -1483,7 +1483,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 			preSavedPlacePhoto: generated.PlacePhoto{
 				UserID:   "3b9c288c-3ae6-41be-b375-c5aa6082114d",
 				PlaceID:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
-				PhotoURL: "https://example.com/other-photo.jpg",
+				PhotoURL: "another-photo.jpg",
 			},
 			isSaved:       false,
 			expectedError: errors.New("failed to save place photos: failed to run transaction: user not found: user-not-exists"),
@@ -1504,7 +1504,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 			preSavedPlacePhoto: generated.PlacePhoto{
 				UserID:   "3b9c288c-3ae6-41be-b375-c5aa6082114d",
 				PlaceID:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
-				PhotoURL: "https://example.com/other-photo.jpg",
+				PhotoURL: "another-photo.jpg",
 			},
 			isSaved:       false,
 			expectedError: errors.New("failed to save place photos: failed to run transaction: place not found: place-not-exists"),

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -3,14 +3,15 @@ package rdb
 import (
 	"context"
 	"database/sql"
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
-	"testing"
-	"time"
 )
 
 func TestPlaceRepository_SavePlacesFromGooglePlace(t *testing.T) {
@@ -1406,6 +1407,107 @@ func TestPlaceRepository_SaveGooglePlacePhotos(t *testing.T) {
 				if !isPhotoLargeSaved {
 					t.Fatalf("photo large is not saved")
 				}
+			}
+		})
+	}
+}
+
+func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
+	cases := []struct {
+		name            string
+		userId          string
+		placeId         string
+		photoUrl        string
+		width           int
+		height          int
+		savedPlacePhoto *generated.PlacePhoto
+		isSaved         bool
+	}{
+		{
+			name:     "save place photo",
+			userId:   "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+			placeId:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+			photoUrl: "https://example.com/photo.jpg",
+			width:    1920,
+			height:   1080,
+			isSaved:  true,
+		},
+		{
+			name:     "already saved place photo",
+			userId:   "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+			placeId:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+			photoUrl: "https://example.com/photo.jpg",
+			width:    1920,
+			height:   1080,
+			isSaved:  true,
+		},
+		{
+			name:     "not exists user",
+			userId:   "user-not-exists",
+			placeId:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+			photoUrl: "https://example.com/photo.jpg",
+			width:    1920,
+			height:   1080,
+			isSaved:  false,
+		},
+		{
+			name:     "not exists place",
+			userId:   "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+			placeId:  "place-not-exists",
+			photoUrl: "https://example.com/photo.jpg",
+			width:    1920,
+			height:   1080,
+			isSaved:  false,
+		},
+	}
+
+	placeRepository, err := NewPlaceRepository(testDB)
+	if err != nil {
+		t.Fatalf("error while initializing place repository: %v", err)
+	}
+	testContext := context.Background()
+
+	// テスト用User・Place
+	testPlace := generated.Place{
+		ID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+	}
+	testUser := generated.User{
+		ID: "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer func(ctx context.Context, db *sql.DB) {
+				err := cleanup(ctx, db)
+				if err != nil {
+					t.Fatalf("error while cleaning up: %v", err)
+				}
+			}(testContext, testDB)
+
+			// 事前にUserとPlaceを保存しておく
+			if err := testPlace.Insert(testContext, testDB, boil.Infer()); err != nil {
+				t.Fatalf("failed to insert place: %v", err)
+			}
+			if err := testUser.Insert(testContext, testDB, boil.Infer()); err != nil {
+				t.Fatalf("failed to insert user: %v", err)
+			}
+
+			err := placeRepository.SavePlacePhotos(testContext, c.userId, c.placeId, c.photoUrl, c.width, c.height)
+			if err != nil {
+				t.Fatalf("error while saving place photo: %v", err)
+			}
+
+			isPlacePhotoSaved, err := generated.
+				PlacePhotos(
+					generated.PlacePhotoWhere.UserID.EQ(c.userId),
+					generated.PlacePhotoWhere.PlaceID.EQ(c.placeId),
+				).Exists(testContext, testDB)
+
+			if err != nil {
+				t.Fatalf("error while checking photo existence: %v", err)
+			}
+			if c.isSaved != isPlacePhotoSaved {
+				t.Fatalf("place photo is not saved")
 			}
 		})
 	}

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -1423,8 +1423,6 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 		preSavedUser       generated.User
 		preSavedPlace      generated.Place
 		preSavedPlacePhoto generated.PlacePhoto
-		isSaved            bool
-		expectedError      error
 	}{
 		{
 			name:     "save place photo",
@@ -1444,7 +1442,6 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 				PlaceID:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
 				PhotoURL: "another-photo.jpg",
 			},
-			isSaved: true,
 		},
 		{
 			name:     "already saved place photo",
@@ -1464,7 +1461,6 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 				PlaceID:  "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
 				PhotoURL: "https://example.com/photo.jpg",
 			},
-			isSaved: true,
 		},
 	}
 
@@ -1499,7 +1495,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 				t.Fatalf("error while saving place photo: %v", err)
 			}
 
-			isSaved, err := generated.
+			_, err = generated.
 				PlacePhotos(
 					generated.PlacePhotoWhere.UserID.EQ(c.userId),
 					generated.PlacePhotoWhere.PlaceID.EQ(c.placeId),
@@ -1508,9 +1504,6 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 				t.Fatalf("error while checking photo existence: %v", err)
 			}
 
-			if c.isSaved != isSaved {
-				t.Fatalf("place photo is not saved")
-			}
 		})
 	}
 }

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -1486,7 +1486,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 				PhotoURL: "another-photo.jpg",
 			},
 			isSaved:       false,
-			expectedError: errors.New("failed to save place photos: failed to run transaction: user not found: user-not-exists"),
+			expectedError: errors.New("failed to save place photos: failed to run transaction: failed to insert place photo: generated: unable to insert into place_photos: Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`poroto`.`place_photos`, CONSTRAINT `place_photos_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))"),
 		},
 		{
 			name:     "not exists place",
@@ -1507,7 +1507,7 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 				PhotoURL: "another-photo.jpg",
 			},
 			isSaved:       false,
-			expectedError: errors.New("failed to save place photos: failed to run transaction: place not found: place-not-exists"),
+			expectedError: errors.New("failed to save place photos: failed to run transaction: failed to insert place photo: generated: unable to insert into place_photos: Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`poroto`.`place_photos`, CONSTRAINT `place_photos_ibfk_2` FOREIGN KEY (`place_id`) REFERENCES `places` (`id`))"),
 		},
 	}
 

--- a/internal/infrastructure/rdb/rdb_main_test.go
+++ b/internal/infrastructure/rdb/rdb_main_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/joho/godotenv"
 	"github.com/volatiletech/sqlboiler/v4/boil"
-	"log"
-	"os"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
-	"strings"
-	"testing"
 )
 
 var (
@@ -89,6 +90,7 @@ func cleanup(ctx context.Context, db *sql.DB) error {
 		generated.GooglePlaceTypes(),
 		generated.GooglePlaces(),
 		// Place
+		generated.PlacePhotos(),
 		generated.Places(),
 		// User
 		generated.Users(),


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 既存のプレイスに対し関連した写真を`user_id`と`place_id`と紐付けて保存できるようにした
- `photo_url`がまだ保存されていないことを確認するようにした
- `usesr_id`と`place_id`が既存のものであるかを確認するようにした
- 機能の確認testを作成した
- テスト用DBのクリーンアップ関数に該当テーブルを追加した
### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/insert_place_photos_to_rdb
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```