### PR TITLE
[スキーマ変更] ユーザーがいいねした場所を取得できるようにする

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -233,6 +233,7 @@ type ComplexityRoot struct {
 	Query struct {
 		AvailablePlacesForPlan          func(childComplexity int, input model.AvailablePlacesForPlanInput) int
 		FirebaseUser                    func(childComplexity int, input *model.FirebaseUserInput) int
+		LikePlaces                      func(childComplexity int, input *model.LikePlacesInput) int
 		NearbyPlaceCategories           func(childComplexity int, input model.NearbyPlaceCategoriesInput) int
 		PlacesToAddForPlanCandidate     func(childComplexity int, input model.PlacesToAddForPlanCandidateInput) int
 		PlacesToReplaceForPlanCandidate func(childComplexity int, input model.PlacesToReplaceForPlanCandidateInput) int
@@ -297,6 +298,7 @@ type QueryResolver interface {
 	PlansByLocation(ctx context.Context, input model.PlansByLocationInput) (*model.PlansByLocationOutput, error)
 	PlansByUser(ctx context.Context, input model.PlansByUserInput) (*model.PlansByUserOutput, error)
 	FirebaseUser(ctx context.Context, input *model.FirebaseUserInput) (*model.User, error)
+	LikePlaces(ctx context.Context, input *model.LikePlacesInput) ([]*model.Place, error)
 }
 
 type executableSchema struct {
@@ -1054,6 +1056,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.FirebaseUser(childComplexity, args["input"].(*model.FirebaseUserInput)), true
 
+	case "Query.likePlaces":
+		if e.complexity.Query.LikePlaces == nil {
+			break
+		}
+
+		args, err := ec.field_Query_likePlaces_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.LikePlaces(childComplexity, args["input"].(*model.LikePlacesInput)), true
+
 	case "Query.nearbyPlaceCategories":
 		if e.complexity.Query.NearbyPlaceCategories == nil {
 			break
@@ -1245,6 +1259,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeletePlaceFromPlanCandidateInput,
 		ec.unmarshalInputEditPlanTitleOfPlanCandidateInput,
 		ec.unmarshalInputFirebaseUserInput,
+		ec.unmarshalInputLikePlacesInput,
 		ec.unmarshalInputLikeToPlaceInPlanCandidateInput,
 		ec.unmarshalInputLikeToPlaceInPlanInput,
 		ec.unmarshalInputNearbyPlaceCategoriesInput,
@@ -1758,11 +1773,19 @@ type Mutation {
 }`, BuiltIn: false},
 	{Name: "../schema/user_query.graphqls", Input: `extend type Query {
     firebaseUser(input: FirebaseUserInput): User!
+
+    likePlaces(input: LikePlacesInput): [Place!]!
 }
 
 input FirebaseUserInput {
     firebaseUserId: String!
     firebaseAuthToken: String!
+}
+
+input LikePlacesInput {
+    userId: ID!
+    firebaseAuthToken: String!
+    planId: ID
 }
 `, BuiltIn: false},
 	{Name: "../schema/user_type.graphqls", Input: `type User {
@@ -2009,6 +2032,21 @@ func (ec *executionContext) field_Query_firebaseUser_args(ctx context.Context, r
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalOFirebaseUserInput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐFirebaseUserInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_likePlaces_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.LikePlacesInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalOLikePlacesInput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikePlacesInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -7539,6 +7577,83 @@ func (ec *executionContext) fieldContext_Query_firebaseUser(ctx context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_likePlaces(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_likePlaces(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LikePlaces(rctx, fc.Args["input"].(*model.LikePlacesInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Place)
+	fc.Result = res
+	return ec.marshalNPlace2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlaceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_likePlaces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Place_id(ctx, field)
+			case "googlePlaceId":
+				return ec.fieldContext_Place_googlePlaceId(ctx, field)
+			case "name":
+				return ec.fieldContext_Place_name(ctx, field)
+			case "location":
+				return ec.fieldContext_Place_location(ctx, field)
+			case "images":
+				return ec.fieldContext_Place_images(ctx, field)
+			case "estimatedStayDuration":
+				return ec.fieldContext_Place_estimatedStayDuration(ctx, field)
+			case "googleReviews":
+				return ec.fieldContext_Place_googleReviews(ctx, field)
+			case "categories":
+				return ec.fieldContext_Place_categories(ctx, field)
+			case "priceRange":
+				return ec.fieldContext_Place_priceRange(ctx, field)
+			case "likeCount":
+				return ec.fieldContext_Place_likeCount(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Place", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_likePlaces_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -10482,6 +10597,53 @@ func (ec *executionContext) unmarshalInputFirebaseUserInput(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputLikePlacesInput(ctx context.Context, obj interface{}) (model.LikePlacesInput, error) {
+	var it model.LikePlacesInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "planId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "userId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserID = data
+		case "firebaseAuthToken":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("firebaseAuthToken"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FirebaseAuthToken = data
+		case "planId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("planId"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PlanID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputLikeToPlaceInPlanCandidateInput(ctx context.Context, obj interface{}) (model.LikeToPlaceInPlanCandidateInput, error) {
 	var it model.LikeToPlaceInPlanCandidateInput
 	asMap := map[string]interface{}{}
@@ -12870,6 +13032,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "likePlaces":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_likePlaces(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -14731,6 +14915,22 @@ func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel as
 	return graphql.WrapContextMarshaler(ctx, res)
 }
 
+func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOID2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalID(*v)
+	return res
+}
+
 func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
 	if v == nil {
 		return nil, nil
@@ -14745,6 +14945,14 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 	}
 	res := graphql.MarshalInt(*v)
 	return res
+}
+
+func (ec *executionContext) unmarshalOLikePlacesInput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐLikePlacesInput(ctx context.Context, v interface{}) (*model.LikePlacesInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputLikePlacesInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOPlace2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlace(ctx context.Context, sel ast.SelectionSet, v *model.Place) graphql.Marshaler {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1785,7 +1785,6 @@ input FirebaseUserInput {
 input LikePlacesInput {
     userId: ID!
     firebaseAuthToken: String!
-    planId: ID
 }
 `, BuiltIn: false},
 	{Name: "../schema/user_type.graphqls", Input: `type User {
@@ -10604,7 +10603,7 @@ func (ec *executionContext) unmarshalInputLikePlacesInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "planId"}
+	fieldsInOrder := [...]string{"userId", "firebaseAuthToken"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10629,15 +10628,6 @@ func (ec *executionContext) unmarshalInputLikePlacesInput(ctx context.Context, o
 				return it, err
 			}
 			it.FirebaseAuthToken = data
-		case "planId":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("planId"))
-			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.PlanID = data
 		}
 	}
 
@@ -14913,22 +14903,6 @@ func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalFloatContext(*v)
 	return graphql.WrapContextMarshaler(ctx, res)
-}
-
-func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := graphql.UnmarshalID(v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOID2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	res := graphql.MarshalID(*v)
-	return res
 }
 
 func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -118,7 +118,8 @@ type ComplexityRoot struct {
 	}
 
 	LikeToPlaceInPlanOutput struct {
-		Plan func(childComplexity int) int
+		LikedPlaceIds func(childComplexity int) int
+		Plan          func(childComplexity int) int
 	}
 
 	LocationCategory struct {
@@ -529,6 +530,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.LikeToPlaceInPlanCandidateOutput.PlanCandidate(childComplexity), true
+
+	case "LikeToPlaceInPlanOutput.likedPlaceIds":
+		if e.complexity.LikeToPlaceInPlanOutput.LikedPlaceIds == nil {
+			break
+		}
+
+		return e.complexity.LikeToPlaceInPlanOutput.LikedPlaceIds(childComplexity), true
 
 	case "LikeToPlaceInPlanOutput.plan":
 		if e.complexity.LikeToPlaceInPlanOutput.Plan == nil {
@@ -1655,6 +1663,7 @@ input LikeToPlaceInPlanInput {
 
 type LikeToPlaceInPlanOutput {
     plan: Plan!
+    likedPlaceIds: [String!]!
 }`, BuiltIn: false},
 	{Name: "../schema/plan_query.graphqls", Input: `extend type Query {
     plan(input: PlanInput!): PlanOutput!
@@ -3751,6 +3760,50 @@ func (ec *executionContext) fieldContext_LikeToPlaceInPlanOutput_plan(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _LikeToPlaceInPlanOutput_likedPlaceIds(ctx context.Context, field graphql.CollectedField, obj *model.LikeToPlaceInPlanOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LikeToPlaceInPlanOutput_likedPlaceIds(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LikedPlaceIds, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LikeToPlaceInPlanOutput_likedPlaceIds(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LikeToPlaceInPlanOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LocationCategory_name(ctx context.Context, field graphql.CollectedField, obj *model.LocationCategory) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LocationCategory_name(ctx, field)
 	if err != nil {
@@ -4683,6 +4736,8 @@ func (ec *executionContext) fieldContext_Mutation_likeToPlaceInPlan(ctx context.
 			switch field.Name {
 			case "plan":
 				return ec.fieldContext_LikeToPlaceInPlanOutput_plan(ctx, field)
+			case "likedPlaceIds":
+				return ec.fieldContext_LikeToPlaceInPlanOutput_likedPlaceIds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type LikeToPlaceInPlanOutput", field.Name)
 		},
@@ -11669,6 +11724,11 @@ func (ec *executionContext) _LikeToPlaceInPlanOutput(ctx context.Context, sel as
 			out.Values[i] = graphql.MarshalString("LikeToPlaceInPlanOutput")
 		case "plan":
 			out.Values[i] = ec._LikeToPlaceInPlanOutput_plan(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "likedPlaceIds":
+			out.Values[i] = ec._LikeToPlaceInPlanOutput_likedPlaceIds(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -163,7 +163,8 @@ type LikeToPlaceInPlanInput struct {
 }
 
 type LikeToPlaceInPlanOutput struct {
-	Plan *Plan `json:"plan"`
+	Plan          *Plan    `json:"plan"`
+	LikedPlaceIds []string `json:"likedPlaceIds"`
 }
 
 type LocationCategory struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -143,9 +143,8 @@ type Image struct {
 }
 
 type LikePlacesInput struct {
-	UserID            string  `json:"userId"`
-	FirebaseAuthToken string  `json:"firebaseAuthToken"`
-	PlanID            *string `json:"planId,omitempty"`
+	UserID            string `json:"userId"`
+	FirebaseAuthToken string `json:"firebaseAuthToken"`
 }
 
 type LikeToPlaceInPlanCandidateInput struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -142,6 +142,12 @@ type Image struct {
 	Large   *string `json:"large,omitempty"`
 }
 
+type LikePlacesInput struct {
+	UserID            string  `json:"userId"`
+	FirebaseAuthToken string  `json:"firebaseAuthToken"`
+	PlanID            *string `json:"planId,omitempty"`
+}
+
 type LikeToPlaceInPlanCandidateInput struct {
 	UserID            *string `json:"userId,omitempty"`
 	FirebaseAuthToken *string `json:"firebaseAuthToken,omitempty"`

--- a/internal/interface/graphql/resolver/plan_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_mutation.resolvers.go
@@ -7,12 +7,12 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"log"
+
+	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/services/plan"
 	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
-
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
 )
 

--- a/internal/interface/graphql/resolver/user_query.resolvers.go
+++ b/internal/interface/graphql/resolver/user_query.resolvers.go
@@ -30,3 +30,8 @@ func (r *queryResolver) FirebaseUser(ctx context.Context, input *model.FirebaseU
 
 	return factory.UserFromDomainModel(u), nil
 }
+
+// LikePlaces is the resolver for the likePlaces field.
+func (r *queryResolver) LikePlaces(ctx context.Context, input *model.LikePlacesInput) ([]*model.Place, error) {
+	panic(fmt.Errorf("not implemented: LikePlaces - likePlaces"))
+}

--- a/internal/interface/graphql/schema/plan_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_mutation.graphqls
@@ -28,4 +28,5 @@ input LikeToPlaceInPlanInput {
 
 type LikeToPlaceInPlanOutput {
     plan: Plan!
+    likedPlaceIds: [String!]!
 }

--- a/internal/interface/graphql/schema/user_query.graphqls
+++ b/internal/interface/graphql/schema/user_query.graphqls
@@ -12,5 +12,4 @@ input FirebaseUserInput {
 input LikePlacesInput {
     userId: ID!
     firebaseAuthToken: String!
-    planId: String
 }

--- a/internal/interface/graphql/schema/user_query.graphqls
+++ b/internal/interface/graphql/schema/user_query.graphqls
@@ -1,8 +1,16 @@
 extend type Query {
     firebaseUser(input: FirebaseUserInput): User!
+
+    likePlaces(input: LikePlacesInput): [Place!]!
 }
 
 input FirebaseUserInput {
     firebaseUserId: String!
     firebaseAuthToken: String!
+}
+
+input LikePlacesInput {
+    userId: ID!
+    firebaseAuthToken: String!
+    planId: String
 }


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- いいねをしたときや、プランを表示するときにいいねした場所を取得できるようにする

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```