### PR TITLE
距離に応じてプランを取得する処理をリファクタ

### DIFF
--- a/internal/domain/repository/plan.go
+++ b/internal/domain/repository/plan.go
@@ -18,7 +18,7 @@ type PlanRepository interface {
 	FindByAuthorId(ctx context.Context, authorId string) (*[]models.Plan, error)
 
 	// FindByLocation location で指定した地点に近いプランを返す
-	FindByLocation(ctx context.Context, location models.GeoLocation, queryCursor *string, limit int) (*[]models.Plan, *string, error)
+	FindByLocation(ctx context.Context, location models.GeoLocation, limit int) (*[]models.Plan, *string, error)
 
 	// UpdatePlanAuthorUserByPlanCandidateSet プラン候補に紐づくプランの作者をユーザーに紐づける
 	UpdatePlanAuthorUserByPlanCandidateSet(ctx context.Context, userId string, planCandidateSetIds []string) error

--- a/internal/domain/repository/plan.go
+++ b/internal/domain/repository/plan.go
@@ -17,8 +17,8 @@ type PlanRepository interface {
 
 	FindByAuthorId(ctx context.Context, authorId string) (*[]models.Plan, error)
 
-	// SortedByLocation location で指定した地点に近いプランを返す
-	SortedByLocation(ctx context.Context, location models.GeoLocation, queryCursor *string, limit int) (*[]models.Plan, *string, error)
+	// FindByLocation location で指定した地点に近いプランを返す
+	FindByLocation(ctx context.Context, location models.GeoLocation, queryCursor *string, limit int) (*[]models.Plan, *string, error)
 
 	// UpdatePlanAuthorUserByPlanCandidateSet プラン候補に紐づくプランの作者をユーザーに紐づける
 	UpdatePlanAuthorUserByPlanCandidateSet(ctx context.Context, userId string, planCandidateSetIds []string) error

--- a/internal/domain/repository/plan.go
+++ b/internal/domain/repository/plan.go
@@ -18,7 +18,7 @@ type PlanRepository interface {
 	FindByAuthorId(ctx context.Context, authorId string) (*[]models.Plan, error)
 
 	// FindByLocation location で指定した地点に近いプランを返す
-	FindByLocation(ctx context.Context, location models.GeoLocation, limit int) (*[]models.Plan, *string, error)
+	FindByLocation(ctx context.Context, location models.GeoLocation, limit int, searchRange int) (*[]models.Plan, *string, error)
 
 	// UpdatePlanAuthorUserByPlanCandidateSet プラン候補に紐づくプランの作者をユーザーに紐づける
 	UpdatePlanAuthorUserByPlanCandidateSet(ctx context.Context, userId string, planCandidateSetIds []string) error

--- a/internal/domain/services/plan/fetch_by_location.go
+++ b/internal/domain/services/plan/fetch_by_location.go
@@ -14,14 +14,13 @@ func (s Service) FetchPlansByLocation(
 	ctx context.Context,
 	location models.GeoLocation,
 	limit *int,
-	pageToken *string,
 ) (plans *[]models.Plan, nextPageToken *string, err error) {
 	if limit == nil {
 		value := defaultLimit
 		limit = &value
 	}
 
-	plans, nextPageToken, err = s.planRepository.FindByLocation(ctx, location, pageToken, *limit)
+	plans, nextPageToken, err = s.planRepository.FindByLocation(ctx, location, *limit)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/domain/services/plan/fetch_by_location.go
+++ b/internal/domain/services/plan/fetch_by_location.go
@@ -2,25 +2,34 @@ package plan
 
 import (
 	"context"
+	"poroto.app/poroto/planner/internal/domain/utils"
 
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
 const (
 	defaultLimit = 10
+
+	// 半径2km圏内のプランを検索する
+	defaultDistanceToSearchPlan = 2 * 1000
 )
 
-func (s Service) FetchPlansByLocation(
-	ctx context.Context,
-	location models.GeoLocation,
-	limit *int,
-) (plans *[]models.Plan, nextPageToken *string, err error) {
-	if limit == nil {
-		value := defaultLimit
-		limit = &value
+type FetchPlansByLocationInput struct {
+	Location    models.GeoLocation
+	Limit       *int
+	SearchRange *int
+}
+
+func (s Service) FetchPlansByLocation(ctx context.Context, input FetchPlansByLocationInput) (plans *[]models.Plan, nextPageToken *string, err error) {
+	if input.Limit == nil {
+		input.Limit = utils.ToPointer(defaultLimit)
 	}
 
-	plans, nextPageToken, err = s.planRepository.FindByLocation(ctx, location, *limit)
+	if input.SearchRange == nil {
+		input.SearchRange = utils.ToPointer(defaultDistanceToSearchPlan)
+	}
+
+	plans, nextPageToken, err = s.planRepository.FindByLocation(ctx, input.Location, *input.Limit, *input.SearchRange)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/domain/services/plan/fetch_by_location.go
+++ b/internal/domain/services/plan/fetch_by_location.go
@@ -21,7 +21,7 @@ func (s Service) FetchPlansByLocation(
 		limit = &value
 	}
 
-	plans, nextPageToken, err = s.planRepository.SortedByLocation(ctx, location, pageToken, *limit)
+	plans, nextPageToken, err = s.planRepository.FindByLocation(ctx, location, pageToken, *limit)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -919,6 +919,10 @@ func (p PlaceRepository) findAllByGooglePlaceId(ctx context.Context, exec boil.C
 // countPlaceLikeCounts は場所ごとのいいね数をカウントする
 // いいねはPlanCandidateSetとUserによって行われるが、その両方を考慮し、総数をカウントする
 func countPlaceLikeCounts(ctx context.Context, exec boil.ContextExecutor, placeIds ...string) (*[]entities.PlanCandidateSetPlaceLikeCount, error) {
+	placeIds = array.DistinctBy(placeIds, func(placeId string) string {
+		return placeId
+	})
+
 	var placeIdPlaceHolder string
 	if len(placeIds) == 0 {
 		return nil, nil

--- a/internal/infrastructure/rdb/plan.go
+++ b/internal/infrastructure/rdb/plan.go
@@ -360,8 +360,14 @@ func (p PlanRepository) FindByLocation(ctx context.Context, location models.GeoL
 		return &[]models.Plan{}, nil, nil
 	}
 
-	planCandidateSetPlaceLikeCounts, err := countPlaceLikeCounts(ctx, p.db, array.Map(planEntities, func(planEntity *generated.Plan) string {
-		return planEntity.ID
+	planCandidateSetPlaceLikeCounts, err := countPlaceLikeCounts(ctx, p.db, array.FlatMap(planEntities, func(planEntity *generated.Plan) []string {
+		if planEntity.R.PlanPlaces == nil {
+			return nil
+		}
+
+		return array.Map(planEntity.R.PlanPlaces, func(planPlace *generated.PlanPlace) string {
+			return planPlace.PlaceID
+		})
 	})...)
 	if err != nil {
 		// いいね数の取得に失敗してもエラーにしない

--- a/internal/infrastructure/rdb/plan.go
+++ b/internal/infrastructure/rdb/plan.go
@@ -342,7 +342,7 @@ func (p PlanRepository) FindByAuthorId(ctx context.Context, authorId string) (*[
 }
 
 // TODO: ページングしない（範囲だけ指定させて、ソートも行わない）
-func (p PlanRepository) SortedByLocation(ctx context.Context, location models.GeoLocation, queryCursor *string, limit int) (*[]models.Plan, *string, error) {
+func (p PlanRepository) FindByLocation(ctx context.Context, location models.GeoLocation, queryCursor *string, limit int) (*[]models.Plan, *string, error) {
 	minLocation, maxLocation := location.CalculateMBR(defaultDistanceToSearchPlan)
 
 	planEntities, err := generated.Plans(concatQueryMod(

--- a/internal/infrastructure/rdb/plan.go
+++ b/internal/infrastructure/rdb/plan.go
@@ -20,11 +20,6 @@ import (
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
 )
 
-const (
-	// 半径2km圏内のプランを検索する
-	defaultDistanceToSearchPlan = 2 * 1000
-)
-
 type PlanRepository struct {
 	db     *sql.DB
 	logger *zap.Logger
@@ -341,8 +336,8 @@ func (p PlanRepository) FindByAuthorId(ctx context.Context, authorId string) (*[
 	return plans, nil
 }
 
-func (p PlanRepository) FindByLocation(ctx context.Context, location models.GeoLocation, limit int) (*[]models.Plan, *string, error) {
-	minLocation, maxLocation := location.CalculateMBR(defaultDistanceToSearchPlan)
+func (p PlanRepository) FindByLocation(ctx context.Context, location models.GeoLocation, limit int, searchRange int) (*[]models.Plan, *string, error) {
+	minLocation, maxLocation := location.CalculateMBR(float64(searchRange))
 
 	planEntities, err := generated.Plans(concatQueryMod(
 		[]qm.QueryMod{

--- a/internal/infrastructure/rdb/plan.go
+++ b/internal/infrastructure/rdb/plan.go
@@ -341,8 +341,7 @@ func (p PlanRepository) FindByAuthorId(ctx context.Context, authorId string) (*[
 	return plans, nil
 }
 
-// TODO: ページングしない（範囲だけ指定させて、ソートも行わない）
-func (p PlanRepository) FindByLocation(ctx context.Context, location models.GeoLocation, queryCursor *string, limit int) (*[]models.Plan, *string, error) {
+func (p PlanRepository) FindByLocation(ctx context.Context, location models.GeoLocation, limit int) (*[]models.Plan, *string, error) {
 	minLocation, maxLocation := location.CalculateMBR(defaultDistanceToSearchPlan)
 
 	planEntities, err := generated.Plans(concatQueryMod(

--- a/internal/infrastructure/rdb/plan_test.go
+++ b/internal/infrastructure/rdb/plan_test.go
@@ -712,7 +712,7 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 	}
 }
 
-func TestPlanRepository_SortedByLocation(t *testing.T) {
+func TestPlanRepository_FindByLocation(t *testing.T) {
 	cases := []struct {
 		name        string
 		savedUsers  generated.UserSlice
@@ -720,6 +720,7 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 		savedPlans  []models.Plan
 		location    models.GeoLocation
 		limit       int
+		searchRange int
 		expected    []models.Plan
 	}{
 		{
@@ -784,8 +785,9 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 					},
 				},
 			},
-			location: models.GeoLocation{Latitude: 35.6905, Longitude: 139.6995},
-			limit:    10,
+			location:    models.GeoLocation{Latitude: 35.6905, Longitude: 139.6995},
+			limit:       10,
+			searchRange: 2 * 1000,
 			expected: []models.Plan{
 				{
 					Id:   "9c93c944-ac8e-11ee-a506-0242ac120002",
@@ -839,7 +841,7 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 				t.Errorf("error saving plan: %v", err)
 			}
 
-			plans, _, err := planRepository.FindByLocation(textContext, c.location, c.limit)
+			plans, _, err := planRepository.FindByLocation(textContext, c.location, c.limit, c.searchRange)
 			if err != nil {
 				t.Errorf("error finding plans: %v", err)
 			}

--- a/internal/infrastructure/rdb/plan_test.go
+++ b/internal/infrastructure/rdb/plan_test.go
@@ -839,7 +839,7 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 				t.Errorf("error saving plan: %v", err)
 			}
 
-			plans, _, err := planRepository.FindByLocation(textContext, c.location, nil, c.limit)
+			plans, _, err := planRepository.FindByLocation(textContext, c.location, c.limit)
 			if err != nil {
 				t.Errorf("error finding plans: %v", err)
 			}

--- a/internal/infrastructure/rdb/plan_test.go
+++ b/internal/infrastructure/rdb/plan_test.go
@@ -714,14 +714,15 @@ func TestPlanRepository_SortedByCreatedAt(t *testing.T) {
 
 func TestPlanRepository_FindByLocation(t *testing.T) {
 	cases := []struct {
-		name        string
-		savedUsers  generated.UserSlice
-		savedPlaces []models.Place
-		savedPlans  []models.Plan
-		location    models.GeoLocation
-		limit       int
-		searchRange int
-		expected    []models.Plan
+		name                       string
+		savedUsers                 generated.UserSlice
+		savedPlaces                []models.Place
+		savedPlans                 []models.Plan
+		savedUserLikePlaceEntities generated.UserLikePlaceSlice
+		location                   models.GeoLocation
+		limit                      int
+		searchRange                int
+		expected                   []models.Plan
 	}{
 		{
 			name: "should find plans sorted by location",
@@ -785,6 +786,13 @@ func TestPlanRepository_FindByLocation(t *testing.T) {
 					},
 				},
 			},
+			savedUserLikePlaceEntities: generated.UserLikePlaceSlice{
+				{
+					ID:      uuid.New().String(),
+					UserID:  "8fde8eff-4b18-4276-b71f-2fec30ea65c8",
+					PlaceID: "f2c98d68-3904-455b-8832-a0f723a96735",
+				},
+			},
 			location:    models.GeoLocation{Latitude: 35.6905, Longitude: 139.6995},
 			limit:       10,
 			searchRange: 2 * 1000,
@@ -794,9 +802,10 @@ func TestPlanRepository_FindByLocation(t *testing.T) {
 					Name: "新宿",
 					Places: []models.Place{
 						{
-							Id:       "f2c98d68-3904-455b-8832-a0f723a96735",
-							Name:     "高島屋新宿店",
-							Location: models.GeoLocation{Latitude: 35.687684359569, Longitude: 139.70220602474},
+							Id:        "f2c98d68-3904-455b-8832-a0f723a96735",
+							Name:      "高島屋新宿店",
+							Location:  models.GeoLocation{Latitude: 35.687684359569, Longitude: 139.70220602474},
+							LikeCount: 1,
 							Google: models.GooglePlace{
 								PlaceId:  "ChIJN1t_tDeuEmsRUsoyG83frY4",
 								Location: models.GeoLocation{Latitude: 35.687684359569, Longitude: 139.70220602474},
@@ -826,19 +835,21 @@ func TestPlanRepository_FindByLocation(t *testing.T) {
 				}
 			})
 
-			// 事前に User を保存
+			// 事前にデータを保存
 			if _, err := c.savedUsers.InsertAll(textContext, planRepository.GetDB(), boil.Infer()); err != nil {
 				t.Errorf("error saving user: %v", err)
 			}
 
-			// 事前に Place を保存
 			if err := savePlaces(textContext, planRepository.GetDB(), c.savedPlaces); err != nil {
 				t.Errorf("error saving places: %v", err)
 			}
 
-			// 事前に Plan を保存
 			if err := savePlans(textContext, planRepository.GetDB(), c.savedPlans); err != nil {
 				t.Errorf("error saving plan: %v", err)
+			}
+
+			if _, err := c.savedUserLikePlaceEntities.InsertAll(textContext, planRepository.GetDB(), boil.Infer()); err != nil {
+				t.Errorf("error saving user like place: %v", err)
 			}
 
 			plans, _, err := planRepository.FindByLocation(textContext, c.location, c.limit, c.searchRange)

--- a/internal/infrastructure/rdb/plan_test.go
+++ b/internal/infrastructure/rdb/plan_test.go
@@ -839,7 +839,7 @@ func TestPlanRepository_SortedByLocation(t *testing.T) {
 				t.Errorf("error saving plan: %v", err)
 			}
 
-			plans, _, err := planRepository.SortedByLocation(textContext, c.location, nil, c.limit)
+			plans, _, err := planRepository.FindByLocation(textContext, c.location, nil, c.limit)
 			if err != nil {
 				t.Errorf("error finding plans: %v", err)
 			}

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -2006,7 +2006,6 @@ input PlansByLocationInput {
     latitude: Float!
     longitude: Float!
     limit: Int
-    pageKey: String
 }
 
 type PlansByLocationOutput {
@@ -12840,7 +12839,7 @@ func (ec *executionContext) unmarshalInputPlansByLocationInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"latitude", "longitude", "limit", "pageKey"}
+	fieldsInOrder := [...]string{"latitude", "longitude", "limit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -12874,15 +12873,6 @@ func (ec *executionContext) unmarshalInputPlansByLocationInput(ctx context.Conte
 				return it, err
 			}
 			it.Limit = data
-		case "pageKey":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pageKey"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.PageKey = data
 		}
 	}
 

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -323,7 +323,6 @@ type PlansByLocationInput struct {
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
 	Limit     *int    `json:"limit,omitempty"`
-	PageKey   *string `json:"pageKey,omitempty"`
 }
 
 type PlansByLocationOutput struct {

--- a/internal/interface/graphql/resolver/plan_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_query.resolvers.go
@@ -63,7 +63,6 @@ func (r *queryResolver) PlansByLocation(ctx context.Context, input model.PlansBy
 			Longitude: input.Longitude,
 		},
 		input.Limit,
-		input.PageKey,
 	)
 	if err != nil {
 		r.Logger.Error("error while fetching plans by location", zap.Error(err))

--- a/internal/interface/graphql/resolver/plan_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_query.resolvers.go
@@ -58,11 +58,13 @@ func (r *queryResolver) Plans(ctx context.Context, input *model.PlansInput) (*mo
 func (r *queryResolver) PlansByLocation(ctx context.Context, input model.PlansByLocationInput) (*model.PlansByLocationOutput, error) {
 	plans, nextPageToken, err := r.PlanService.FetchPlansByLocation(
 		ctx,
-		models.GeoLocation{
-			Latitude:  input.Latitude,
-			Longitude: input.Longitude,
+		plan.FetchPlansByLocationInput{
+			Location: models.GeoLocation{
+				Latitude:  input.Latitude,
+				Longitude: input.Longitude,
+			},
+			Limit: input.Limit,
 		},
-		input.Limit,
 	)
 	if err != nil {
 		r.Logger.Error("error while fetching plans by location", zap.Error(err))

--- a/internal/interface/graphql/resolver/plan_type.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_type.resolvers.go
@@ -7,10 +7,10 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"poroto.app/poroto/planner/internal/domain/services/plan"
 
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/models"
-	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 	"poroto.app/poroto/planner/internal/interface/graphql/generated"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
@@ -30,11 +30,12 @@ func (r *planResolver) NearbyPlans(ctx context.Context, obj *model.Plan) ([]*mod
 
 	plans, _, err := r.PlanService.FetchPlansByLocation(
 		ctx,
-		models.GeoLocation{
-			Latitude:  obj.Places[0].Location.Latitude,
-			Longitude: obj.Places[0].Location.Longitude,
+		plan.FetchPlansByLocationInput{
+			Location: models.GeoLocation{
+				Latitude:  obj.Places[0].Location.Latitude,
+				Longitude: obj.Places[0].Location.Longitude,
+			},
 		},
-		utils.ToPointer(10),
 	)
 	if err != nil {
 		r.Logger.Error("error while fetching nearby plans", zap.Error(err))

--- a/internal/interface/graphql/resolver/plan_type.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_type.resolvers.go
@@ -35,7 +35,6 @@ func (r *planResolver) NearbyPlans(ctx context.Context, obj *model.Plan) ([]*mod
 			Longitude: obj.Places[0].Location.Longitude,
 		},
 		utils.ToPointer(10),
-		nil,
 	)
 	if err != nil {
 		r.Logger.Error("error while fetching nearby plans", zap.Error(err))

--- a/internal/interface/graphql/resolver/plan_type.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_type.resolvers.go
@@ -7,11 +7,11 @@ package resolver
 import (
 	"context"
 	"fmt"
+
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
-
 	"poroto.app/poroto/planner/internal/interface/graphql/generated"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
 )

--- a/internal/interface/graphql/resolver/plan_type.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_type.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"poroto.app/poroto/planner/internal/domain/services/plan"
+	"poroto.app/poroto/planner/internal/domain/utils"
 
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/models"
@@ -35,6 +36,7 @@ func (r *planResolver) NearbyPlans(ctx context.Context, obj *model.Plan) ([]*mod
 				Latitude:  obj.Places[0].Location.Latitude,
 				Longitude: obj.Places[0].Location.Longitude,
 			},
+			SearchRange: utils.ToPointer(5 * 1000),
 		},
 	)
 	if err != nil {

--- a/internal/interface/graphql/schema/plan_query.graphqls
+++ b/internal/interface/graphql/schema/plan_query.graphqls
@@ -30,7 +30,6 @@ input PlansByLocationInput {
     latitude: Float!
     longitude: Float!
     limit: Int
-    pageKey: String
 }
 
 type PlansByLocationOutput {


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- PlanRepositoryの位置情報に基づいて、プランを取得する処理について、ページング機能やソート機能を削除した。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] プランの付近のプランを取得できることを確認（Postman）

```shell
# planner
export BRANCH_PLANNER=feature/rdb_neaby_plans
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```