### PR TITLE
[Graphql] プラン候補を指定するときにログインユーザーとして取得できるようにする

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1599,6 +1599,8 @@ type LikeToPlaceInPlanCandidateOutput {
 
 input PlanCandidateInput {
     planCandidateId: ID!
+    userId: String
+    firebaseAuthToken: String
 }
 
 type PlanCandidateOutput {
@@ -10894,7 +10896,7 @@ func (ec *executionContext) unmarshalInputPlanCandidateInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"planCandidateId"}
+	fieldsInOrder := [...]string{"planCandidateId", "userId", "firebaseAuthToken"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10910,6 +10912,24 @@ func (ec *executionContext) unmarshalInputPlanCandidateInput(ctx context.Context
 				return it, err
 			}
 			it.PlanCandidateID = data
+		case "userId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserID = data
+		case "firebaseAuthToken":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("firebaseAuthToken"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FirebaseAuthToken = data
 		}
 	}
 

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -252,7 +252,9 @@ type PlanCandidate struct {
 }
 
 type PlanCandidateInput struct {
-	PlanCandidateID string `json:"planCandidateId"`
+	PlanCandidateID   string  `json:"planCandidateId"`
+	UserID            *string `json:"userId,omitempty"`
+	FirebaseAuthToken *string `json:"firebaseAuthToken,omitempty"`
 }
 
 type PlanCandidateOutput struct {

--- a/internal/interface/graphql/resolver/plan_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_mutation.resolvers.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"poroto.app/poroto/planner/internal/domain/array"
-	"poroto.app/poroto/planner/internal/domain/models"
 
 	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/array"
+	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/plan"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"

--- a/internal/interface/graphql/resolver/user_query.resolvers.go
+++ b/internal/interface/graphql/resolver/user_query.resolvers.go
@@ -7,18 +7,18 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"log"
+
+	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/models"
-
 	"poroto.app/poroto/planner/internal/domain/services/user"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
-	graphql "poroto.app/poroto/planner/internal/interface/graphql/model"
+	"poroto.app/poroto/planner/internal/interface/graphql/model"
 )
 
 // FirebaseUser is the resolver for the firebaseUser field.
-func (r *queryResolver) FirebaseUser(ctx context.Context, input *graphql.FirebaseUserInput) (*graphql.User, error) {
+func (r *queryResolver) FirebaseUser(ctx context.Context, input *model.FirebaseUserInput) (*model.User, error) {
 	service, err := user.NewService(ctx, r.DB)
 	if err != nil {
 		log.Printf("error while initializing user service: %v\n", err)
@@ -35,7 +35,7 @@ func (r *queryResolver) FirebaseUser(ctx context.Context, input *graphql.Firebas
 }
 
 // LikePlaces is the resolver for the likePlaces field.
-func (r *queryResolver) LikePlaces(ctx context.Context, input *graphql.LikePlacesInput) ([]*graphql.Place, error) {
+func (r *queryResolver) LikePlaces(ctx context.Context, input *model.LikePlacesInput) ([]*model.Place, error) {
 	placesLikedByUser, err := r.UserService.FindLikePlaces(ctx, user.FindLikedPlacesInput{
 		UserId:            input.UserID,
 		FirebaseAuthToken: input.FirebaseAuthToken,
@@ -45,7 +45,7 @@ func (r *queryResolver) LikePlaces(ctx context.Context, input *graphql.LikePlace
 		return nil, fmt.Errorf("internal error")
 	}
 
-	graphqlPlaces := array.Map(*placesLikedByUser, func(place models.Place) *graphql.Place {
+	graphqlPlaces := array.Map(*placesLikedByUser, func(place models.Place) *model.Place {
 		return factory.PlaceFromDomainModel(&place)
 	})
 

--- a/internal/interface/graphql/schema/plan_candidate_query.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_query.graphqls
@@ -16,6 +16,8 @@ extend type Query {
 
 input PlanCandidateInput {
     planCandidateId: ID!
+    userId: String
+    firebaseAuthToken: String
 }
 
 type PlanCandidateOutput {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プランを作成するときに、ログインユーザーの場合、そのユーザーがいいねした場所を取得する必要がある
- そのために、ログイン情報を付け加えられるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #443 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/graphql_plan_candidate_with_user
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```