### PR TITLE
すでに検索を行ったかという履歴を残す

### DIFF
--- a/db/migrations/20240605084012_add_is_place_searched_to_plan_candidate_sets.sql
+++ b/db/migrations/20240605084012_add_is_place_searched_to_plan_candidate_sets.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE plan_candidate_sets
+    ADD COLUMN is_place_searched BOOLEAN NOT NULL DEFAULT FALSE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE plan_candidate_sets
+    DROP COLUMN is_place_searched;
+-- +goose StatementEnd

--- a/doc/database/er.md
+++ b/doc/database/er.md
@@ -124,7 +124,7 @@ erDiagram
 ```
 
 ### Plan Candidate
-
+- 複数回検索が行われることを避けるため、`is_place_searched` で検索済みかどうかを管理
 ```mermaid
 ---
 title: plan_candidate
@@ -133,6 +133,7 @@ erDiagram
     plan_candidate_sets {
         char(36) id PK
         timestamp expires_at
+        bool is_place_searched
     }
 
     plan_candidate_set_meta_data {

--- a/internal/domain/models/plan_candidate.go
+++ b/internal/domain/models/plan_candidate.go
@@ -5,11 +5,12 @@ import "time"
 // TODO: PlanCandidateSet という名前にする
 // TODO: Plans を PlanCandidate という名前にする
 type PlanCandidate struct {
-	Id            string
-	Plans         []Plan
-	MetaData      PlanCandidateMetaData
-	ExpiresAt     time.Time
-	LikedPlaceIds []string
+	Id              string
+	Plans           []Plan
+	MetaData        PlanCandidateMetaData
+	IsPlaceSearched bool
+	ExpiresAt       time.Time
+	LikedPlaceIds   []string
 }
 
 func (p PlanCandidate) HasPlace(placeId string) bool {

--- a/internal/domain/repository/plan_candidate.go
+++ b/internal/domain/repository/plan_candidate.go
@@ -30,6 +30,8 @@ type PlanCandidateRepository interface {
 
 	UpdatePlanCandidateMetaData(ctx context.Context, planCandidateId string, meta models.PlanCandidateMetaData) error
 
+	UpdateIsPlaceSearched(ctx context.Context, planCandidateId string, isPlaceSearched bool) error
+
 	ReplacePlace(ctx context.Context, planCandidateId string, planId string, placeIdToBeReplaced string, placeToReplace models.Place) error
 
 	DeleteAll(ctx context.Context, planCandidateIds []string) error

--- a/internal/domain/services/place/places_for_plan.go
+++ b/internal/domain/services/place/places_for_plan.go
@@ -47,7 +47,10 @@ func (s Service) FetchCandidatePlaces(
 	}
 
 	// 付近の場所を検索
-	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{Location: *planCandidate.MetaData.LocationStart})
+	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
+		Location:           *planCandidate.MetaData.LocationStart,
+		PlanCandidateSetId: &planCandidate.Id,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching nearby places: %v\n", err)
 	}

--- a/internal/domain/services/place/places_to_add.go
+++ b/internal/domain/services/place/places_to_add.go
@@ -82,7 +82,10 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 	}
 
 	// 付近の場所を検索
-	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{Location: startPlace.Location})
+	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
+		Location:           startPlace.Location,
+		PlanCandidateSetId: &planCandidate.Id,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching nearby places: %v\n", err)
 	}

--- a/internal/domain/services/place/places_to_replace.go
+++ b/internal/domain/services/place/places_to_replace.go
@@ -49,7 +49,10 @@ func (s Service) FetchPlacesToReplace(
 	}
 
 	// 付近の場所を検索
-	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{Location: startPlace.Location})
+	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
+		Location:           startPlace.Location,
+		PlanCandidateSetId: &planCandidate.Id,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching nearby places: %v\n", err)
 	}

