### PR TITLE
[スキーマ変更]画像がGoogleから取得したものかユーザーによりアップロードされたものかを区別できるようにする

### DIFF
--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -108,7 +108,10 @@ type ComplexityRoot struct {
 	}
 
 	Image struct {
+		Author  func(childComplexity int) int
 		Default func(childComplexity int) int
+		Google  func(childComplexity int) int
+		ID      func(childComplexity int) int
 		Large   func(childComplexity int) int
 		Small   func(childComplexity int) int
 	}
@@ -512,12 +515,33 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.GooglePlaceReview.Time(childComplexity), true
 
+	case "Image.author":
+		if e.complexity.Image.Author == nil {
+			break
+		}
+
+		return e.complexity.Image.Author(childComplexity), true
+
 	case "Image.default":
 		if e.complexity.Image.Default == nil {
 			break
 		}
 
 		return e.complexity.Image.Default(childComplexity), true
+
+	case "Image.google":
+		if e.complexity.Image.Google == nil {
+			break
+		}
+
+		return e.complexity.Image.Google(childComplexity), true
+
+	case "Image.id":
+		if e.complexity.Image.ID == nil {
+			break
+		}
+
+		return e.complexity.Image.ID(childComplexity), true
 
 	case "Image.large":
 		if e.complexity.Image.Large == nil {
@@ -1410,9 +1434,13 @@ var sources = []*ast.Source{
 }
 
 type Image {
+    id: ID!
     default: String!
     small: String
     large: String
+    # Google Places APIから取得した画像かどうか
+    google: Boolean!
+    author: User
 }
 `, BuiltIn: false},
 	{Name: "../schema/place_query.graphqls", Input: `extend type Query {
@@ -3648,6 +3676,50 @@ func (ec *executionContext) fieldContext_GooglePlaceReview_originalLanguage(ctx 
 	return fc, nil
 }
 
+func (ec *executionContext) _Image_id(ctx context.Context, field graphql.CollectedField, obj *model.Image) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Image_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Image_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Image",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Image_default(ctx context.Context, field graphql.CollectedField, obj *model.Image) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Image_default(ctx, field)
 	if err != nil {
@@ -3769,6 +3841,99 @@ func (ec *executionContext) fieldContext_Image_large(ctx context.Context, field 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Image_google(ctx context.Context, field graphql.CollectedField, obj *model.Image) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Image_google(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Google, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Image_google(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Image",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Image_author(ctx context.Context, field graphql.CollectedField, obj *model.Image) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Image_author(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Author, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.User)
+	fc.Result = res
+	return ec.marshalOUser2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Image_author(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Image",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "photoUrl":
+				return ec.fieldContext_User_photoUrl(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
 	}
 	return fc, nil
@@ -5401,12 +5566,18 @@ func (ec *executionContext) fieldContext_Place_images(ctx context.Context, field
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Image_id(ctx, field)
 			case "default":
 				return ec.fieldContext_Image_default(ctx, field)
 			case "small":
 				return ec.fieldContext_Image_small(ctx, field)
 			case "large":
 				return ec.fieldContext_Image_large(ctx, field)
+			case "google":
+				return ec.fieldContext_Image_google(ctx, field)
+			case "author":
+				return ec.fieldContext_Image_author(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Image", field.Name)
 		},
@@ -12109,6 +12280,11 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Image")
+		case "id":
+			out.Values[i] = ec._Image_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "default":
 			out.Values[i] = ec._Image_default(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12118,6 +12294,13 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 			out.Values[i] = ec._Image_small(ctx, field, obj)
 		case "large":
 			out.Values[i] = ec._Image_large(ctx, field, obj)
+		case "google":
+			out.Values[i] = ec._Image_google(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "author":
+			out.Values[i] = ec._Image_author(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -137,9 +137,12 @@ type GooglePlaceReview struct {
 }
 
 type Image struct {
+	ID      string  `json:"id"`
 	Default string  `json:"default"`
 	Small   *string `json:"small,omitempty"`
 	Large   *string `json:"large,omitempty"`
+	Google  bool    `json:"google"`
+	Author  *User   `json:"author,omitempty"`
 }
 
 type LikePlacesInput struct {

--- a/internal/interface/graphql/schema/image_type.graphqls
+++ b/internal/interface/graphql/schema/image_type.graphqls
@@ -4,7 +4,11 @@ enum ImageSize {
 }
 
 type Image {
+    id: ID!
     default: String!
     small: String
     large: String
+    # Google Places APIから取得した画像かどうか
+    google: Boolean!
+    author: User
 }


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 画像のアップロードもとを区別できるようにするために、Graphqlのスキーマを変更した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/graphql_place_photo_google_or_user
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```