### PR TITLE
Google Places APIから取得する画像サイズを小さくする

### DIFF
--- a/internal/infrastructure/api/google/places/photos.go
+++ b/internal/infrastructure/api/google/places/photos.go
@@ -21,8 +21,8 @@ type PlacePhotoWithSize struct {
 }
 
 const (
-	imgMaxHeight = 2000
-	imgMaxWidth  = 2000
+	imgMaxHeight = 500
+	imgMaxWidth  = 500
 )
 
 func imgUrlBuilder(maxWidth uint, maxHeight uint, photoReference string, apiKey string) (string, error) {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- Google Place Photos APIから取得する画像のサイズを 最大 500x500になるように修正した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #506 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- トップページの読み込み速度を改善するため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 新たに画像を取得したときに、500x500未満の画像が取得されることを確認

```shell
# planner
export BRANCH_PLANNER=feature/google_place_photo_resolution
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```