### PR TITLE
すでに保存されているプランをカスタムできるようにする

### DIFF
--- a/internal/domain/services/plancandidate/create_from_saved_plan.go
+++ b/internal/domain/services/plancandidate/create_from_saved_plan.go
@@ -1,0 +1,57 @@
+package plancandidate
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"poroto.app/poroto/planner/internal/domain/models"
+)
+
+type CreatePlanCandidateSetFromSavedPlanInput struct {
+	PlanId            string
+	UserId            *string
+	FirebaseAuthToken *string
+}
+
+type CreatePlanCandidateSetFromSavedPlanOutput struct {
+	PlanCandidateSet models.PlanCandidate
+}
+
+func (s Service) CreatePlanCandidateSetFromSavedPlan(ctx context.Context, input CreatePlanCandidateSetFromSavedPlanInput) (*CreatePlanCandidateSetFromSavedPlanOutput, error) {
+	plan, err := s.planRepository.Find(ctx, input.PlanId)
+	if err != nil {
+		return nil, fmt.Errorf("error while fetching plan: %v", err)
+	}
+
+	if plan == nil {
+		return nil, fmt.Errorf("plan not found")
+	}
+
+	// 保存されるときにもとのプランと別のIDになるようにする
+	copiedPlan := plan
+	copiedPlan.Id = uuid.New().String()
+
+	newPlanCandidateSetId := uuid.New().String()
+
+	if err := s.CreatePlanCandidate(ctx, newPlanCandidateSetId); err != nil {
+		return nil, fmt.Errorf("error while creating plan candidate: %v", err)
+	}
+
+	if err := s.planCandidateRepository.AddPlan(ctx, newPlanCandidateSetId, *copiedPlan); err != nil {
+		return nil, fmt.Errorf("error while adding plan to plan candidate: %v", err)
+	}
+
+	planCandidateSet, err := s.FindPlanCandidate(ctx, FindPlanCandidateInput{
+		PlanCandidateId:   newPlanCandidateSetId,
+		UserId:            input.UserId,
+		FirebaseAuthToken: input.FirebaseAuthToken,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error while fetching plan candidate: %v", err)
+	}
+
+	return &CreatePlanCandidateSetFromSavedPlanOutput{
+		PlanCandidateSet: *planCandidateSet,
+	}, nil
+}

--- a/internal/domain/services/plancandidate/service.go
+++ b/internal/domain/services/plancandidate/service.go
@@ -16,6 +16,7 @@ import (
 type Service struct {
 	placesApi               places.PlacesApi
 	placeRepository         repository.PlaceRepository
+	planRepository          repository.PlanRepository
 	planCandidateRepository repository.PlanCandidateRepository
 	userService             user.Service
 	placeSearchService      placesearch.Service
@@ -31,6 +32,11 @@ func NewService(ctx context.Context, db *sql.DB) (*Service, error) {
 	placeRepository, err := rdb.NewPlaceRepository(db)
 	if err != nil {
 		return nil, fmt.Errorf("error while initializing place repository: %v", err)
+	}
+
+	planRepository, err := rdb.NewPlanRepository(db)
+	if err != nil {
+		return nil, fmt.Errorf("error while initializing plan repository: %v", err)
 	}
 
 	planCandidateRepository, err := rdb.NewPlanCandidateRepository(db)
@@ -58,6 +64,7 @@ func NewService(ctx context.Context, db *sql.DB) (*Service, error) {
 	return &Service{
 		placesApi:               *placesApi,
 		placeRepository:         placeRepository,
+		planRepository:          planRepository,
 		planCandidateRepository: planCandidateRepository,
 		userService:             *userService,
 		placeSearchService:      *placeSearchService,

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -106,7 +106,33 @@ func (r *mutationResolver) CreatePlanByPlace(ctx context.Context, input model.Cr
 
 // CreatePlanCandidateSetFromSavedPlan is the resolver for the createPlanCandidateSetFromSavedPlan field.
 func (r *mutationResolver) CreatePlanCandidateSetFromSavedPlan(ctx context.Context, input model.CreatePlanCandidateSetFromSavedPlanInput) (*model.CreatePlanCandidateSetFromSavedPlanOutput, error) {
-	panic(fmt.Errorf("not implemented: CreatePlanCandidateSetFromSavedPlan - createPlanCandidateSetFromSavedPlan"))
+	r.Logger.Info(
+		"CreatePlanCandidateSetFromSavedPlan",
+		zap.String("planId", input.SavedPlanID),
+		zap.String("userId", utils.StrEmptyIfNil(input.UserID)),
+		zap.String("firebaseAuthToken", utils.StrEmptyIfNil(input.FirebaseAuthToken)),
+	)
+
+	output, err := r.PlanCandidateService.CreatePlanCandidateSetFromSavedPlan(ctx, plancandidate.CreatePlanCandidateSetFromSavedPlanInput{
+		PlanId:            input.SavedPlanID,
+		UserId:            input.UserID,
+		FirebaseAuthToken: input.FirebaseAuthToken,
+	})
+	if err != nil {
+		r.Logger.Error("error while creating plan candidate set from saved plan", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	planGraphQLModel := factory.PlanCandidateFromDomainModel(&output.PlanCandidateSet)
+
+	if err != nil {
+		r.Logger.Error("error while converting plan domain model to graphql model", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	return &model.CreatePlanCandidateSetFromSavedPlanOutput{
+		PlanCandidate: planGraphQLModel,
+	}, nil
 }
 
 // ChangePlacesOrderInPlanCandidate is the resolver for the changePlacesOrderInPlanCandidate field.

--- a/internal/interface/graphql/resolver/plan_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_mutation.resolvers.go
@@ -7,7 +7,6 @@ package resolver
 import (
 	"context"
 	"fmt"
-
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/models"


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- すでに保存されているプランをコピーし PlanCnadidateSetを作成するMutationを実装した。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #534 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- モデルコースをベースにプランを作成できるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] すでに保存されているプランをベースに新しいプランを作成できることを確認（Postman）
- [x] 作成されたプランを編集・保存できることを確認（komichi） 

```shell
# planner
export BRANCH_PLANNER=feature/customize_plan_from_saved_from
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```