### PR TITLE
ユーザーがいいねしたことをDBに保存する

### DIFF
--- a/internal/domain/repository/place.go
+++ b/internal/domain/repository/place.go
@@ -23,4 +23,6 @@ type PlaceRepository interface {
 	SaveGooglePlacePhotos(ctx context.Context, googlePlaceId string, photos []models.GooglePlacePhoto) error
 
 	SaveGooglePlaceDetail(ctx context.Context, googlePlaceId string, detail models.GooglePlaceDetail) error
+
+	UpdateLikeByUserId(ctx context.Context, userId string, placeId string, like bool) error
 }

--- a/internal/domain/repository/plan_candidate.go
+++ b/internal/domain/repository/plan_candidate.go
@@ -37,5 +37,6 @@ type PlanCandidateRepository interface {
 
 	DeleteAll(ctx context.Context, planCandidateIds []string) error
 
+	// TODO: PlaceRepository に移動する
 	UpdateLikeToPlaceInPlanCandidate(ctx context.Context, planCandidateId string, placeId string, like bool) error
 }

--- a/internal/infrastructure/rdb/entities/plan_candidate_set_place_likes.go
+++ b/internal/infrastructure/rdb/entities/plan_candidate_set_place_likes.go
@@ -8,10 +8,10 @@ type PlanCandidateSetPlaceLikeCount struct {
 }
 
 var PlanCandidateSetPlaceLikeCountColumns = struct {
-	Name      string
+	PlaceId   string
 	LikeCount string
 }{
-	Name:      "place_id",
+	PlaceId:   "place_id",
 	LikeCount: "like_count",
 }
 

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-
 	"github.com/friendsofgo/errors"
 	"github.com/google/uuid"
 	"github.com/volatiletech/sqlboiler/v4/boil"