--- a/internal/domain/services/placesearch/search_nearby_location.go
+++ b/internal/domain/services/placesearch/search_nearby_location.go
@@ -10,6 +10,7 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/domain/services/placefilter"
 	googleplaces "poroto.app/poroto/planner/internal/infrastructure/api/google/places"
+	"time"
 )
 
 // nearbySearchRadius すでに保存された場所から近くにある場所を検索するときの検索範囲
@@ -17,8 +18,14 @@ const (
 	nearbySearchRadius = 5 * 1000
 )
 
+// SearchNearbyPlacesInput は付近の場所を検索するときの入力
+//
+// PlanCandidateSetId が指定されており、すでに対応するプラン候補で検索が行われている場合は、検索を行わない
+// これは、付近の特定のカテゴリが無い場合に、すでに検索が行われているのに、再度検索が行われてしまうという状況を防ぐため
+// 例：水族館は30km圏内に存在しない場合は検索が行われるが、検索したことを記録していないと、水族館が30km圏内に存在しない場合にもう一度検索が行われてしまう
 type SearchNearbyPlacesInput struct {
-	Location models.GeoLocation
+	Location           models.GeoLocation
+	PlanCandidateSetId *string
 }
 
 // placeTypeWithCondition 検索する必要のあるカテゴリを表す
@@ -45,10 +52,29 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 		panic("location is not specified")
 	}
 
+	var isAlreadySearched bool
+	if input.PlanCandidateSetId != nil {
+		planCandidateSet, err := s.planCandidateRepository.Find(ctx, *input.PlanCandidateSetId, time.Now())
+		if err != nil {
+			// エラーが発生しても処理を続行する
+			s.logger.Warn("error while fetching plan candidate set", zap.Error(err))
+		} else if planCandidateSet != nil {
+			isAlreadySearched = planCandidateSet.IsPlaceSearched
+		}
+	} else {
+		s.logger.Warn("plan candidate set id is not specified")
+	}
+
 	// キャッシュされた検索結果を取得
 	placesSaved, err := s.placeRepository.FindByLocation(ctx, input.Location, float64(nearbySearchRadius))
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places from location: %w", err)
+	}
+
+	// すでに検索されている場合は、検索を行わない
+	if isAlreadySearched && len(placesSaved) > 0 {
+		s.logger.Info("skip searching places because it has already been searched", zap.Int("places", len(placesSaved)))
+		return placesSaved, nil
 	}
 
 	// カテゴリごとにキャッシュされた検索結果を取得
@@ -174,6 +200,14 @@ func (s Service) SearchNearbyPlaces(ctx context.Context, input SearchNearbyPlace
 		return nil, fmt.Errorf("error while saving places from google place: %v\n", err)
 	}
 
+	// 検索済みであることを保存する
+	if input.PlanCandidateSetId != nil {
+		err := s.planCandidateRepository.UpdateIsPlaceSearched(ctx, *input.PlanCandidateSetId, true)
+		if err != nil {
+			s.logger.Warn("error while updating place searched", zap.Error(err))
+		}
+	}
+
 	if places == nil {
 		return nil, nil
 	}
@@ -240,7 +274,6 @@ func (s Service) placeTypesToSearch() []placeTypeWithCondition {
 			ignorePlaceCount: 1,
 		},
 		// 近くに無いことがあたりまえなレベル
-		// TODO: すでに検索したが、ヒットしなかった場合に対応する
 		{
 			placeType:        maps.PlaceTypeAquarium,
 			searchRange:      50 * 1000,

--- a/internal/domain/services/plancandidate/category_nearby.go
+++ b/internal/domain/services/plancandidate/category_nearby.go
@@ -47,7 +47,10 @@ func (s Service) CategoriesNearLocation(
 	}
 
 	// 付近の場所を検索
-	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{Location: params.Location})
+	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
+		Location:           params.Location,
+		PlanCandidateSetId: &params.CreatePlanSessionId,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching places: %v\n", err)
 	}

