### PR TITLE
ユーザーがいいねした場所を取得できるようにする

### DIFF
--- a/internal/domain/repository/place.go
+++ b/internal/domain/repository/place.go
@@ -20,6 +20,9 @@ type PlaceRepository interface {
 	// FindByPlanCandidateId は models.PlanCandidate に紐づく models.Place を取得する
 	FindByPlanCandidateId(ctx context.Context, planCandidateId string) ([]models.Place, error)
 
+	// FindLikePlacesByUserId はユーザーがいいねした Place を取得する
+	FindLikePlacesByUserId(ctx context.Context, userId string) (*[]models.Place, error)
+
 	SaveGooglePlacePhotos(ctx context.Context, googlePlaceId string, photos []models.GooglePlacePhoto) error
 
 	SaveGooglePlaceDetail(ctx context.Context, googlePlaceId string, detail models.GooglePlaceDetail) error

--- a/internal/domain/services/user/find_liked_places.go
+++ b/internal/domain/services/user/find_liked_places.go
@@ -12,10 +12,7 @@ type FindLikedPlacesInput struct {
 }
 
 func (s Service) FindLikePlaces(ctx context.Context, input FindLikedPlacesInput) (*[]models.Place, error) {
-	checkAuthStateResult, err := s.CheckUserAuthState(ctx, CheckUserAuthStateInput{
-		UserId:            input.UserId,
-		FirebaseAuthToken: input.FirebaseAuthToken,
-	})
+	checkAuthStateResult, err := s.CheckUserAuthState(ctx, CheckUserAuthStateInput(input))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/services/user/find_liked_places.go
+++ b/internal/domain/services/user/find_liked_places.go
@@ -1,0 +1,33 @@
+package user
+
+import (
+	"context"
+	"fmt"
+	"poroto.app/poroto/planner/internal/domain/models"
+)
+
+type FindLikedPlacesInput struct {
+	UserId            string
+	FirebaseAuthToken string
+}
+
+func (s Service) FindLikePlaces(ctx context.Context, input FindLikedPlacesInput) (*[]models.Place, error) {
+	checkAuthStateResult, err := s.CheckUserAuthState(ctx, CheckUserAuthStateInput{
+		UserId:            input.UserId,
+		FirebaseAuthToken: input.FirebaseAuthToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if !checkAuthStateResult.IsAuthenticated {
+		return nil, fmt.Errorf("user is not authenticated")
+	}
+
+	likedPlaces, err := s.placeRepository.FindLikePlacesByUserId(ctx, input.UserId)
+	if err != nil {
+		return nil, fmt.Errorf("error while fetching liked places: %v", err)
+	}
+
+	return likedPlaces, nil
+}

--- a/internal/domain/services/user/service.go
+++ b/internal/domain/services/user/service.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Service struct {
-	userRepository repository.UserRepository
-	firebaseAuth   *auth.FirebaseAuth
+	userRepository  repository.UserRepository
+	placeRepository repository.PlaceRepository
+	firebaseAuth    *auth.FirebaseAuth
 }
 
 func NewService(ctx context.Context, db *sql.DB) (*Service, error) {
@@ -20,13 +21,19 @@ func NewService(ctx context.Context, db *sql.DB) (*Service, error) {
 		return nil, fmt.Errorf("error while initializing user repository: %v", err)
 	}
 
+	placeRepository, err := rdb.NewPlaceRepository(db)
+	if err != nil {
+		return nil, fmt.Errorf("error while initializing place repository: %v", err)
+	}
+
 	firebaseAuth, err := auth.NewFirebaseAuth(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error while initializing firebase auth: %v", err)
 	}
 
 	return &Service{
-		userRepository: userRepository,
-		firebaseAuth:   firebaseAuth,
+		userRepository:  userRepository,
+		placeRepository: placeRepository,
+		firebaseAuth:    firebaseAuth,
 	}, nil
 }

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -448,6 +448,10 @@ func (p PlaceRepository) FindLikePlacesByUserId(ctx context.Context, userId stri
 		}
 		return userLikePlace.PlaceID, true
 	})...)
+	if err != nil {
+		// いいね数の取得に失敗してもエラーにしない
+		p.logger.Warn("failed to count place like counts", zap.Error(err))
+	}
 
 	places := make([]models.Place, 0, len(userLikePlaces))
 	for _, userLikePlace := range userLikePlaces {

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -433,6 +433,67 @@ func (p PlaceRepository) FindByPlanCandidateId(ctx context.Context, planCandidat
 	return places, nil
 }
 
+func (p PlaceRepository) FindLikePlacesByUserId(ctx context.Context, userId string) (*[]models.Place, error) {
+	userLikePlaces, err := generated.UserLikePlaces(concatQueryMod(
+		[]qm.QueryMod{generated.UserLikePlaceWhere.UserID.EQ(userId)},
+		placeQueryModes(generated.PlanCandidateSetSearchedPlaceRels.Place),
+	)...).All(ctx, p.db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find user like places: %w", err)
+	}
+
+	placeLikeCounts, err := countPlaceLikeCounts(ctx, p.db, array.MapAndFilter(userLikePlaces, func(userLikePlace *generated.UserLikePlace) (string, bool) {
+		if userLikePlace == nil {
+			return "", false
+		}
+		return userLikePlace.PlaceID, true
+	})...)
+
+	places := make([]models.Place, 0, len(userLikePlaces))
+	for _, userLikePlace := range userLikePlaces {
+		if userLikePlace == nil {
+			continue
+		}
+
+		if userLikePlace.R == nil {
+			panic("userLikePlace.R is nil")
+		}
+
+		if userLikePlace.R.Place == nil {
+			p.logger.Warn("userLikePlace.R.Place is nil", zap.String("user_like_place_id", userLikePlace.ID))
+			continue
+		}
+
+		if userLikePlace.R.Place.R == nil {
+			panic("userLikePlace.R.Place.R is nil")
+		}
+
+		if len(userLikePlace.R.Place.R.GooglePlaces) == 0 {
+			p.logger.Warn("userLikePlace.R.Place.R.GooglePlaces is empty", zap.String("user_like_place_id", userLikePlace.ID))
+			continue
+		}
+
+		place, err := factory.NewPlaceFromEntity(
+			*userLikePlace.R.Place,
+			*userLikePlace.R.Place.R.GooglePlaces[0],
+			userLikePlace.R.Place.R.GooglePlaces[0].R.GooglePlaceTypes,
+			userLikePlace.R.Place.R.GooglePlaces[0].R.GooglePlacePhotoReferences,
+			userLikePlace.R.Place.R.GooglePlaces[0].R.GooglePlacePhotoAttributions,
+			userLikePlace.R.Place.R.GooglePlaces[0].R.GooglePlacePhotos,
+			userLikePlace.R.Place.R.GooglePlaces[0].R.GooglePlaceReviews,
+			userLikePlace.R.Place.R.GooglePlaces[0].R.GooglePlaceOpeningPeriods,
+			entities.CountLikeOfPlace(placeLikeCounts, userLikePlace.PlaceID),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert google place googlePlaceEntity to place: %w", err)
+		}
+
+		places = append(places, *place)
+	}
+
+	return &places, nil
+}
+
 func (p PlaceRepository) SaveGooglePlacePhotos(ctx context.Context, googlePlaceId string, photos []models.GooglePlacePhoto) error {
 	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
 		googlePlaceEntity, err := generated.GooglePlaces(

--- a/internal/interface/graphql/resolver/plan_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_mutation.resolvers.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"poroto.app/poroto/planner/internal/domain/array"
+	"poroto.app/poroto/planner/internal/domain/models"
 
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/services/plan"
-	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
 )
@@ -23,17 +24,7 @@ func (r *mutationResolver) UploadPlacePhotoInPlan(ctx context.Context, inputs []
 
 // LikeToPlaceInPlan is the resolver for the likeToPlaceInPlan field.
 func (r *mutationResolver) LikeToPlaceInPlan(ctx context.Context, input model.LikeToPlaceInPlanInput) (*model.LikeToPlaceInPlanOutput, error) {
-	logger, err := utils.NewLogger(utils.LoggerOption{Tag: "GraphQL"})
-	if err != nil {
-		return nil, fmt.Errorf("error while creating logger: %v", err)
-	}
-
-	planService, err := plan.NewService(ctx, r.DB)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating plan service: %v", err)
-	}
-
-	logger.Info(
+	r.Logger.Info(
 		"LikeToPlaceInPlan",
 		zap.String("planId", input.PlanID),
 		zap.String("placeId", input.PlaceID),
@@ -41,7 +32,7 @@ func (r *mutationResolver) LikeToPlaceInPlan(ctx context.Context, input model.Li
 		zap.Bool("like", input.Like),
 	)
 
-	plan, err := planService.LikeToPlace(
+	likeToPlaceResult, err := r.PlanService.LikeToPlace(
 		ctx,
 		plan.LikeToPlaceInput{
 			PlanId:            input.PlanID,
@@ -51,11 +42,11 @@ func (r *mutationResolver) LikeToPlaceInPlan(ctx context.Context, input model.Li
 			FirebaseAuthToken: input.FirebaseAuthToken,
 		})
 	if err != nil {
-		logger.Error("error while liking to place in plan", zap.Error(err))
+		r.Logger.Error("error while liking to place in plan", zap.Error(err))
 		return nil, fmt.Errorf("internal server error: %v", err)
 	}
 
-	graphqlPlan, err := factory.PlanFromDomainModel(*plan, nil)
+	graphqlPlan, err := factory.PlanFromDomainModel(likeToPlaceResult.Plan, nil)
 	if err != nil {
 		log.Println(err)
 		return nil, fmt.Errorf("internal server error")
@@ -63,5 +54,8 @@ func (r *mutationResolver) LikeToPlaceInPlan(ctx context.Context, input model.Li
 
 	return &model.LikeToPlaceInPlanOutput{
 		Plan: graphqlPlan,
+		LikedPlaceIds: array.Map(likeToPlaceResult.LikePlacesByUser, func(p models.Place) string {
+			return p.Id
+		}),
 	}, nil
 }

--- a/internal/interface/graphql/resolver/resolver.go
+++ b/internal/interface/graphql/resolver/resolver.go
@@ -2,12 +2,18 @@
 
 package resolver
 
-import "database/sql"
+import (
+	"database/sql"
+	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/services/user"
+)
 
 // This file will not be regenerated automatically.
 //
 // It serves as dependency injection for your app, add any dependencies you require here.
 
 type Resolver struct {
-	DB *sql.DB
+	Logger      *zap.Logger
+	DB          *sql.DB
+	UserService *user.Service
 }

--- a/internal/interface/graphql/resolver/resolver.go
+++ b/internal/interface/graphql/resolver/resolver.go
@@ -5,6 +5,7 @@ package resolver
 import (
 	"database/sql"
 	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/services/plan"
 	"poroto.app/poroto/planner/internal/domain/services/user"
 )
 
@@ -16,4 +17,5 @@ type Resolver struct {
 	Logger      *zap.Logger
 	DB          *sql.DB
 	UserService *user.Service
+	PlanService *plan.Service
 }

--- a/internal/interface/rest/graphql.go
+++ b/internal/interface/rest/graphql.go
@@ -5,6 +5,10 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"log"
+	"poroto.app/poroto/planner/internal/domain/services/user"
+	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/generated"
 	"poroto.app/poroto/planner/internal/interface/graphql/resolver"
 )
@@ -16,8 +20,28 @@ func GraphQlPlayGround(c *gin.Context) {
 
 func GraphQlQueryHandler(db *sql.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		logger, err := utils.NewLogger(utils.LoggerOption{
+			Tag: "GraphQL",
+		})
+		if err != nil {
+			log.Println("error while initializing Logger: ", err)
+			c.JSON(500, gin.H{
+				"error": "internal server error",
+			})
+		}
+
+		userService, err := user.NewService(c.Request.Context(), db)
+		if err != nil {
+			logger.Error("error while initializing user service", zap.Error(err))
+			c.JSON(500, gin.H{
+				"error": "internal server error",
+			})
+		}
+
 		schema := generated.NewExecutableSchema(generated.Config{Resolvers: &resolver.Resolver{
-			DB: db,
+			Logger:      logger,
+			DB:          db,
+			UserService: userService,
 		}})
 		h := handler.NewDefaultServer(schema)
 		h.ServeHTTP(c.Writer, c.Request)


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プラン内の場所にたいしていいねしたときや、プランを取得したときにユーザーがいいねした場所を取得できるようにした
- また、どこにいいねしたかを確認できるのは本人だけにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #442 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] ログイン状態のユーザーがいいねできることを確認（Postman > update_like_places）
- [x] ログイン状態のユーザーがいいねした場所を取得できることを確認（Postman > get_like_places）

**Postmanでユーザーのログイン状態を再現する方法**
1. porotoでログインを行う
2. ReduxからUserIDを確認する
1. porotoのコードを書き換えて、ログイントークンをコンソールに出力して確認する
    https://github.com/poroto-app/poroto/blob/d5f7acbbbf8c3ce7437ed16f361cc6ea4aefd00d/src/view/hooks/useAuth.ts#L25
    ```ts
    console.log("idToken", idToken);
    ```
1. UserIDを`userId`, ログイントークンを`firebaseAuthToken`に入力する

```shell
# planner
export BRANCH_PLANNER=feature/get_user_like_places
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```