### PR TITLE
DBに保存されたGoogle Places Photoの画質を下げる

### DIFF
--- a/cmd/features/down_size_google_place_photo/main.go
+++ b/cmd/features/down_size_google_place_photo/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"log"
+	"poroto.app/poroto/planner/internal/env"
+	"poroto.app/poroto/planner/internal/infrastructure/rdb"
+	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
+	"regexp"
+	"strings"
+)
+
+func main() {
+	env.LoadEnv()
+
+	db, err := rdb.InitDB(false)
+	if err != nil {
+		log.Fatalf("error while initializing db: %v", err)
+	}
+
+	ctx := context.Background()
+	googlePlacePhotoSlice, err := generated.GooglePlacePhotos().All(ctx, db)
+	if err != nil {
+		log.Fatalf("error while getting google place photos: %v", err)
+	}
+
+	for _, googlePlacePhoto := range googlePlacePhotoSlice {
+		newUrl, err := rewriteUrl(googlePlacePhoto.URL, 500, 500)
+		if err != nil {
+			log.Printf("error while rewriting URL: %v", err)
+			continue
+		}
+
+		googlePlacePhoto.URL = *newUrl
+		if _, err := googlePlacePhoto.Update(ctx, db, boil.Infer()); err != nil {
+			log.Printf("error while updating google place photo: %v", err)
+			continue
+		}
+	}
+}
+
+func rewriteUrl(url string, width int, height int) (*string, error) {
+	// URLの最後の部分を取得
+	parts := strings.Split(url, "=")
+	if len(parts) < 2 {
+		fmt.Println("Invalid URL format")
+		return nil, fmt.Errorf("invalid URL format")
+	}
+	lastPart := parts[len(parts)-1]
+
+	// 正規表現パターンを定義
+	re := regexp.MustCompile(`w\d+-h\d+`)
+
+	// 置換文字列を定義
+	newSuffix := fmt.Sprintf("w%d-h%d", width, height)
+
+	// URLの最後の部分の書き換え
+	updatedLastPart := re.ReplaceAllString(lastPart, newSuffix)
+
+	// 更新されたURLを組み立て
+	updatedURL := strings.Join(parts[:len(parts)-1], "=") + "=" + updatedLastPart
+
+	return &updatedURL, nil
+}

--- a/cmd/features/down_size_google_place_photo/main_test.go
+++ b/cmd/features/down_size_google_place_photo/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"poroto.app/poroto/planner/internal/domain/utils"
+	"testing"
+)
+
+func TestRewriteUrl(t *testing.T) {
+	cases := []struct {
+		name     string
+		url      string
+		width    int
+		height   int
+		expected *string
+	}{
+		{
+			name:     "valid url",
+			url:      "https://lh3.googleusercontent.com/places/photo_id=s1600-w2000-h2000",
+			width:    500,
+			height:   500,
+			expected: utils.ToPointer("https://lh3.googleusercontent.com/places/photo_id=s1600-w500-h500"),
+		},
+		{
+			name:     "invalid url",
+			url:      "https://lh3.googleusercontent.com/places/photo_id",
+			width:    500,
+			height:   500,
+			expected: nil,
+		},
+		{
+			name:     "replace only last part",
+			url:      "https://lh3.googleusercontent.com/places/photo_w2000-h2000=s1600-w2000-h2000",
+			width:    500,
+			height:   500,
+			expected: utils.ToPointer("https://lh3.googleusercontent.com/places/photo_w2000-h2000=s1600-w500-h500"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result, _ := rewriteUrl(c.url, c.width, c.height)
+			if diff := cmp.Diff(result, c.expected); diff != "" {
+				t.Errorf("expected: %v, result: %v", c.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- DBに保存された高画質なGoogle Places PhotoのURLを500x500まで低下させるように書き換えるスクリプトを作成

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #505

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- トップページの読み込み速度を改善するため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] ローカルPCで動作させたときに、適切に書き換わることを確認
- [x] 新しいURLを作成する関数の単体テストを作成 

```shell
# planner
export BRANCH_PLANNER=feature/down_size_google_place_photo
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```