### PR TITLE
[Graphql] ログインユーザーが場所に対していいねできるようにする

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1650,6 +1650,7 @@ input LikeToPlaceInPlanInput {
     firebaseAuthToken: String!
     planId: String!
     placeId: String!
+    like: Boolean!
 }
 
 type LikeToPlaceInPlanOutput {
@@ -10498,7 +10499,7 @@ func (ec *executionContext) unmarshalInputLikeToPlaceInPlanInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "planId", "placeId"}
+	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "planId", "placeId", "like"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10541,6 +10542,15 @@ func (ec *executionContext) unmarshalInputLikeToPlaceInPlanInput(ctx context.Con
 				return it, err
 			}
 			it.PlaceID = data
+		case "like":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("like"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Like = data
 		}
 	}
 

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1522,6 +1522,8 @@ type AutoReorderPlacesInPlanCandidateOutput {
 }
 
 input LikeToPlaceInPlanCandidateInput {
+    userId: String
+    firebaseAuthToken: String
     planCandidateId: String!
     placeId: String!
     like: Boolean!
@@ -10258,13 +10260,31 @@ func (ec *executionContext) unmarshalInputLikeToPlaceInPlanCandidateInput(ctx co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"planCandidateId", "placeId", "like"}
+	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "planCandidateId", "placeId", "like"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "userId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserID = data
+		case "firebaseAuthToken":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("firebaseAuthToken"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FirebaseAuthToken = data
 		case "planCandidateId":
 			var err error
 

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -117,6 +117,10 @@ type ComplexityRoot struct {
 		PlanCandidate func(childComplexity int) int
 	}
 
+	LikeToPlaceInPlanOutput struct {
+		Plan func(childComplexity int) int
+	}
+
 	LocationCategory struct {
 		DefaultPhotoURL func(childComplexity int) int
 		DisplayName     func(childComplexity int) int
@@ -132,6 +136,7 @@ type ComplexityRoot struct {
 		CreatePlanByPlace                 func(childComplexity int, input model.CreatePlanByPlaceInput) int
 		DeletePlaceFromPlanCandidate      func(childComplexity int, input model.DeletePlaceFromPlanCandidateInput) int
 		EditPlanTitleOfPlanCandidate      func(childComplexity int, input model.EditPlanTitleOfPlanCandidateInput) int
+		LikeToPlaceInPlan                 func(childComplexity int, input model.LikeToPlaceInPlanInput) int
 		LikeToPlaceInPlanCandidate        func(childComplexity int, input model.LikeToPlaceInPlanCandidateInput) int
 		Ping                              func(childComplexity int, message string) int
 		ReplacePlaceOfPlanCandidate       func(childComplexity int, input model.ReplacePlaceOfPlanCandidateInput) int
@@ -277,6 +282,7 @@ type MutationResolver interface {
 	AutoReorderPlacesInPlanCandidate(ctx context.Context, input model.AutoReorderPlacesInPlanCandidateInput) (*model.AutoReorderPlacesInPlanCandidateOutput, error)
 	LikeToPlaceInPlanCandidate(ctx context.Context, input model.LikeToPlaceInPlanCandidateInput) (*model.LikeToPlaceInPlanCandidateOutput, error)
 	UploadPlacePhotoInPlan(ctx context.Context, inputs []*model.UploadPlacePhotoInPlanInput) (*model.UploadPlacePhotoInPlanOutput, error)
+	LikeToPlaceInPlan(ctx context.Context, input model.LikeToPlaceInPlanInput) (*model.LikeToPlaceInPlanOutput, error)
 }
 type QueryResolver interface {
 	Version(ctx context.Context) (string, error)
@@ -524,6 +530,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LikeToPlaceInPlanCandidateOutput.PlanCandidate(childComplexity), true
 
+	case "LikeToPlaceInPlanOutput.plan":
+		if e.complexity.LikeToPlaceInPlanOutput.Plan == nil {
+			break
+		}
+
+		return e.complexity.LikeToPlaceInPlanOutput.Plan(childComplexity), true
+
 	case "LocationCategory.defaultPhotoUrl":
 		if e.complexity.LocationCategory.DefaultPhotoURL == nil {
 			break
@@ -635,6 +648,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.EditPlanTitleOfPlanCandidate(childComplexity, args["input"].(model.EditPlanTitleOfPlanCandidateInput)), true
+
+	case "Mutation.likeToPlaceInPlan":
+		if e.complexity.Mutation.LikeToPlaceInPlan == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_likeToPlaceInPlan_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.LikeToPlaceInPlan(childComplexity, args["input"].(model.LikeToPlaceInPlanInput)), true
 
 	case "Mutation.likeToPlaceInPlanCandidate":
 		if e.complexity.Mutation.LikeToPlaceInPlanCandidate == nil {
@@ -1213,6 +1238,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputEditPlanTitleOfPlanCandidateInput,
 		ec.unmarshalInputFirebaseUserInput,
 		ec.unmarshalInputLikeToPlaceInPlanCandidateInput,
+		ec.unmarshalInputLikeToPlaceInPlanInput,
 		ec.unmarshalInputNearbyPlaceCategoriesInput,
 		ec.unmarshalInputPlacesToAddForPlanCandidateInput,
 		ec.unmarshalInputPlacesToReplaceForPlanCandidateInput,
@@ -1601,6 +1627,8 @@ type PlacesToReplaceForPlanCandidateOutput {
 }`, BuiltIn: false},
 	{Name: "../schema/plan_mutation.graphqls", Input: `extend type Mutation {
     uploadPlacePhotoInPlan(inputs: [UploadPlacePhotoInPlanInput!]!): UploadPlacePhotoInPlanOutput!
+
+    likeToPlaceInPlan(input: LikeToPlaceInPlanInput!): LikeToPlaceInPlanOutput!
 }
 
 input UploadPlacePhotoInPlanInput {
@@ -1614,6 +1642,17 @@ input UploadPlacePhotoInPlanInput {
 }
 
 type UploadPlacePhotoInPlanOutput {
+    plan: Plan!
+}
+
+input LikeToPlaceInPlanInput {
+    userId: String!
+    firebaseAuthToken: String!
+    planId: String!
+    placeId: String!
+}
+
+type LikeToPlaceInPlanOutput {
     plan: Plan!
 }`, BuiltIn: false},
 	{Name: "../schema/plan_query.graphqls", Input: `extend type Query {
@@ -1840,6 +1879,21 @@ func (ec *executionContext) field_Mutation_likeToPlaceInPlanCandidate_args(ctx c
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNLikeToPlaceInPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikeToPlaceInPlanCandidateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_likeToPlaceInPlan_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.LikeToPlaceInPlanInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNLikeToPlaceInPlanInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikeToPlaceInPlanInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -3636,6 +3690,66 @@ func (ec *executionContext) fieldContext_LikeToPlaceInPlanCandidateOutput_planCa
 	return fc, nil
 }
 
+func (ec *executionContext) _LikeToPlaceInPlanOutput_plan(ctx context.Context, field graphql.CollectedField, obj *model.LikeToPlaceInPlanOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LikeToPlaceInPlanOutput_plan(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Plan, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Plan)
+	fc.Result = res
+	return ec.marshalNPlan2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlan(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LikeToPlaceInPlanOutput_plan(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LikeToPlaceInPlanOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Plan_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Plan_name(ctx, field)
+			case "places":
+				return ec.fieldContext_Plan_places(ctx, field)
+			case "timeInMinutes":
+				return ec.fieldContext_Plan_timeInMinutes(ctx, field)
+			case "description":
+				return ec.fieldContext_Plan_description(ctx, field)
+			case "transitions":
+				return ec.fieldContext_Plan_transitions(ctx, field)
+			case "author":
+				return ec.fieldContext_Plan_author(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Plan", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LocationCategory_name(ctx context.Context, field graphql.CollectedField, obj *model.LocationCategory) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LocationCategory_name(ctx, field)
 	if err != nil {
@@ -4521,6 +4635,65 @@ func (ec *executionContext) fieldContext_Mutation_uploadPlacePhotoInPlan(ctx con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_uploadPlacePhotoInPlan_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_likeToPlaceInPlan(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_likeToPlaceInPlan(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().LikeToPlaceInPlan(rctx, fc.Args["input"].(model.LikeToPlaceInPlanInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.LikeToPlaceInPlanOutput)
+	fc.Result = res
+	return ec.marshalNLikeToPlaceInPlanOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikeToPlaceInPlanOutput(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_likeToPlaceInPlan(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "plan":
+				return ec.fieldContext_LikeToPlaceInPlanOutput_plan(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LikeToPlaceInPlanOutput", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_likeToPlaceInPlan_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -10318,6 +10491,62 @@ func (ec *executionContext) unmarshalInputLikeToPlaceInPlanCandidateInput(ctx co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputLikeToPlaceInPlanInput(ctx context.Context, obj interface{}) (model.LikeToPlaceInPlanInput, error) {
+	var it model.LikeToPlaceInPlanInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "planId", "placeId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "userId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserID = data
+		case "firebaseAuthToken":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("firebaseAuthToken"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FirebaseAuthToken = data
+		case "planId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("planId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PlanID = data
+		case "placeId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("placeId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PlaceID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputNearbyPlaceCategoriesInput(ctx context.Context, obj interface{}) (model.NearbyPlaceCategoriesInput, error) {
 	var it model.NearbyPlaceCategoriesInput
 	asMap := map[string]interface{}{}
@@ -11417,6 +11646,45 @@ func (ec *executionContext) _LikeToPlaceInPlanCandidateOutput(ctx context.Contex
 	return out
 }
 
+var likeToPlaceInPlanOutputImplementors = []string{"LikeToPlaceInPlanOutput"}
+
+func (ec *executionContext) _LikeToPlaceInPlanOutput(ctx context.Context, sel ast.SelectionSet, obj *model.LikeToPlaceInPlanOutput) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, likeToPlaceInPlanOutputImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LikeToPlaceInPlanOutput")
+		case "plan":
+			out.Values[i] = ec._LikeToPlaceInPlanOutput_plan(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var locationCategoryImplementors = []string{"LocationCategory"}
 
 func (ec *executionContext) _LocationCategory(ctx context.Context, sel ast.SelectionSet, obj *model.LocationCategory) graphql.Marshaler {
@@ -11567,6 +11835,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "uploadPlacePhotoInPlan":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_uploadPlacePhotoInPlan(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "likeToPlaceInPlan":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_likeToPlaceInPlan(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -13492,6 +13767,25 @@ func (ec *executionContext) marshalNLikeToPlaceInPlanCandidateOutput2ᚖporoto�
 		return graphql.Null
 	}
 	return ec._LikeToPlaceInPlanCandidateOutput(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNLikeToPlaceInPlanInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikeToPlaceInPlanInput(ctx context.Context, v interface{}) (model.LikeToPlaceInPlanInput, error) {
+	res, err := ec.unmarshalInputLikeToPlaceInPlanInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNLikeToPlaceInPlanOutput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikeToPlaceInPlanOutput(ctx context.Context, sel ast.SelectionSet, v model.LikeToPlaceInPlanOutput) graphql.Marshaler {
+	return ec._LikeToPlaceInPlanOutput(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNLikeToPlaceInPlanOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikeToPlaceInPlanOutput(ctx context.Context, sel ast.SelectionSet, v *model.LikeToPlaceInPlanOutput) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._LikeToPlaceInPlanOutput(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNNearbyLocationCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐNearbyLocationCategoryᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.NearbyLocationCategory) graphql.Marshaler {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -154,6 +154,17 @@ type LikeToPlaceInPlanCandidateOutput struct {
 	PlanCandidate *PlanCandidate `json:"planCandidate"`
 }
 
+type LikeToPlaceInPlanInput struct {
+	UserID            string `json:"userId"`
+	FirebaseAuthToken string `json:"firebaseAuthToken"`
+	PlanID            string `json:"planId"`
+	PlaceID           string `json:"placeId"`
+}
+
+type LikeToPlaceInPlanOutput struct {
+	Plan *Plan `json:"plan"`
+}
+
 type LocationCategory struct {
 	Name            string  `json:"name"`
 	DisplayName     string  `json:"displayName"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -159,6 +159,7 @@ type LikeToPlaceInPlanInput struct {
 	FirebaseAuthToken string `json:"firebaseAuthToken"`
 	PlanID            string `json:"planId"`
 	PlaceID           string `json:"placeId"`
+	Like              bool   `json:"like"`
 }
 
 type LikeToPlaceInPlanOutput struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -143,9 +143,11 @@ type Image struct {
 }
 
 type LikeToPlaceInPlanCandidateInput struct {
-	PlanCandidateID string `json:"planCandidateId"`
-	PlaceID         string `json:"placeId"`
-	Like            bool   `json:"like"`
+	UserID            *string `json:"userId,omitempty"`
+	FirebaseAuthToken *string `json:"firebaseAuthToken,omitempty"`
+	PlanCandidateID   string  `json:"planCandidateId"`
+	PlaceID           string  `json:"placeId"`
+	Like              bool    `json:"like"`
 }
 
 type LikeToPlaceInPlanCandidateOutput struct {

--- a/internal/interface/graphql/resolver/plan_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_mutation.resolvers.go
@@ -15,3 +15,8 @@ import (
 func (r *mutationResolver) UploadPlacePhotoInPlan(ctx context.Context, inputs []*model.UploadPlacePhotoInPlanInput) (*model.UploadPlacePhotoInPlanOutput, error) {
 	panic(fmt.Errorf("not implemented: UploadPlacePhotoInPlan - uploadPlacePhotoInPlan"))
 }
+
+// LikeToPlaceInPlan is the resolver for the likeToPlaceInPlan field.
+func (r *mutationResolver) LikeToPlaceInPlan(ctx context.Context, input model.LikeToPlaceInPlanInput) (*model.LikeToPlaceInPlanOutput, error) {
+	panic(fmt.Errorf("not implemented: LikeToPlaceInPlan - likeToPlaceInPlan"))
+}

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -144,6 +144,8 @@ type AutoReorderPlacesInPlanCandidateOutput {
 }
 
 input LikeToPlaceInPlanCandidateInput {
+    userId: String
+    firebaseAuthToken: String
     planCandidateId: String!
     placeId: String!
     like: Boolean!

--- a/internal/interface/graphql/schema/plan_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_mutation.graphqls
@@ -23,6 +23,7 @@ input LikeToPlaceInPlanInput {
     firebaseAuthToken: String!
     planId: String!
     placeId: String!
+    like: Boolean!
 }
 
 type LikeToPlaceInPlanOutput {

--- a/internal/interface/graphql/schema/plan_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_mutation.graphqls
@@ -1,5 +1,7 @@
 extend type Mutation {
     uploadPlacePhotoInPlan(inputs: [UploadPlacePhotoInPlanInput!]!): UploadPlacePhotoInPlanOutput!
+
+    likeToPlaceInPlan(input: LikeToPlaceInPlanInput!): LikeToPlaceInPlanOutput!
 }
 
 input UploadPlacePhotoInPlanInput {
@@ -13,5 +15,16 @@ input UploadPlacePhotoInPlanInput {
 }
 
 type UploadPlacePhotoInPlanOutput {
+    plan: Plan!
+}
+
+input LikeToPlaceInPlanInput {
+    userId: String!
+    firebaseAuthToken: String!
+    planId: String!
+    placeId: String!
+}
+
+type LikeToPlaceInPlanOutput {
     plan: Plan!
 }


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Graphqlスキーマ変更
- プラン候補や保存済みプランで場所に対していいねするときにユーザー情報を付与できるようにした。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- プラン候補作成中以外でもログインユーザーであれば場所に対していいねできるようにする
- 将来的にいいねした場所からプランを作れるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/graphql_like_by_user
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```