@@ -17,6 +16,7 @@ import (
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/entities"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/factory"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
+	"strings"
 )
 
 type PlaceRepository struct {
@@ -726,20 +726,53 @@ func (p PlaceRepository) findAllByGooglePlaceId(ctx context.Context, exec boil.C
 	return places, nil
 }
 
+// countPlaceLikeCounts は場所ごとのいいね数をカウントする
+// いいねはPlanCandidateSetとUserによって行われるが、その両方を考慮し、総数をカウントする
 func countPlaceLikeCounts(ctx context.Context, exec boil.ContextExecutor, placeIds ...string) (*[]entities.PlanCandidateSetPlaceLikeCount, error) {
+	var placeIdPlaceHolder string
+	if len(placeIds) == 0 {
+		return nil, nil
+	} else if len(placeIds) == 1 {
+		placeIdPlaceHolder = "?"
+	} else {
+		placeIdPlaceHolder = strings.Repeat("?,", len(placeIds)-1) + "?"
+	}
+
+	query := fmt.Sprintf(
+		`SELECT place_likes.%s, COUNT(*) AS %s
+FROM (
+	SELECT %s, %s AS %s
+	FROM %s
+	UNION ALL
+	SELECT %s, %s AS %s
+	FROM %s
+) AS place_likes	
+WHERE %s IN (%s)
+GROUP BY place_likes.place_id`,
+		entities.PlanCandidateSetPlaceLikeCountColumns.PlaceId,
+		entities.PlanCandidateSetPlaceLikeCountColumns.LikeCount,
+
+		generated.PlanCandidateSetLikePlaceColumns.ID,
+		generated.PlanCandidateSetLikePlaceColumns.PlaceID,
+		entities.PlanCandidateSetPlaceLikeCountColumns.PlaceId,
+
+		generated.TableNames.PlanCandidateSetLikePlaces,
+
+		generated.UserLikePlaceColumns.ID,
+		generated.UserLikePlaceColumns.PlaceID,
+		entities.PlanCandidateSetPlaceLikeCountColumns.PlaceId,
+
+		generated.TableNames.UserLikePlaces,
+
+		entities.PlanCandidateSetPlaceLikeCountColumns.PlaceId,
+
+		placeIdPlaceHolder,
+	)
+
 	var planCandidateSetPlaceLikeCounts []entities.PlanCandidateSetPlaceLikeCount
-	if err := generated.NewQuery(
-		qm.Select(
-			entities.PlanCandidateSetPlaceLikeCountColumns.Name,
-			fmt.Sprintf("COUNT(*) as `%s`", entities.PlanCandidateSetPlaceLikeCountColumns.LikeCount),
-		),
-		qm.From(generated.TableNames.PlanCandidateSetLikePlaces),
-		qm.WhereIn(
-			fmt.Sprintf("%s IN ?", generated.PlanCandidateSetLikePlaceColumns.PlaceID),
-			toInterfaceArray(placeIds)...,
-		),
-		qm.GroupBy(generated.PlanCandidateSetLikePlaceTableColumns.PlaceID),
-	).Bind(ctx, exec, &planCandidateSetPlaceLikeCounts); err != nil {
+	if err := queries.
+		Raw(query, toInterfaceArray(placeIds)...).
+		Bind(ctx, exec, &planCandidateSetPlaceLikeCounts); err != nil {
 		return nil, fmt.Errorf("failed to count place like counts: %w", err)
 	}
 	return &planCandidateSetPlaceLikeCounts, nil

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -603,6 +603,10 @@ func (p PlaceRepository) SavePlacePhotos(ctx context.Context, userId string, pla
 	return nil
 }
 
+func (p PlaceRepository) UpdateLikeByUserId(ctx context.Context, userId string, placeId string, like bool) error {
+	panic("implement me")
+}
+
 func (p PlaceRepository) findByGooglePlaceId(ctx context.Context, exec boil.ContextExecutor, googlePlaceId string) (*models.Place, error) {
 	googlePlaceEntity, err := generated.GooglePlaces(
 		generated.GooglePlaceWhere.GooglePlaceID.EQ(googlePlaceId),

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -1525,14 +1525,10 @@ func TestPlaceRepository_UpdateLikeByUserId(t *testing.T) {
 			placeId: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
 			liked:   true,
 			savedUsers: []generated.User{
-				{
-					ID: "3b9c288c-3ae6-41be-b375-c5aa6082114d",
-				},
+				{ID: "3b9c288c-3ae6-41be-b375-c5aa6082114d"},
 			},
 			savedPlaces: []generated.Place{
-				{
-					ID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
-				},
+				{ID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12"},
 			},
 			savedUserLikePlaces: []generated.UserLikePlace{},
 			expectedExists:      true,
@@ -1543,18 +1539,13 @@ func TestPlaceRepository_UpdateLikeByUserId(t *testing.T) {
 			placeId: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
 			liked:   false,
 			savedUsers: []generated.User{
-				{
-					ID: "3b9c288c-3ae6-41be-b375-c5aa6082114d",
-				},
+				{ID: "3b9c288c-3ae6-41be-b375-c5aa6082114d"},
 			},
 			savedPlaces: []generated.Place{
-				{
-					ID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
-				},
+				{ID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12"},
 			},
 			savedUserLikePlaces: []generated.UserLikePlace{
 				{
-
 					UserID:  "3b9c288c-3ae6-41be-b375-c5aa6082114d",
 					PlaceID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
 				},

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -1507,3 +1507,105 @@ func TestPlaceRepository_SavePlacePhotos(t *testing.T) {
 		})
 	}
 }
+
+func TestPlaceRepository_UpdateLikeByUserId(t *testing.T) {
+	cases := []struct {
+		name                string
+		userId              string
+		placeId             string
+		liked               bool
+		savedUsers          []generated.User
+		savedPlaces         []generated.Place
+		savedUserLikePlaces []generated.UserLikePlace
+		expectedExists      bool
+	}{
+		{
+			name:    "like place by user",
+			userId:  "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+			placeId: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+			liked:   true,
+			savedUsers: []generated.User{
+				{
+					ID: "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+				},
+			},
+			savedPlaces: []generated.Place{
+				{
+					ID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+				},
+			},
+			savedUserLikePlaces: []generated.UserLikePlace{},
+			expectedExists:      true,
+		},
+		{
+			name:    "unlike place by user",
+			userId:  "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+			placeId: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+			liked:   false,
+			savedUsers: []generated.User{
+				{
+					ID: "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+				},
+			},
+			savedPlaces: []generated.Place{
+				{
+					ID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+				},
+			},
+			savedUserLikePlaces: []generated.UserLikePlace{
+				{
+
+					UserID:  "3b9c288c-3ae6-41be-b375-c5aa6082114d",
+					PlaceID: "c0bbee6a-acd4-41b6-957e-2aeb83e29d12",
+				},
+			},
+			expectedExists: false,
+		},
+	}
+
+	placeRepository, err := NewPlaceRepository(testDB)
+	if err != nil {
+		t.Fatalf("error while initializing place repository: %v", err)
+	}
+
+	testContext := context.Background()
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer func(ctx context.Context, db *sql.DB) {
+				err := cleanup(ctx, db)
+				if err != nil {
+					t.Fatalf("error while cleaning up: %v", err)
+				}
+			}(testContext, testDB)
+
+			// 事前にUser・Placeを保存しておく
+			for _, user := range c.savedUsers {
+				if err := user.Insert(testContext, testDB, boil.Infer()); err != nil {
+					t.Fatalf("failed to insert user: %v", err)
+				}
+			}
+			for _, place := range c.savedPlaces {
+				if err := place.Insert(testContext, testDB, boil.Infer()); err != nil {
+					t.Fatalf("failed to insert place: %v", err)
+				}
+			}
+
+			if err := placeRepository.UpdateLikeByUserId(testContext, c.userId, c.placeId, c.liked); err != nil {
+				t.Fatalf("error while updating like by user id: %v", err)
+			}
+
+			isUserLikePlaceExists, err := generated.UserLikePlaces(
+				generated.UserLikePlaceWhere.UserID.EQ(c.userId),
+				generated.UserLikePlaceWhere.PlaceID.EQ(c.placeId),
+			).Exists(testContext, testDB)
+			if err != nil {
+				t.Fatalf("error while checking user like place existence: %v", err)
+			}
+
+			if isUserLikePlaceExists != c.expectedExists {
+				t.Fatalf("expected: %v, actual: %v", c.expectedExists, isUserLikePlaceExists)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/rdb/rdb_main_test.go
+++ b/internal/infrastructure/rdb/rdb_main_test.go
@@ -90,6 +90,7 @@ func cleanup(ctx context.Context, db *sql.DB) error {
 		generated.GooglePlaceTypes(),
 		generated.GooglePlaces(),
 		// Place
+		generated.UserLikePlaces(),
 		generated.PlacePhotos(),
 		generated.Places(),
 		// User


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- ユーザーがいいねしたことを`user_like_places`テーブルに保存する処理を実装した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #436 
- #435 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 単体テストを作成し、like追加、like削除の処理を実装
- [x] 単体テストを作成し、プラン候補、ユーザーがlikeした個数を取得できることを確認 

```shell
# planner
export BRANCH_PLANNER=feature/like_place_by_user_db
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```