### PR TITLE
プランの近くのプランを取得できるようにする

### DIFF
--- a/internal/interface/graphql/resolver/plan_type.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_type.resolvers.go
@@ -7,6 +7,10 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/utils"
+	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 
 	"poroto.app/poroto/planner/internal/interface/graphql/generated"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
@@ -19,7 +23,36 @@ func (r *planResolver) Collage(ctx context.Context, obj *model.Plan) (*model.Pla
 
 // NearbyPlans is the resolver for the nearbyPlans field.
 func (r *planResolver) NearbyPlans(ctx context.Context, obj *model.Plan) ([]*model.Plan, error) {
-	panic(fmt.Errorf("not implemented: NearbyPlans - nearbyPlans"))
+	r.Logger.Info("Plan#NeabyPlans", zap.String("plan_id", obj.ID))
+	if len(obj.Places) == 0 {
+		return nil, nil
+	}
+
+	plans, _, err := r.PlanService.FetchPlansByLocation(
+		ctx,
+		models.GeoLocation{
+			Latitude:  obj.Places[0].Location.Latitude,
+			Longitude: obj.Places[0].Location.Longitude,
+		},
+		utils.ToPointer(10),
+		nil,
+	)
+	if err != nil {
+		r.Logger.Error("error while fetching nearby plans", zap.Error(err))
+		return nil, nil
+	}
+
+	graphqlPlans := make([]*model.Plan, 0, len(*plans))
+	for _, p := range *plans {
+		graphqlPlan, err := factory.PlanFromDomainModel(p, nil)
+		if err != nil {
+			r.Logger.Error("error while converting plan domain model to graphql model", zap.Error(err))
+			return nil, nil
+		}
+		graphqlPlans = append(graphqlPlans, graphqlPlan)
+	}
+
+	return graphqlPlans, nil
 }
 
 // Plan returns generated.PlanResolver implementation.


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 指定されたプランの近くにあるプランを取得するQueryを実装した。


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #540 
- close #539 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- プラン詳細ページから別のプランを閲覧できるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] プランの近くのプランを取得できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/neaby_plans
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```