### PR TITLE
プラン作成中もログインユーザーとしていいねをできるようにする

### DIFF
--- a/internal/domain/services/plancandidate/find.go
+++ b/internal/domain/services/plancandidate/find.go
@@ -2,12 +2,49 @@ package plancandidate
 
 import (
 	"context"
+	"fmt"
+	"poroto.app/poroto/planner/internal/domain/array"
+	"poroto.app/poroto/planner/internal/domain/services/user"
 	"time"
 
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-func (s Service) FindPlanCandidate(ctx context.Context, planCandidateId string) (*models.PlanCandidate, error) {
-	// TODO: ユーザーとして Like した場所を取得できるようにする
-	return s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+type FindPlanCandidateInput struct {
+	PlanCandidateId   string
+	UserId            *string
+	FirebaseAuthToken *string
+}
+
+func (s Service) FindPlanCandidate(ctx context.Context, input FindPlanCandidateInput) (*models.PlanCandidate, error) {
+	planCandidate, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateId, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("error finding plan candidate: %w", err)
+	}
+
+	// ログインしている場合は、そのユーザーがいいねした場所を取得する
+	if input.UserId != nil && input.FirebaseAuthToken != nil {
+		checkAuthResult, err := s.userService.CheckUserAuthState(ctx, user.CheckUserAuthStateInput{
+			UserId:            *input.UserId,
+			FirebaseAuthToken: *input.FirebaseAuthToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if !checkAuthResult.IsAuthenticated {
+			return nil, fmt.Errorf("user is not authorized")
+		}
+
+		likePlaces, err := s.placeRepository.FindLikePlacesByUserId(ctx, *input.UserId)
+		if err != nil {
+			return nil, fmt.Errorf("error finding like places: %w", err)
+		}
+
+		planCandidate.LikedPlaceIds = array.Map(*likePlaces, func(place models.Place) string {
+			return place.Id
+		})
+	}
+
+	return planCandidate, nil
 }

--- a/internal/domain/services/plancandidate/like_to_place.go
+++ b/internal/domain/services/plancandidate/like_to_place.go
@@ -50,7 +50,11 @@ func (s Service) LikeToPlaceInPlanCandidate(
 		}
 	}
 
-	planCandidate, err := s.FindPlanCandidate(ctx, input.PlanCandidateId)
+	planCandidate, err := s.FindPlanCandidate(ctx, FindPlanCandidateInput{
+		PlanCandidateId:   input.PlanCandidateId,
+		UserId:            input.UserId,
+		FirebaseAuthToken: input.FirebaseAuthToken,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plan candidate after updating: %v", err)
 	}

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -145,7 +145,9 @@ func (r *mutationResolver) ChangePlacesOrderInPlanCandidate(ctx context.Context,
 		return nil, fmt.Errorf("could not change places order")
 	}
 
-	planCandidate, err := service.FindPlanCandidate(ctx, input.Session)
+	planCandidate, err := service.FindPlanCandidate(ctx, plancandidate.FindPlanCandidateInput{
+		PlanCandidateId: input.Session,
+	})
 	if err != nil {
 		log.Println(fmt.Errorf("error while finding plan candidate: %v", err))
 		return nil, fmt.Errorf("internal server error")
@@ -213,7 +215,9 @@ func (r *mutationResolver) AddPlaceToPlanCandidateAfterPlace(ctx context.Context
 		return nil, fmt.Errorf("could not add place to plan candidate")
 	}
 
-	planCandidate, err := s.FindPlanCandidate(ctx, input.PlanCandidateID)
+	planCandidate, err := s.FindPlanCandidate(ctx, plancandidate.FindPlanCandidateInput{
+		PlanCandidateId: input.PlanCandidateID,
+	})
 	if err != nil {
 		log.Println(fmt.Errorf("error while finding plan candidate: %v", err))
 		return nil, fmt.Errorf("internal server error")
@@ -244,7 +248,9 @@ func (r *mutationResolver) DeletePlaceFromPlanCandidate(ctx context.Context, inp
 		return nil, fmt.Errorf("could not delete place from plan candidate")
 	}
 
-	planCandidate, err := s.FindPlanCandidate(ctx, input.PlanCandidateID)
+	planCandidate, err := s.FindPlanCandidate(ctx, plancandidate.FindPlanCandidateInput{
+		PlanCandidateId: input.PlanCandidateID,
+	})
 	if err != nil {
 		log.Println(fmt.Errorf("error while finding plan candidate: %v", err))
 		return nil, fmt.Errorf("internal server error")
@@ -276,7 +282,9 @@ func (r *mutationResolver) ReplacePlaceOfPlanCandidate(ctx context.Context, inpu
 		return nil, fmt.Errorf("could not replace place of plan candidate")
 	}
 
-	planCandidate, err := s.FindPlanCandidate(ctx, input.PlanCandidateID)
+	planCandidate, err := s.FindPlanCandidate(ctx, plancandidate.FindPlanCandidateInput{
+		PlanCandidateId: input.PlanCandidateID,
+	})
 	if err != nil {
 		log.Println(fmt.Errorf("error while finding plan candidate: %v", err))
 		return nil, fmt.Errorf("internal server error")

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -38,7 +38,11 @@ func (r *queryResolver) PlanCandidate(ctx context.Context, input model.PlanCandi
 		zap.String("planCandidateId", input.PlanCandidateID),
 	)
 
-	planCandidate, err := planService.FindPlanCandidate(ctx, input.PlanCandidateID)
+	planCandidate, err := planService.FindPlanCandidate(ctx, plancandidate.FindPlanCandidateInput{
+		PlanCandidateId:   input.PlanCandidateID,
+		UserId:            input.UserID,
+		FirebaseAuthToken: input.FirebaseAuthToken,
+	})
 	if err != nil {
 		logger.Error("error while finding plan candidate", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プラン作成中は「いいね」をするとプラン候補に結びつくようになっていた
- ログインしている場合は、「いいね」がユーザーに紐づくようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- ログイン状態でプランを作成したときに、適切にいいねができるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認（https://github.com/poroto-app/poroto/pull/508）

```shell
# planner
export BRANCH_PLANNER=feature/plan_candidate_with_user
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```