### PR TITLE
プラン候補について検索した場所が無い場合に追加・関連した場所が提示できない不具合を修正

### DIFF
--- a/internal/domain/services/place/places_to_replace.go
+++ b/internal/domain/services/place/places_to_replace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
+	"poroto.app/poroto/planner/internal/domain/services/placesearch"
 	"time"
 )
 
@@ -50,6 +51,22 @@ func (s Service) FetchPlacesToReplace(
 	placesSearched, err := s.placeSearchService.FetchSearchedPlaces(ctx, planCandidateId)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching placesToReplace searched: %v", err)
+	}
+
+	if placesSearched == nil {
+		// 付近の場所を検索
+		placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{Location: startPlace.Location})
+		if err != nil {
+			return nil, fmt.Errorf("error while fetching places: %v\n", err)
+		}
+
+		// 検索された場所を保存
+		places, err := s.placeSearchService.SaveSearchedPlaces(ctx, planCandidateId, placesNearby)
+		if err != nil {
+			return nil, fmt.Errorf("error while saving searched places: %v\n", err)
+		}
+
+		placesSearched = places
 	}
 
 	placesFiltered := placesSearched


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プランカスタムによって作成したときに、追加・関連する場所を提示できない不具合を修正した。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認（https://github.com/poroto-app/poroto/pull/701）
- [x] すでに保存されたプランからプランを作成したときに、関連した場所を表示できることを確認
- [x] すでに保存されたプランからプランを作成したときに、追加する場所を表示できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/fix_fetch_places_of_customized_plan
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=feature/customize_plan_from_saved_plan
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```