### PR TITLE
指定した場所を基準として追加する場所が提案されるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ goose -dir db/migrations create <your migration name> sql
 ```shell
 DB_USER=root \
 DB_PASSWORD=password \
-DB_HOST=localhost:3306 \
+DB_HOST=localhost \
+DB_PORT=3306 \
 DB_NAME=poroto \
-goose -dir db/migrations mysql "$DB_USER:$DB_PASSWORD@tcp($DB_HOST)/$DB_NAME?parseTime=true&loc=Asia%2FTokyo" up
+goose -dir db/migrations -certfile=/etc/ssl/cert.pem mysql "$DB_USER:$DB_PASSWORD@tcp($DB_HOST:$DB_PORT)/$DB_NAME?parseTime=true&loc=Asia%2FTokyo" up
 ```
 
 ### SQLBoilerをインストール

--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -42,6 +42,14 @@ func (p Place) EstimatedPriceRange() (priceRange *PriceRange) {
 	return PriceRangeFromGooglePriceLevel(p.Google.PriceLevel)
 }
 
+func (p Place) CreateTransition(destination Place) Transition {
+	return Transition{
+		FromPlaceId: &p.Id,
+		ToPlaceId:   destination.Id,
+		Duration:    p.Location.TravelTimeTo(destination.Location, 80.0),
+	}
+}
+
 // ShufflePlaces 場所の順番をシャッフルする
 func ShufflePlaces(places []Place) []Place {
 	placesCopy := make([]Place, len(places))

--- a/internal/domain/models/transition.go
+++ b/internal/domain/models/transition.go
@@ -24,15 +24,11 @@ func CreateTransition(places []Place, startLocation *GeoLocation) []Transition {
 		})
 	}
 
-	for i, place := range places {
+	for i := range places {
 		if i >= len(places)-1 {
 			break
 		}
-		transitions = append(transitions, Transition{
-			FromPlaceId: &places[i].Id,
-			ToPlaceId:   places[i+1].Id,
-			Duration:    place.Location.TravelTimeTo(places[i+1].Location, 80.0),
-		})
+		transitions = append(transitions, places[i].CreateTransition(places[i+1]))
 	}
 
 	return transitions

--- a/internal/domain/services/place/places_to_add.go
+++ b/internal/domain/services/place/places_to_add.go
@@ -24,6 +24,7 @@ type FetchPlacesToAddInput struct {
 type FetchPlacesToAddOutput struct {
 	PlacesRecommended []models.Place
 	PlacesGrouped     []categoryGroupedPlaces
+	PlacesAll         []models.Place
 	Transitions       []models.Transition
 }
 
@@ -210,6 +211,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 	placesAll = append(placesAll, array.FlatMap(placesGrouped, func(categoryGroupedPlaces categoryGroupedPlaces) []models.Place {
 		return categoryGroupedPlaces.Places
 	})...)
+	placesAll = append(placesAll, startPlace)
 	placesAll = array.DistinctBy(placesAll, func(place models.Place) string {
 		return place.Id
 	})
@@ -220,6 +222,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 	return &FetchPlacesToAddOutput{
 		PlacesRecommended: placesRecommend,
 		PlacesGrouped:     placesGrouped,
+		PlacesAll:         placesAll,
 		Transitions:       transitions,
 	}, nil
 }

--- a/internal/domain/services/place/places_to_add.go
+++ b/internal/domain/services/place/places_to_add.go
@@ -17,6 +17,7 @@ const (
 type FetchPlacesToAddInput struct {
 	PlanCandidateId string
 	PlanId          string
+	PlaceId         *string
 	NLimit          uint
 }
 
@@ -64,7 +65,18 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 		return nil, fmt.Errorf("plan has no places")
 	}
 
-	startPlace := plan.Places[0]
+	var startPlace models.Place
+	if input.PlaceId != nil {
+		p, found := array.Find(plan.Places, func(place models.Place) bool {
+			return place.Id == *input.PlaceId
+		})
+		if !found {
+			return nil, fmt.Errorf("place(%s) not found in plan", *input.PlaceId)
+		}
+		startPlace = p
+	} else {
+		startPlace = plan.Places[0]
+	}
 
 	placesSearched, err := s.placeSearchService.FetchSearchedPlaces(ctx, input.PlanCandidateId)
 	if err != nil {

--- a/internal/infrastructure/rdb/plan_candidate.go
+++ b/internal/infrastructure/rdb/plan_candidate.go
@@ -66,8 +66,8 @@ func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateId strin
 		},
 		placeQueryModes(generated.PlanCandidateSetRels.PlanCandidatePlaces, generated.PlanCandidatePlaceRels.Place),
 	)...).One(ctx, p.db)
-
 	if err != nil {
+		// TODO: エラーにする
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}

--- a/internal/interface/graphql/factory/transition.go
+++ b/internal/interface/graphql/factory/transition.go
@@ -1,0 +1,34 @@
+package factory
+
+import (
+	"fmt"
+	"poroto.app/poroto/planner/internal/domain/array"
+	"poroto.app/poroto/planner/internal/domain/models"
+	graphql "poroto.app/poroto/planner/internal/interface/graphql/model"
+)
+
+func TransitionFromDomainModel(transition models.Transition, places []models.Place) (*graphql.Transition, error) {
+	var placeFrom *models.Place
+	if transition.FromPlaceId != nil {
+		p, found := array.Find(places, func(p models.Place) bool {
+			return p.Id == *transition.FromPlaceId
+		})
+		if !found {
+			return nil, fmt.Errorf("could not find place %s", *transition.FromPlaceId)
+		}
+		placeFrom = &p
+	}
+
+	placeTo, found := array.Find(places, func(p models.Place) bool {
+		return p.Id == transition.ToPlaceId
+	})
+	if !found {
+		return nil, fmt.Errorf("could not find place %s", transition.ToPlaceId)
+	}
+
+	return &graphql.Transition{
+		From:     PlaceFromDomainModel(placeFrom),
+		To:       PlaceFromDomainModel(&placeTo),
+		Duration: int(transition.Duration),
+	}, nil
+}

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -111,6 +111,7 @@ func (r *queryResolver) PlacesToAddForPlanCandidate(ctx context.Context, input m
 	result, err := r.PlaceService.FetchPlacesToAdd(ctx, place.FetchPlacesToAddInput{
 		PlanCandidateId: input.PlanCandidateID,
 		PlanId:          input.PlanID,
+		PlaceId:         input.PlaceID,
 		NLimit:          4,
 	})
 	if err != nil {

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -7,6 +7,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"poroto.app/poroto/planner/internal/domain/array"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -145,9 +146,18 @@ func (r *queryResolver) PlacesToAddForPlanCandidate(ctx context.Context, input m
 		})
 	}
 
+	graphqlTransitions, err := array.MapWithErr(result.Transitions, func(transition models.Transition) (**model.Transition, error) {
+		t, err := factory.TransitionFromDomainModel(transition, result.PlacesAll)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	})
+
 	return &model.PlacesToAddForPlanCandidateOutput{
 		Places:                  places,
 		PlacesGroupedByCategory: placesGroupedByCategory,
+		Transitions:             *graphqlTransitions,
 	}, nil
 }
 


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プラン編集画面で追加しようとした場所を基準として、候補となる場所が提示されるように修正した
- また、基準となる場所からの移動時間も取得できるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #469 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- プラン作成をより行いやすくするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 指定した場所を基準としたTransitionの情報が取得できることを確認（Postman）

```shell
# planner
export BRANCH_PLANNER=feature/add_place_by_selected_place
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```