### PR TITLE
より短い住所データを取得できるようにする

### DIFF
--- a/internal/domain/models/place.go
+++ b/internal/domain/models/place.go
@@ -3,6 +3,8 @@ package models
 import (
 	"math"
 	"math/rand"
+	"poroto.app/poroto/planner/internal/domain/utils"
+	"regexp"
 	"sort"
 )
 
@@ -26,6 +28,22 @@ func (p Place) MainCategory() *LocationCategory {
 		return nil
 	}
 	return &p.Categories()[0]
+}
+
+// ShortenAddress 番地等の細かい情報のない住所を取得する
+func (p Place) ShortenAddress() *string {
+	if p.Address == nil {
+		return nil
+	}
+
+	re := regexp.MustCompile(`^(.*?)[0-9０-９]`)
+	match := re.FindStringSubmatch(*p.Address)
+	if len(match) > 1 {
+		return utils.ToPointer(match[1])
+	}
+
+	// 数字が含まれていない
+	return p.Address
 }
 
 // PlacePhotosSortedByUploadedAt 新しい画像が先頭になるように並び替える

--- a/internal/domain/models/place_test.go
+++ b/internal/domain/models/place_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"github.com/google/go-cmp/cmp"
+	"poroto.app/poroto/planner/internal/domain/utils"
 	"testing"
 	"time"
 )
@@ -54,6 +55,56 @@ func TestPlace_EstimatedStayDuration(t *testing.T) {
 	}
 }
 
+func TestPlace_ShortenAddress(t *testing.T) {
+	cases := []struct {
+		name     string
+		place    Place
+		expected *string
+	}{
+		{
+			name: "should return address without numbers",
+			place: Place{
+				Address: utils.ToPointer("相模原市中央区淵野辺1丁目13−12"),
+			},
+			expected: utils.ToPointer("相模原市中央区淵野辺"),
+		},
+		{
+			name: "should return address without full-width numbers",
+			place: Place{
+				Address: utils.ToPointer("相模原市中央区淵野辺１丁目１３−１２"),
+			},
+			expected: utils.ToPointer("相模原市中央区淵野辺"),
+		},
+		{
+			name: "should return original address",
+			place: Place{
+				Address: utils.ToPointer("相模原市中央区淵野辺"),
+			},
+			expected: utils.ToPointer("相模原市中央区淵野辺"),
+		},
+		{
+			name: "should return nil if value is empty",
+			place: Place{
+				Address: nil,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := c.place.ShortenAddress()
+
+			if diff := cmp.Diff(c.expected, actual); diff != "" {
+				t.Errorf("ShortenAddress() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestShufflePlaces(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -78,9 +129,10 @@ func TestShufflePlaces(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Parallel()
 		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			original := make([]Place, len(c.places))
 			copy(original, c.places)
 

--- a/internal/interface/graphql/factory/place.go
+++ b/internal/interface/graphql/factory/place.go
@@ -52,7 +52,7 @@ func PlaceFromDomainModel(place *models.Place) *graphql.Place {
 		GooglePlaceID: place.Google.PlaceId,
 		Name:          place.Name,
 		Images:        images,
-		Address:       place.Address,
+		Address:       place.ShortenAddress(),
 		Location: &graphql.GeoLocation{
 			Latitude:  place.Location.Latitude,
 			Longitude: place.Location.Longitude,


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 番地情報等が含まれない大雑把な住所情報を取得できるようにした

![image](https://github.com/poroto-app/planner/assets/55840281/900f6b4b-39bf-476a-90db-037b22be7f73)


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 大まかな住所を知れるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] porotoで表示したときに、適切に住所が表示されることを確認（https://github.com/poroto-app/poroto/pull/632）

```shell
# planner
export BRANCH_PLANNER=feature/place_address_shorten
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=feature/place_with_address
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```