### PR TITLE
TestShufflePlacesが落ちないようにする

### DIFF
--- a/internal/domain/models/place_test.go
+++ b/internal/domain/models/place_test.go
@@ -77,6 +77,8 @@ func TestShufflePlaces(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		t.Parallel()
+		c := c
 		t.Run(c.name, func(t *testing.T) {
 			original := make([]Place, len(c.places))
 			copy(original, c.places)

--- a/internal/domain/models/place_test.go
+++ b/internal/domain/models/place_test.go
@@ -62,10 +62,16 @@ func TestShufflePlaces(t *testing.T) {
 		{
 			name: "should return shuffled places",
 			places: []Place{
-				NewMockPlaceShinjukuStation(),
-				NewMockPlaceIsetan(),
-				NewMockPlaceShinjukuGyoen(),
-				NewMockPlaceTakashimaya(),
+				{Id: "1"},
+				{Id: "2"},
+				{Id: "3"},
+				{Id: "4"},
+				{Id: "5"},
+				{Id: "6"},
+				{Id: "7"},
+				{Id: "8"},
+				{Id: "9"},
+				{Id: "10"},
 			},
 		},
 	}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 配列をシャッフルするテストで要素数が少ないためにテストが落ちることが頻繁に発生した
- テストのデータ数を3から10に増やすことで、テストが落ちづらくなるようにした

```sh
# 落ちる確率（予想）
1 / 3! = 6
1 / 10! = 3628800
```

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- テストが落ちないようにする

### どのようにテストされているか
- [x] 以下のコマンドで10回テストを実行して落ちないことを確認
```fish
for i in (seq 10)                                                                                                                                                                                
          go test -count=1 ./...
  end

```

```shell
# planner
export BRANCH_PLANNER=feature/fix_shuffle_test
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```