--- a/internal/domain/services/plangen/create_by_location.go
+++ b/internal/domain/services/plangen/create_by_location.go
@@ -37,7 +37,10 @@ func (s Service) CreatePlanByLocation(ctx context.Context, input CreatePlanByLoc
 	}
 
 	// 付近の場所を検索
-	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{Location: input.LocationStart})
+	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
+		Location:           input.LocationStart,
+		PlanCandidateSetId: &input.PlanCandidateId,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching google Places: %v\n", err)
 	}

--- a/internal/domain/services/plangen/create_from_place.go
+++ b/internal/domain/services/plangen/create_from_place.go
@@ -30,7 +30,8 @@ func (s Service) CreatePlanFromPlace(
 	}
 
 	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
-		Location: placeStart.Location,
+		Location:           placeStart.Location,
+		PlanCandidateSetId: &createPlanSessionId,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching nearby places")

--- a/internal/infrastructure/mock/plan_candidate.go
+++ b/internal/infrastructure/mock/plan_candidate.go
@@ -68,6 +68,11 @@ func (p PlanRepository) UpdatePlanCandidateMetaData(ctx context.Context, planCan
 	panic("implement me")
 }
 
+func (p PlanRepository) UpdateIsPlaceSearched(ctx context.Context, planCandidateId string, isPlaceSearched bool) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p PlanRepository) ReplacePlace(ctx context.Context, planCandidateId string, planId string, placeIdToBeReplaced string, placeToReplace models.Place) error {
 	// TODO implement me
 	panic("implement me")

--- a/internal/infrastructure/rdb/factory/plan_candidate_set.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate_set.go
@@ -53,10 +53,11 @@ func NewPlanCandidateSetFromEntity(
 	})
 
 	return &models.PlanCandidate{
-		Id:            planCandidateSetEntity.ID,
-		Plans:         *plans,
-		MetaData:      *planCandidateSetMetaData,
-		ExpiresAt:     planCandidateSetEntity.ExpiresAt,
-		LikedPlaceIds: likedPlaceIds,
+		Id:              planCandidateSetEntity.ID,
+		Plans:           *plans,
+		MetaData:        *planCandidateSetMetaData,
+		IsPlaceSearched: planCandidateSetEntity.IsPlaceSearched,
+		ExpiresAt:       planCandidateSetEntity.ExpiresAt,
+		LikedPlaceIds:   likedPlaceIds,
 	}, nil
 }

--- a/internal/infrastructure/rdb/generated/plan_candidate_sets.go
+++ b/internal/infrastructure/rdb/generated/plan_candidate_sets.go
@@ -23,51 +23,58 @@ import (
 
 // PlanCandidateSet is an object representing the database table.
 type PlanCandidateSet struct {
-	ID        string    `boil:"id" json:"id" toml:"id" yaml:"id"`
-	ExpiresAt time.Time `boil:"expires_at" json:"expires_at" toml:"expires_at" yaml:"expires_at"`
-	CreatedAt time.Time `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
-	UpdatedAt time.Time `boil:"updated_at" json:"updated_at" toml:"updated_at" yaml:"updated_at"`
+	ID              string    `boil:"id" json:"id" toml:"id" yaml:"id"`
+	ExpiresAt       time.Time `boil:"expires_at" json:"expires_at" toml:"expires_at" yaml:"expires_at"`
+	CreatedAt       time.Time `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
+	UpdatedAt       time.Time `boil:"updated_at" json:"updated_at" toml:"updated_at" yaml:"updated_at"`
+	IsPlaceSearched bool      `boil:"is_place_searched" json:"is_place_searched" toml:"is_place_searched" yaml:"is_place_searched"`
 
 	R *planCandidateSetR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L planCandidateSetL  `boil:"-" json:"-" toml:"-" yaml:"-"`
 }
 
 var PlanCandidateSetColumns = struct {
-	ID        string
-	ExpiresAt string
-	CreatedAt string
-	UpdatedAt string
+	ID              string
+	ExpiresAt       string
+	CreatedAt       string
+	UpdatedAt       string
+	IsPlaceSearched string
 }{
-	ID:        "id",
-	ExpiresAt: "expires_at",
-	CreatedAt: "created_at",
-	UpdatedAt: "updated_at",
+	ID:              "id",
+	ExpiresAt:       "expires_at",
+	CreatedAt:       "created_at",
+	UpdatedAt:       "updated_at",
+	IsPlaceSearched: "is_place_searched",
 }
 
 var PlanCandidateSetTableColumns = struct {
-	ID        string
-	ExpiresAt string
-	CreatedAt string
-	UpdatedAt string
+	ID              string
+	ExpiresAt       string
+	CreatedAt       string
+	UpdatedAt       string
+	IsPlaceSearched string
 }{
-	ID:        "plan_candidate_sets.id",
-	ExpiresAt: "plan_candidate_sets.expires_at",
-	CreatedAt: "plan_candidate_sets.created_at",
-	UpdatedAt: "plan_candidate_sets.updated_at",
+	ID:              "plan_candidate_sets.id",
+	ExpiresAt:       "plan_candidate_sets.expires_at",
+	CreatedAt:       "plan_candidate_sets.created_at",
+	UpdatedAt:       "plan_candidate_sets.updated_at",
+	IsPlaceSearched: "plan_candidate_sets.is_place_searched",
 }
 
 // Generated where
 
 var PlanCandidateSetWhere = struct {
-	ID        whereHelperstring
-	ExpiresAt whereHelpertime_Time
-	CreatedAt whereHelpertime_Time
-	UpdatedAt whereHelpertime_Time
+	ID              whereHelperstring
+	ExpiresAt       whereHelpertime_Time
+	CreatedAt       whereHelpertime_Time
+	UpdatedAt       whereHelpertime_Time
+	IsPlaceSearched whereHelperbool
 }{
-	ID:        whereHelperstring{field: "`plan_candidate_sets`.`id`"},
-	ExpiresAt: whereHelpertime_Time{field: "`plan_candidate_sets`.`expires_at`"},
-	CreatedAt: whereHelpertime_Time{field: "`plan_candidate_sets`.`created_at`"},
-	UpdatedAt: whereHelpertime_Time{field: "`plan_candidate_sets`.`updated_at`"},
+	ID:              whereHelperstring{field: "`plan_candidate_sets`.`id`"},
+	ExpiresAt:       whereHelpertime_Time{field: "`plan_candidate_sets`.`expires_at`"},
+	CreatedAt:       whereHelpertime_Time{field: "`plan_candidate_sets`.`created_at`"},
+	UpdatedAt:       whereHelpertime_Time{field: "`plan_candidate_sets`.`updated_at`"},
+	IsPlaceSearched: whereHelperbool{field: "`plan_candidate_sets`.`is_place_searched`"},
 }
 
 // PlanCandidateSetRels is where relationship names are stored.
@@ -138,9 +145,9 @@ func (r *planCandidateSetR) GetPlanCandidates() PlanCandidateSlice {
 type planCandidateSetL struct{}
 
 var (
-	planCandidateSetAllColumns            = []string{"id", "expires_at", "created_at", "updated_at"}
+	planCandidateSetAllColumns            = []string{"id", "expires_at", "created_at", "updated_at", "is_place_searched"}
 	planCandidateSetColumnsWithoutDefault = []string{"id", "expires_at"}
-	planCandidateSetColumnsWithDefault    = []string{"created_at", "updated_at"}
+	planCandidateSetColumnsWithDefault    = []string{"created_at", "updated_at", "is_place_searched"}
 	planCandidateSetPrimaryKeyColumns     = []string{"id"}
 	planCandidateSetGeneratedColumns      = []string{}
 )

--- a/internal/infrastructure/rdb/plan_candidate.go
+++ b/internal/infrastructure/rdb/plan_candidate.go
@@ -435,6 +435,28 @@ func (p PlanCandidateRepository) UpdatePlanCandidateMetaData(ctx context.Context
 	return nil
 }
 
+func (p PlanCandidateRepository) UpdateIsPlaceSearched(ctx context.Context, planCandidateId string, isPlaceSearched bool) error {
+	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
+		planCandidateSetEntity, err := generated.PlanCandidateSets(
+			generated.PlanCandidateSetWhere.ID.EQ(planCandidateId),
+		).One(ctx, tx)
+		if err != nil {
+			return fmt.Errorf("failed to get plan candidate set: %w", err)
+		}
+
+		planCandidateSetEntity.IsPlaceSearched = isPlaceSearched
+		if _, err := planCandidateSetEntity.Update(ctx, tx, boil.Whitelist(generated.PlanCandidateSetColumns.IsPlaceSearched)); err != nil {
+			return fmt.Errorf("failed to update plan candidate set: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to run transaction: %w", err)
+	}
+
+	return nil
+}
+
 func (p PlanCandidateRepository) ReplacePlace(ctx context.Context, planCandidateId string, planId string, placeIdToBeReplaced string, placeToReplace models.Place) error {
 	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
 		planCandidatePlaceEntity, err := generated.PlanCandidatePlaces(

--- a/internal/infrastructure/rdb/plan_candidate_test.go
+++ b/internal/infrastructure/rdb/plan_candidate_test.go
@@ -73,21 +73,24 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			name: "plan candidate set with only id",
 			now:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			savedPlanCandidateSet: models.PlanCandidate{
-				Id:        "test",
-				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: true,
 			},
 			planCandidateId: "test",
 			expected: models.PlanCandidate{
-				Id:        "test",
-				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: true,
 			},
 		},
 		{
 			name: "plan candidate set with plan candidate",
 			now:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			savedPlanCandidateSet: models.PlanCandidate{
-				Id:        "test",
-				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: true,
 				MetaData: models.PlanCandidateMetaData{
 					CreatedBasedOnCurrentLocation: true,
 					LocationStart:                 &models.GeoLocation{Latitude: 139.767125, Longitude: 35.681236},
@@ -108,8 +111,9 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			},
 			planCandidateId: "test",
 			expected: models.PlanCandidate{
-				Id:        "test",
-				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: true,
 				MetaData: models.PlanCandidateMetaData{
 					CreatedBasedOnCurrentLocation: true,
 					LocationStart:                 &models.GeoLocation{Latitude: 139.767125, Longitude: 35.681236},
@@ -131,8 +135,9 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			now:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			planCandidateId: "test",
 			savedPlanCandidateSet: models.PlanCandidate{
-				Id:        "test",
-				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: true,
 				Plans: []models.Plan{
 					{
 						Id: "test-plan",
@@ -143,8 +148,9 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 				},
 			},
 			expected: models.PlanCandidate{
-				Id:        "test",
-				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: true,
 				Plans: []models.Plan{
 					{
 						Id: "test-plan",
@@ -153,6 +159,21 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			name:            "plan candidate set with IsPlaceSearched false",
+			now:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
+			planCandidateId: "test",
+			savedPlanCandidateSet: models.PlanCandidate{
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: false,
+			},
+			expected: models.PlanCandidate{
+				Id:              "test",
+				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				IsPlaceSearched: false,
 			},
 		},
 	}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プラン作成時に場所の検索を行ったかという履歴を記録するようにした
- 以前は検索した場所をすべて記録していたが、その代わりに検索を行ったか否かだけを記録するようにした。

**背景**
- #543 の修正により、プラン候補が検索した場所一覧を保存する処理を削除した
- 付近の特定のカテゴリが無い場合に、すでに検索が行われているのに、再度検索が行われてしまうという状況が発生してしまうようになった
- そこで、検索が行われたかどうかという履歴を管理することで、再検索が行われないようにした。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #543 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 不要な再検索が行われないようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 「掛川駅」でプランを作成したときに「水族館」の検索が行われないことを確認（修正前は30km圏内に水族館が存在しないため、再度検索が行われていた）

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```