### PR TITLE
[refactor] プラン候補をPlanCandidateSetという変数名に統一

### DIFF
--- a/internal/domain/models/plan_candidate_meta_data.go
+++ b/internal/domain/models/plan_candidate_meta_data.go
@@ -1,6 +1,6 @@
 package models
 
-// PlanCandidateMetaData は PlanCandidate を作成するにあたって、元になった情報
+// PlanCandidateMetaData は PlanCandidateSet を作成するにあたって、元になった情報
 type PlanCandidateMetaData struct {
 	CreatedBasedOnCurrentLocation bool
 	CategoriesPreferred           *[]LocationCategory

--- a/internal/domain/models/plan_candidate_set.go
+++ b/internal/domain/models/plan_candidate_set.go
@@ -2,9 +2,7 @@ package models
 
 import "time"
 
-// TODO: PlanCandidateSet という名前にする
-// TODO: Plans を PlanCandidate という名前にする
-type PlanCandidate struct {
+type PlanCandidateSet struct {
 	Id              string
 	Plans           []Plan
 	MetaData        PlanCandidateMetaData
@@ -13,7 +11,7 @@ type PlanCandidate struct {
 	LikedPlaceIds   []string
 }
 
-func (p PlanCandidate) HasPlace(placeId string) bool {
+func (p PlanCandidateSet) HasPlace(placeId string) bool {
 	for _, plan := range p.Plans {
 		for _, place := range plan.Places {
 			if placeId == place.Id {
@@ -24,7 +22,7 @@ func (p PlanCandidate) HasPlace(placeId string) bool {
 	return false
 }
 
-func (p PlanCandidate) GetPlan(planId string) *Plan {
+func (p PlanCandidateSet) GetPlan(planId string) *Plan {
 	for _, plan := range p.Plans {
 		if plan.Id == planId {
 			return &plan

--- a/internal/domain/models/plan_candidate_set_test.go
+++ b/internal/domain/models/plan_candidate_set_test.go
@@ -5,16 +5,16 @@ import (
 	"testing"
 )
 
-func TestPlanCandidate_HasPlace(t *testing.T) {
+func TestPlanCandidateSet_HasPlace(t *testing.T) {
 	cases := []struct {
-		name          string
-		planCandidate PlanCandidateSet
-		placeId       string
-		expected      bool
+		name             string
+		planCandidateSet PlanCandidateSet
+		placeId          string
+		expected         bool
 	}{
 		{
 			name: "Has place of placeId",
-			planCandidate: PlanCandidateSet{
+			planCandidateSet: PlanCandidateSet{
 				Plans: []Plan{
 					{
 						Places: []Place{{Id: "1"}},
@@ -26,7 +26,7 @@ func TestPlanCandidate_HasPlace(t *testing.T) {
 		},
 		{
 			name: "Does not have place of placeId",
-			planCandidate: PlanCandidateSet{
+			planCandidateSet: PlanCandidateSet{
 				Plans: []Plan{
 					{
 						Places: []Place{{Id: "1"}},
@@ -40,7 +40,7 @@ func TestPlanCandidate_HasPlace(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result := c.planCandidate.HasPlace(c.placeId)
+			result := c.planCandidateSet.HasPlace(c.placeId)
 			if result != c.expected {
 				t.Errorf("expected: %t\nactual: %t", c.expected, result)
 			}
@@ -48,30 +48,30 @@ func TestPlanCandidate_HasPlace(t *testing.T) {
 	}
 }
 
-func TestPlanCandidate_GetPlan(t *testing.T) {
+func TestPlanCandidateSet_GetPlan(t *testing.T) {
 	cases := []struct {
-		name          string
-		planCandidate PlanCandidateSet
-		planId        string
-		expected      *Plan
+		name             string
+		planCandidateSet PlanCandidateSet
+		planId           string
+		expected         *Plan
 	}{
 		{
-			name:          "Has plan",
-			planCandidate: PlanCandidateSet{Plans: []Plan{{Id: "1"}}},
-			planId:        "1",
-			expected:      &Plan{Id: "1"},
+			name:             "Has plan",
+			planCandidateSet: PlanCandidateSet{Plans: []Plan{{Id: "1"}}},
+			planId:           "1",
+			expected:         &Plan{Id: "1"},
 		},
 		{
-			name:          "Does not have plan",
-			planCandidate: PlanCandidateSet{Plans: []Plan{{Id: "1"}}},
-			planId:        "2",
-			expected:      nil,
+			name:             "Does not have plan",
+			planCandidateSet: PlanCandidateSet{Plans: []Plan{{Id: "1"}}},
+			planId:           "2",
+			expected:         nil,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result := c.planCandidate.GetPlan(c.planId)
+			result := c.planCandidateSet.GetPlan(c.planId)
 			if diff := cmp.Diff(result, c.expected); diff != "" {
 				t.Errorf("GetPlan() mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/domain/models/plan_candidate_set_test.go
+++ b/internal/domain/models/plan_candidate_set_test.go
@@ -8,13 +8,13 @@ import (
 func TestPlanCandidate_HasPlace(t *testing.T) {
 	cases := []struct {
 		name          string
-		planCandidate PlanCandidate
+		planCandidate PlanCandidateSet
 		placeId       string
 		expected      bool
 	}{
 		{
 			name: "Has place of placeId",
-			planCandidate: PlanCandidate{
+			planCandidate: PlanCandidateSet{
 				Plans: []Plan{
 					{
 						Places: []Place{{Id: "1"}},
@@ -26,7 +26,7 @@ func TestPlanCandidate_HasPlace(t *testing.T) {
 		},
 		{
 			name: "Does not have place of placeId",
-			planCandidate: PlanCandidate{
+			planCandidate: PlanCandidateSet{
 				Plans: []Plan{
 					{
 						Places: []Place{{Id: "1"}},
@@ -51,19 +51,19 @@ func TestPlanCandidate_HasPlace(t *testing.T) {
 func TestPlanCandidate_GetPlan(t *testing.T) {
 	cases := []struct {
 		name          string
-		planCandidate PlanCandidate
+		planCandidate PlanCandidateSet
 		planId        string
 		expected      *Plan
 	}{
 		{
 			name:          "Has plan",
-			planCandidate: PlanCandidate{Plans: []Plan{{Id: "1"}}},
+			planCandidate: PlanCandidateSet{Plans: []Plan{{Id: "1"}}},
 			planId:        "1",
 			expected:      &Plan{Id: "1"},
 		},
 		{
 			name:          "Does not have plan",
-			planCandidate: PlanCandidate{Plans: []Plan{{Id: "1"}}},
+			planCandidate: PlanCandidateSet{Plans: []Plan{{Id: "1"}}},
 			planId:        "2",
 			expected:      nil,
 		},

--- a/internal/domain/repository/plan_candidate.go
+++ b/internal/domain/repository/plan_candidate.go
@@ -10,32 +10,32 @@ import (
 type PlanCandidateRepository interface {
 	// Create プラン候補を作成する
 	// この時点ではプランは保存されない
-	Create(cxt context.Context, planCandidateId string, expiresAt time.Time) error
+	Create(cxt context.Context, planCandidateSetId string, expiresAt time.Time) error
 
-	Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidateSet, error)
+	Find(ctx context.Context, planCandidateSetId string, now time.Time) (*models.PlanCandidateSet, error)
 
-	FindPlan(ctx context.Context, planCandidateId string, planId string) (*models.Plan, error)
+	FindPlan(ctx context.Context, planCandidateSetId string, planId string) (*models.Plan, error)
 
 	FindExpiredBefore(ctx context.Context, expiresAt time.Time) (*[]string, error)
 
 	// AddPlan プラン候補にプランを追加する
 	// 事前に models.PlanCandidateSet が保存されている必要がある
-	AddPlan(ctx context.Context, planCandidateId string, plans ...models.Plan) error
+	AddPlan(ctx context.Context, planCandidateSetId string, plans ...models.Plan) error
 
-	AddPlaceToPlan(ctx context.Context, planCandidateId string, planId string, previousPlaceId string, place models.Place) error
+	AddPlaceToPlan(ctx context.Context, planCandidateSetId string, planId string, previousPlaceId string, place models.Place) error
 
-	RemovePlaceFromPlan(ctx context.Context, planCandidateId string, planId string, placeId string) error
+	RemovePlaceFromPlan(ctx context.Context, planCandidateSetId string, planId string, placeId string) error
 
-	UpdatePlacesOrder(ctx context.Context, planId string, planCandidate string, placeIdsOrdered []string) error
+	UpdatePlacesOrder(ctx context.Context, planId string, planCandidateSetId string, placeIdsOrdered []string) error
 
-	UpdatePlanCandidateMetaData(ctx context.Context, planCandidateId string, meta models.PlanCandidateMetaData) error
+	UpdatePlanCandidateMetaData(ctx context.Context, planCandidateSetId string, meta models.PlanCandidateMetaData) error
 
-	UpdateIsPlaceSearched(ctx context.Context, planCandidateId string, isPlaceSearched bool) error
+	UpdateIsPlaceSearched(ctx context.Context, planCandidateSetId string, isPlaceSearched bool) error
 
-	ReplacePlace(ctx context.Context, planCandidateId string, planId string, placeIdToBeReplaced string, placeToReplace models.Place) error
+	ReplacePlace(ctx context.Context, planCandidateSetId string, planId string, placeIdToBeReplaced string, placeToReplace models.Place) error
 
-	DeleteAll(ctx context.Context, planCandidateIds []string) error
+	DeleteAll(ctx context.Context, planCandidateSetIds []string) error
 
 	// TODO: PlaceRepository に移動する
-	UpdateLikeToPlaceInPlanCandidate(ctx context.Context, planCandidateId string, placeId string, like bool) error
+	UpdateLikeToPlaceInPlanCandidateSet(ctx context.Context, planCandidateSetId string, placeId string, like bool) error
 }

--- a/internal/domain/repository/plan_candidate.go
+++ b/internal/domain/repository/plan_candidate.go
@@ -12,14 +12,14 @@ type PlanCandidateRepository interface {
 	// この時点ではプランは保存されない
 	Create(cxt context.Context, planCandidateId string, expiresAt time.Time) error
 
-	Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidate, error)
+	Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidateSet, error)
 
 	FindPlan(ctx context.Context, planCandidateId string, planId string) (*models.Plan, error)
 
 	FindExpiredBefore(ctx context.Context, expiresAt time.Time) (*[]string, error)
 
 	// AddPlan プラン候補にプランを追加する
-	// 事前に models.PlanCandidate が保存されている必要がある
+	// 事前に models.PlanCandidateSet が保存されている必要がある
 	AddPlan(ctx context.Context, planCandidateId string, plans ...models.Plan) error
 
 	AddPlaceToPlan(ctx context.Context, planCandidateId string, planId string, previousPlaceId string, place models.Place) error

--- a/internal/domain/services/place/places_for_plan.go
+++ b/internal/domain/services/place/places_for_plan.go
@@ -15,8 +15,8 @@ const (
 )
 
 type FetchCandidatePlacesInput struct {
-	PlanCandidateId string
-	NLimit          int
+	PlanCandidateSetId string
+	NLimit             int
 }
 
 // FetchCandidatePlaces はプランの候補となる場所を取得する
@@ -24,23 +24,23 @@ func (s Service) FetchCandidatePlaces(
 	ctx context.Context,
 	input FetchCandidatePlacesInput,
 ) (*[]models.Place, error) {
-	if input.PlanCandidateId == "" {
-		panic("PlanCandidateId is empty")
+	if input.PlanCandidateSetId == "" {
+		panic("PlanCandidateSetId is empty")
 	}
 
 	if input.NLimit == 0 {
 		input.NLimit = defaultMaxPlacesToSuggest
 	}
 
-	planCandidate, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateId, time.Now())
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateSetId, time.Now())
 	if err != nil {
 		return nil, err
 	}
 
-	if planCandidate.MetaData.LocationStart == nil {
+	if planCandidateSet.MetaData.LocationStart == nil {
 		s.logger.Warn(
-			"plan candidate has no start location",
-			zap.String("planCandidateId", planCandidate.Id),
+			"plan candidate set has no start location",
+			zap.String("Id", planCandidateSet.Id),
 		)
 
 		return nil, nil
@@ -48,8 +48,8 @@ func (s Service) FetchCandidatePlaces(
 
 	// 付近の場所を検索
 	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
-		Location:           *planCandidate.MetaData.LocationStart,
-		PlanCandidateSetId: &planCandidate.Id,
+		Location:           *planCandidateSet.MetaData.LocationStart,
+		PlanCandidateSetId: &planCandidateSet.Id,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching nearby places: %v\n", err)
@@ -59,14 +59,14 @@ func (s Service) FetchCandidatePlaces(
 	placesFiltered := placesNearby
 	placesFiltered = placefilter.FilterDefaultIgnore(placefilter.FilterDefaultIgnoreInput{
 		Places:        placesFiltered,
-		StartLocation: *planCandidate.MetaData.LocationStart,
+		StartLocation: *planCandidateSet.MetaData.LocationStart,
 	})
 
 	placesSortedByRating := models.SortPlacesByRating(placesFiltered)
 
 	placesToSuggest := make([]models.Place, 0, len(placesSortedByRating))
 	for _, place := range placesSortedByRating {
-		if planCandidate.HasPlace(place.Id) {
+		if planCandidateSet.HasPlace(place.Id) {
 			continue
 		}
 

--- a/internal/domain/services/place/places_to_add.go
+++ b/internal/domain/services/place/places_to_add.go
@@ -16,10 +16,10 @@ const (
 )
 
 type FetchPlacesToAddInput struct {
-	PlanCandidateId string
-	PlanId          string
-	PlaceId         *string
-	NLimit          uint
+	PlanCandidateSetId string
+	PlanId             string
+	PlaceId            *string
+	NLimit             uint
 }
 
 type FetchPlacesToAddOutput struct {
@@ -40,21 +40,21 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 		input.NLimit = defaultMaxPlacesToRecommendPerCategory
 	}
 
-	if input.PlanCandidateId == "" {
-		return nil, fmt.Errorf("plan candidate id is empty")
+	if input.PlanCandidateSetId == "" {
+		return nil, fmt.Errorf("plan candidate set id is empty")
 	}
 
 	if input.PlanId == "" {
 		return nil, fmt.Errorf("plan id is empty")
 	}
 
-	planCandidate, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateId, time.Now())
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateSetId, time.Now())
 	if err != nil {
-		return nil, fmt.Errorf("error while fetching plan candidate: %v", err)
+		return nil, fmt.Errorf("error while fetching plan candidate set: %v", err)
 	}
 
 	var plan *models.Plan
-	for _, p := range planCandidate.Plans {
+	for _, p := range planCandidateSet.Plans {
 		if p.Id == input.PlanId {
 			plan = &p
 			break
@@ -84,7 +84,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 	// 付近の場所を検索
 	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
 		Location:           startPlace.Location,
-		PlanCandidateSetId: &planCandidate.Id,
+		PlanCandidateSetId: &planCandidateSet.Id,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching nearby places: %v\n", err)
@@ -93,8 +93,8 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 	categoriesToSearch := make([]models.LocationCategory, 0)
 
 	// ユーザーが選択したカテゴリを優先的に調べる
-	if planCandidate.MetaData.CategoriesPreferred != nil {
-		categoriesToSearch = append(categoriesToSearch, *planCandidate.MetaData.CategoriesPreferred...)
+	if planCandidateSet.MetaData.CategoriesPreferred != nil {
+		categoriesToSearch = append(categoriesToSearch, *planCandidateSet.MetaData.CategoriesPreferred...)
 	}
 
 	for _, locationCategory := range []models.LocationCategory{
@@ -117,8 +117,8 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 		}
 
 		// 検索対象から除外されている場合はスキップする
-		if planCandidate.MetaData.CategoriesRejected != nil {
-			_, isRejected := array.Find(*planCandidate.MetaData.CategoriesRejected, func(category models.LocationCategory) bool {
+		if planCandidateSet.MetaData.CategoriesRejected != nil {
+			_, isRejected := array.Find(*planCandidateSet.MetaData.CategoriesRejected, func(category models.LocationCategory) bool {
 				return category.Name == locationCategory.Name
 			})
 			if isRejected {
@@ -135,7 +135,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 		nil,
 		*plan,
 		startPlace.Location,
-		planCandidate.MetaData,
+		planCandidateSet.MetaData,
 		int(input.NLimit),
 		nil,
 	)
@@ -162,7 +162,7 @@ func (s Service) FetchPlacesToAdd(ctx context.Context, input FetchPlacesToAddInp
 			placesAlreadyChosen,
 			*plan,
 			startPlace.Location,
-			planCandidate.MetaData,
+			planCandidateSet.MetaData,
 			int(input.NLimit),
 			&category,
 		)

--- a/internal/domain/services/place/places_to_replace.go
+++ b/internal/domain/services/place/places_to_replace.go
@@ -11,17 +11,17 @@ import (
 
 func (s Service) FetchPlacesToReplace(
 	ctx context.Context,
-	planCandidateId string,
+	planCandidateSetId string,
 	planId string,
 	placeId string,
 	nLimit uint,
 ) ([]models.Place, error) {
-	planCandidate, err := s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
-		return nil, fmt.Errorf("error while fetching plan candidate: %v", err)
+		return nil, fmt.Errorf("error while fetching plan candidate set: %v", err)
 	}
 	var plan *models.Plan
-	for _, p := range planCandidate.Plans {
+	for _, p := range planCandidateSet.Plans {
 		if p.Id == planId {
 			plan = &p
 			break
@@ -51,7 +51,7 @@ func (s Service) FetchPlacesToReplace(
 	// 付近の場所を検索
 	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
 		Location:           startPlace.Location,
-		PlanCandidateSetId: &planCandidate.Id,
+		PlanCandidateSetId: &planCandidateSet.Id,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching nearby places: %v\n", err)

--- a/internal/domain/services/plan/save.go
+++ b/internal/domain/services/plan/save.go
@@ -12,18 +12,18 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-func (s Service) SavePlanFromPlanCandidate(ctx context.Context, planCandidateId string, planId string, authToken *string) (*models.Plan, error) {
+func (s Service) SavePlanFromPlanCandidateSet(ctx context.Context, planCandidateSetId string, planId string, authToken *string) (*models.Plan, error) {
 	// プラン候補から対応するプランを取得
-	planCandidate, err := s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
 		return nil, err
 	}
 
-	planToSave, ok := array.Find(planCandidate.Plans, func(plan models.Plan) bool {
+	planToSave, ok := array.Find(planCandidateSet.Plans, func(plan models.Plan) bool {
 		return plan.Id == planId
 	})
 	if !ok {
-		return nil, fmt.Errorf("plan(%v) not found in plan candidate(%v)", planId, planCandidateId)
+		return nil, fmt.Errorf("plan(%v) not found in plan candidate(%v)", planId, planCandidateSetId)
 	}
 
 	// 冪等性を保つために、既存のプランを取得してから保存する

--- a/internal/domain/services/plancandidate/add_place.go
+++ b/internal/domain/services/plancandidate/add_place.go
@@ -10,20 +10,20 @@ import (
 
 // AddPlaceAfterPlace プランに指定された場所を追加する
 // すでに指定された場所が登録されている場合は、なにもしない
-func (s Service) AddPlaceAfterPlace(ctx context.Context, planCandidateId string, planId string, previousPlaceId string, placeId string) (*models.Plan, error) {
-	planCandidate, err := s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+func (s Service) AddPlaceAfterPlace(ctx context.Context, planCandidateSetId string, planId string, previousPlaceId string, placeId string) (*models.Plan, error) {
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plan candidate: %v", err)
 	}
 
-	planToUpdate := planCandidate.GetPlan(planId)
+	planToUpdate := planCandidateSet.GetPlan(planId)
 	if planToUpdate == nil {
 		return nil, fmt.Errorf("plan not found: %v", planId)
 	}
 
 	s.logger.Debug(
 		"Fetching searched places for plan candidate",
-		zap.String("planCandidateId", planCandidateId),
+		zap.String("planCandidateSetId", planCandidateSetId),
 	)
 
 	// 追加する場所を取得
@@ -42,7 +42,7 @@ func (s Service) AddPlaceAfterPlace(ctx context.Context, planCandidateId string,
 			s.logger.Debug(
 				"Place is already added to plan candidate",
 				zap.String("placeId", placeId),
-				zap.String("planCandidateId", planCandidateId),
+				zap.String("planCandidateSetId", planCandidateSetId),
 			)
 			return planToUpdate, nil
 		}
@@ -51,43 +51,43 @@ func (s Service) AddPlaceAfterPlace(ctx context.Context, planCandidateId string,
 	// 画像を取得
 	s.logger.Info(
 		"Fetching photos and reviews for places for plan candidate",
-		zap.String("planCandidateId", planCandidateId),
+		zap.String("planCandidateSetId", planCandidateSetId),
 	)
 	placesWithPhoto := s.placeSearchService.FetchPlacesPhotosAndSave(ctx, *placeToAdd)
 	placeToAdd = &placesWithPhoto[0]
 	s.logger.Info(
 		"Successfully fetched photos and reviews for places for plan candidate",
-		zap.String("planCandidateId", planCandidateId),
+		zap.String("planCandidateSetId", planCandidateSetId),
 	)
 
 	// プランに指定された場所を追加
 	s.logger.Info(
 		"Adding place to plan candidate",
-		zap.String("planCandidateId", planCandidateId),
+		zap.String("planCandidateSetId", planCandidateSetId),
 	)
-	if err := s.planCandidateRepository.AddPlaceToPlan(ctx, planCandidateId, planId, previousPlaceId, *placeToAdd); err != nil {
+	if err := s.planCandidateRepository.AddPlaceToPlan(ctx, planCandidateSetId, planId, previousPlaceId, *placeToAdd); err != nil {
 		return nil, fmt.Errorf("error while adding place to plan candidate: %v", err)
 	}
 	s.logger.Info(
 		"Successfully added place to plan candidate",
-		zap.String("planCandidateId", planCandidateId),
+		zap.String("planCandidateSetId", planCandidateSetId),
 	)
 
 	// 最新のプランの情報を取得
 	s.logger.Info(
 		"Fetching plan candidate",
-		zap.String("planCandidateId", planCandidateId),
+		zap.String("planCandidateSetId", planCandidateSetId),
 	)
-	planCandidate, err = s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+	planCandidateSet, err = s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plan candidate: %v", err)
 	}
 	s.logger.Info(
 		"Successfully fetched plan candidate",
-		zap.String("planCandidateId", planCandidateId),
+		zap.String("planCandidateSetId", planCandidateSetId),
 	)
 
-	plan := planCandidate.GetPlan(planId)
+	plan := planCandidateSet.GetPlan(planId)
 	if plan == nil {
 		return nil, fmt.Errorf("plan not found: %v", planId)
 	}

--- a/internal/domain/services/plancandidate/auto_reorder_places.go
+++ b/internal/domain/services/plancandidate/auto_reorder_places.go
@@ -7,13 +7,13 @@ import (
 )
 
 type AutoReorderPlacesInput struct {
-	PlanCandidateId string
-	PlanId          string
+	PlanCandidateSetId string
+	PlanId             string
 }
 
 // AutoReorderPlaces はプラン候補の場所をスタート地点からの移動が最小になるように並び替える
 func (s *Service) AutoReorderPlaces(ctx context.Context, input AutoReorderPlacesInput) (*models.Plan, error) {
-	plan, err := s.planCandidateRepository.FindPlan(ctx, input.PlanCandidateId, input.PlanId)
+	plan, err := s.planCandidateRepository.FindPlan(ctx, input.PlanCandidateSetId, input.PlanId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find plan: %w", err)
 	}
@@ -30,7 +30,7 @@ func (s *Service) AutoReorderPlaces(ctx context.Context, input AutoReorderPlaces
 		placeIdsOrdered = append(placeIdsOrdered, place.Id)
 	}
 
-	if err := s.planCandidateRepository.UpdatePlacesOrder(ctx, input.PlanId, input.PlanCandidateId, placeIdsOrdered); err != nil {
+	if err := s.planCandidateRepository.UpdatePlacesOrder(ctx, input.PlanId, input.PlanCandidateSetId, placeIdsOrdered); err != nil {
 		return nil, fmt.Errorf("failed to update places order: %v", err)
 	}
 

--- a/internal/domain/services/plancandidate/category_nearby.go
+++ b/internal/domain/services/plancandidate/category_nearby.go
@@ -42,7 +42,7 @@ func (s Service) CategoriesNearLocation(
 	}
 
 	// プラン候補を作成
-	if err := s.CreatePlanCandidate(ctx, params.CreatePlanSessionId); err != nil {
+	if err := s.CreatePlanCandidateSet(ctx, params.CreatePlanSessionId); err != nil {
 		return nil, fmt.Errorf("error while creating plan candidate: %v\n", err)
 	}
 

--- a/internal/domain/services/plancandidate/change_places_order.go
+++ b/internal/domain/services/plancandidate/change_places_order.go
@@ -7,19 +7,19 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-func (s Service) ChangePlacesOrderPlanCandidate(
+func (s Service) ChangePlacesOrderPlanCandidateSet(
 	ctx context.Context,
 	planId string,
-	planCandidateId string,
+	planCandidateSetId string,
 	placeIdsOrdered []string,
 	currentLocation *model.GeoLocation,
 ) (*models.Plan, error) {
 	// TODO：移動時間の再計算処理を実装（latitude, longitudeがnilでなければ使う）
-	if err := s.planCandidateRepository.UpdatePlacesOrder(ctx, planId, planCandidateId, placeIdsOrdered); err != nil {
+	if err := s.planCandidateRepository.UpdatePlacesOrder(ctx, planId, planCandidateSetId, placeIdsOrdered); err != nil {
 		return nil, err
 	}
 
-	plan, err := s.planCandidateRepository.FindPlan(ctx, planCandidateId, planId)
+	plan, err := s.planCandidateRepository.FindPlan(ctx, planCandidateSetId, planId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/services/plancandidate/create.go
+++ b/internal/domain/services/plancandidate/create.go
@@ -6,11 +6,11 @@ import (
 	"time"
 )
 
-func (s Service) CreatePlanCandidate(
+func (s Service) CreatePlanCandidateSet(
 	ctx context.Context,
-	planCandidateId string,
+	planCandidateSetId string,
 ) error {
-	if err := s.planCandidateRepository.Create(ctx, planCandidateId, time.Now().Add(7*24*time.Hour)); err != nil {
+	if err := s.planCandidateRepository.Create(ctx, planCandidateSetId, time.Now().Add(7*24*time.Hour)); err != nil {
 		return fmt.Errorf("error while creating plan candidate: %v\n", err)
 	}
 	return nil

--- a/internal/domain/services/plancandidate/create_from_saved_plan.go
+++ b/internal/domain/services/plancandidate/create_from_saved_plan.go
@@ -14,7 +14,7 @@ type CreatePlanCandidateSetFromSavedPlanInput struct {
 }
 
 type CreatePlanCandidateSetFromSavedPlanOutput struct {
-	PlanCandidateSet models.PlanCandidate
+	PlanCandidateSet models.PlanCandidateSet
 }
 
 func (s Service) CreatePlanCandidateSetFromSavedPlan(ctx context.Context, input CreatePlanCandidateSetFromSavedPlanInput) (*CreatePlanCandidateSetFromSavedPlanOutput, error) {

--- a/internal/domain/services/plancandidate/create_from_saved_plan.go
+++ b/internal/domain/services/plancandidate/create_from_saved_plan.go
@@ -33,7 +33,7 @@ func (s Service) CreatePlanCandidateSetFromSavedPlan(ctx context.Context, input 
 
 	newPlanCandidateSetId := uuid.New().String()
 
-	if err := s.CreatePlanCandidate(ctx, newPlanCandidateSetId); err != nil {
+	if err := s.CreatePlanCandidateSet(ctx, newPlanCandidateSetId); err != nil {
 		return nil, fmt.Errorf("error while creating plan candidate: %v", err)
 	}
 
@@ -41,10 +41,10 @@ func (s Service) CreatePlanCandidateSetFromSavedPlan(ctx context.Context, input 
 		return nil, fmt.Errorf("error while adding plan to plan candidate: %v", err)
 	}
 
-	planCandidateSet, err := s.FindPlanCandidate(ctx, FindPlanCandidateInput{
-		PlanCandidateId:   newPlanCandidateSetId,
-		UserId:            input.UserId,
-		FirebaseAuthToken: input.FirebaseAuthToken,
+	planCandidateSet, err := s.Find(ctx, FindPlanCandidateSetInput{
+		PlanCandidateSetId: newPlanCandidateSetId,
+		UserId:             input.UserId,
+		FirebaseAuthToken:  input.FirebaseAuthToken,
 	})
 
 	if err != nil {

--- a/internal/domain/services/plancandidate/expired.go
+++ b/internal/domain/services/plancandidate/expired.go
@@ -14,32 +14,32 @@ func (s Service) DeleteExpiredPlanCandidates(ctx context.Context, expiresAt time
 		"Fetching expired plan candidates",
 		zap.Time("expiresAt", expiresAt),
 	)
-	expiredPlanCandidateIds, err := s.planCandidateRepository.FindExpiredBefore(ctx, expiresAt)
+	expiredPlanCandidateSetIds, err := s.planCandidateRepository.FindExpiredBefore(ctx, expiresAt)
 	if err != nil {
 		return fmt.Errorf("error while finding expired plan candidates: %v", err)
 	}
 
-	if len(*expiredPlanCandidateIds) == 0 {
+	if len(*expiredPlanCandidateSetIds) == 0 {
 		s.logger.Info("No expired plan candidates found")
 		return nil
 	}
 
 	s.logger.Info(
-		"Found expired plan candidates",
-		zap.Int("count", len(*expiredPlanCandidateIds)),
+		"Found expired plan candidate sets",
+		zap.Int("count", len(*expiredPlanCandidateSetIds)),
 	)
 
 	// プラン候補を削除
 	s.logger.Info(
 		"Deleting expired plan candidates",
-		zap.Int("count", len(*expiredPlanCandidateIds)),
+		zap.Int("count", len(*expiredPlanCandidateSetIds)),
 	)
-	if err := s.planCandidateRepository.DeleteAll(ctx, *expiredPlanCandidateIds); err != nil {
+	if err := s.planCandidateRepository.DeleteAll(ctx, *expiredPlanCandidateSetIds); err != nil {
 		return fmt.Errorf("error while deleting expired plan candidates: %v", err)
 	}
 	s.logger.Info(
 		"Successfully deleted expired plan candidates",
-		zap.Int("count", len(*expiredPlanCandidateIds)),
+		zap.Int("count", len(*expiredPlanCandidateSetIds)),
 	)
 
 	return nil

--- a/internal/domain/services/plancandidate/expired_test.go
+++ b/internal/domain/services/plancandidate/expired_test.go
@@ -16,13 +16,13 @@ func TestDeleteExpiredPlanCandidates(t *testing.T) {
 	cases := []struct {
 		name                   string
 		expiresAt              time.Time
-		planCandidates         map[string]models.PlanCandidate
-		expectedPlanCandidates map[string]models.PlanCandidate
+		planCandidates         map[string]models.PlanCandidateSet
+		expectedPlanCandidates map[string]models.PlanCandidateSet
 	}{
 		{
 			name:      "expired plan candidates are deleted",
 			expiresAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
-			planCandidates: map[string]models.PlanCandidate{
+			planCandidates: map[string]models.PlanCandidateSet{
 				"planCandidate1": {
 					Id:        "planCandidate1",
 					ExpiresAt: time.Date(2019, 12, 31, 23, 59, 59, 0, time.UTC),
@@ -36,7 +36,7 @@ func TestDeleteExpiredPlanCandidates(t *testing.T) {
 					ExpiresAt: time.Date(2020, 1, 1, 0, 0, 1, 0, time.UTC),
 				},
 			},
-			expectedPlanCandidates: map[string]models.PlanCandidate{
+			expectedPlanCandidates: map[string]models.PlanCandidateSet{
 				"planCandidate3": {
 					Id:        "planCandidate3",
 					ExpiresAt: time.Date(2020, 1, 1, 0, 0, 1, 0, time.UTC),

--- a/internal/domain/services/plancandidate/expired_test.go
+++ b/internal/domain/services/plancandidate/expired_test.go
@@ -23,22 +23,22 @@ func TestDeleteExpiredPlanCandidates(t *testing.T) {
 			name:      "expired plan candidates are deleted",
 			expiresAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			planCandidates: map[string]models.PlanCandidateSet{
-				"planCandidate1": {
-					Id:        "planCandidate1",
+				"planCandidateSet1": {
+					Id:        "planCandidateSet1",
 					ExpiresAt: time.Date(2019, 12, 31, 23, 59, 59, 0, time.UTC),
 				},
-				"planCandidate2": {
-					Id:        "planCandidate2",
+				"planCandidateSet2": {
+					Id:        "planCandidateSet2",
 					ExpiresAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
-				"planCandidate3": {
-					Id:        "planCandidate3",
+				"planCandidateSet3": {
+					Id:        "planCandidateSet3",
 					ExpiresAt: time.Date(2020, 1, 1, 0, 0, 1, 0, time.UTC),
 				},
 			},
 			expectedPlanCandidates: map[string]models.PlanCandidateSet{
-				"planCandidate3": {
-					Id:        "planCandidate3",
+				"planCandidateSet3": {
+					Id:        "planCandidateSet3",
 					ExpiresAt: time.Date(2020, 1, 1, 0, 0, 1, 0, time.UTC),
 				},
 			},

--- a/internal/domain/services/plancandidate/find.go
+++ b/internal/domain/services/plancandidate/find.go
@@ -16,7 +16,7 @@ type FindPlanCandidateInput struct {
 	FirebaseAuthToken *string
 }
 
-func (s Service) FindPlanCandidate(ctx context.Context, input FindPlanCandidateInput) (*models.PlanCandidate, error) {
+func (s Service) FindPlanCandidate(ctx context.Context, input FindPlanCandidateInput) (*models.PlanCandidateSet, error) {
 	planCandidate, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error finding plan candidate: %w", err)

--- a/internal/domain/services/plancandidate/find.go
+++ b/internal/domain/services/plancandidate/find.go
@@ -10,14 +10,14 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-type FindPlanCandidateInput struct {
-	PlanCandidateId   string
-	UserId            *string
-	FirebaseAuthToken *string
+type FindPlanCandidateSetInput struct {
+	PlanCandidateSetId string
+	UserId             *string
+	FirebaseAuthToken  *string
 }
 
-func (s Service) FindPlanCandidate(ctx context.Context, input FindPlanCandidateInput) (*models.PlanCandidateSet, error) {
-	planCandidate, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateId, time.Now())
+func (s Service) Find(ctx context.Context, input FindPlanCandidateSetInput) (*models.PlanCandidateSet, error) {
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateSetId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error finding plan candidate: %w", err)
 	}
@@ -41,10 +41,10 @@ func (s Service) FindPlanCandidate(ctx context.Context, input FindPlanCandidateI
 			return nil, fmt.Errorf("error finding like places: %w", err)
 		}
 
-		planCandidate.LikedPlaceIds = array.Map(*likePlaces, func(place models.Place) string {
+		planCandidateSet.LikedPlaceIds = array.Map(*likePlaces, func(place models.Place) string {
 			return place.Id
 		})
 	}
 
-	return planCandidate, nil
+	return planCandidateSet, nil
 }

--- a/internal/domain/services/plancandidate/like_to_place.go
+++ b/internal/domain/services/plancandidate/like_to_place.go
@@ -8,17 +8,17 @@ import (
 	"poroto.app/poroto/planner/internal/domain/models"
 )
 
-type LikeToPlaceInPlanCandidateInput struct {
-	PlanCandidateId   string
-	PlaceId           string
-	Like              bool
-	UserId            *string
-	FirebaseAuthToken *string
+type LikeToPlaceInPlanCandidateSetInput struct {
+	PlanCandidateSetId string
+	PlaceId            string
+	Like               bool
+	UserId             *string
+	FirebaseAuthToken  *string
 }
 
-func (s Service) LikeToPlaceInPlanCandidate(
+func (s Service) LikeToPlaceInPlanCandidateSet(
 	ctx context.Context,
-	input LikeToPlaceInPlanCandidateInput,
+	input LikeToPlaceInPlanCandidateSetInput,
 ) (*models.PlanCandidateSet, error) {
 	if input.UserId != nil && input.FirebaseAuthToken == nil {
 		return nil, fmt.Errorf("firebase auth token is required")
@@ -44,20 +44,20 @@ func (s Service) LikeToPlaceInPlanCandidate(
 		}
 	} else {
 		// ゲストの場合はプラン候補作成セッションとしてLikeを更新する
-		err := s.planCandidateRepository.UpdateLikeToPlaceInPlanCandidate(ctx, input.PlanCandidateId, input.PlaceId, input.Like)
+		err := s.planCandidateRepository.UpdateLikeToPlaceInPlanCandidateSet(ctx, input.PlanCandidateSetId, input.PlaceId, input.Like)
 		if err != nil {
 			return nil, fmt.Errorf("error while updating like to place in plan candidate: %v", err)
 		}
 	}
 
-	planCandidate, err := s.FindPlanCandidate(ctx, FindPlanCandidateInput{
-		PlanCandidateId:   input.PlanCandidateId,
-		UserId:            input.UserId,
-		FirebaseAuthToken: input.FirebaseAuthToken,
+	planCandidateSet, err := s.Find(ctx, FindPlanCandidateSetInput{
+		PlanCandidateSetId: input.PlanCandidateSetId,
+		UserId:             input.UserId,
+		FirebaseAuthToken:  input.FirebaseAuthToken,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plan candidate after updating: %v", err)
 	}
 
-	return planCandidate, nil
+	return planCandidateSet, nil
 }

--- a/internal/domain/services/plancandidate/like_to_place.go
+++ b/internal/domain/services/plancandidate/like_to_place.go
@@ -19,7 +19,7 @@ type LikeToPlaceInPlanCandidateInput struct {
 func (s Service) LikeToPlaceInPlanCandidate(
 	ctx context.Context,
 	input LikeToPlaceInPlanCandidateInput,
-) (*models.PlanCandidate, error) {
+) (*models.PlanCandidateSet, error) {
 	if input.UserId != nil && input.FirebaseAuthToken == nil {
 		return nil, fmt.Errorf("firebase auth token is required")
 	}

--- a/internal/domain/services/plancandidate/remove_place.go
+++ b/internal/domain/services/plancandidate/remove_place.go
@@ -10,13 +10,13 @@ import (
 // RemovePlaceFromPlan プラン候補から場所を削除する
 // planId に対応するプランが存在しない場合はエラーを返す
 // 指定された場所をプランから除外すると、プランに含まれる場所が0になる場合はエラーを返す
-func (s Service) RemovePlaceFromPlan(ctx context.Context, planCandidateId string, planId string, placeId string) (*models.Plan, error) {
-	planCandidate, err := s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+func (s Service) RemovePlaceFromPlan(ctx context.Context, planCandidateSetId string, planId string, placeId string) (*models.Plan, error) {
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving plan candidate: %v", err)
 	}
 
-	plan := planCandidate.GetPlan(planId)
+	plan := planCandidateSet.GetPlan(planId)
 	if err != nil {
 		return nil, fmt.Errorf("plan not found in plan candidate: %v", err)
 	}
@@ -27,18 +27,18 @@ func (s Service) RemovePlaceFromPlan(ctx context.Context, planCandidateId string
 	}
 
 	// プラン候補から場所を削除
-	err = s.planCandidateRepository.RemovePlaceFromPlan(ctx, planCandidateId, planId, placeId)
+	err = s.planCandidateRepository.RemovePlaceFromPlan(ctx, planCandidateSetId, planId, placeId)
 	if err != nil {
 		return nil, fmt.Errorf("error while removing place from plan candidate: %v", err)
 	}
 
 	// 更新後のプラン候補を取得
-	planCandidate, err = s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+	planCandidateSet, err = s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving plan candidate: %v", err)
 	}
 
-	plan = planCandidate.GetPlan(planId)
+	plan = planCandidateSet.GetPlan(planId)
 	if err != nil {
 		return nil, fmt.Errorf("plan not found in plan candidate: %v", err)
 	}

--- a/internal/domain/services/plancandidate/replace_place.go
+++ b/internal/domain/services/plancandidate/replace_place.go
@@ -7,13 +7,13 @@ import (
 	"time"
 )
 
-func (s Service) ReplacePlace(ctx context.Context, planCandidateId string, planId string, placeIdToBeReplaced string, placeIdToReplace string) (*models.Plan, error) {
-	planCandidate, err := s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+func (s Service) ReplacePlace(ctx context.Context, planCandidateSetId string, planId string, placeIdToBeReplaced string, placeIdToReplace string) (*models.Plan, error) {
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plan candidate: %v\n", err)
 	}
 
-	planToUpdate := planCandidate.GetPlan(planId)
+	planToUpdate := planCandidateSet.GetPlan(planId)
 	if planToUpdate == nil {
 		return nil, fmt.Errorf("plan not found: %v\n", planId)
 	}
@@ -38,16 +38,16 @@ func (s Service) ReplacePlace(ctx context.Context, planCandidateId string, planI
 		return nil, fmt.Errorf("place to replace not found: %v\n", placeIdToReplace)
 	}
 
-	if err := s.planCandidateRepository.ReplacePlace(ctx, planCandidateId, planId, placeIdToBeReplaced, *placeToReplace); err != nil {
+	if err := s.planCandidateRepository.ReplacePlace(ctx, planCandidateSetId, planId, placeIdToBeReplaced, *placeToReplace); err != nil {
 		return nil, fmt.Errorf("error while replacing place: %v\n", err)
 	}
 
-	planCandidateUpdated, err := s.planCandidateRepository.Find(ctx, planCandidateId, time.Now())
+	planCandidateSetUpdated, err := s.planCandidateRepository.Find(ctx, planCandidateSetId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plan candidate: %v\n", err)
 	}
 
-	planUpdated := planCandidateUpdated.GetPlan(planId)
+	planUpdated := planCandidateSetUpdated.GetPlan(planId)
 	if planUpdated == nil {
 		return nil, fmt.Errorf("plan not found: %v\n", planId)
 	}

--- a/internal/domain/services/plancandidate/save_plans.go
+++ b/internal/domain/services/plancandidate/save_plans.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SavePlansInput struct {
-	PlanCandidateId              string
+	PlanCandidateSetId           string
 	Plans                        []models.Plan
 	LocationStart                *models.GeoLocation
 	CategoryNamesPreferred       *[]string
@@ -20,7 +20,7 @@ type SavePlansInput struct {
 // はじめてプランを作成したときに呼び出す
 func (s Service) SavePlans(ctx context.Context, input SavePlansInput) (err error) {
 	// プランをプラン候補に追加して保存する
-	if err := s.planCandidateRepository.AddPlan(ctx, input.PlanCandidateId, input.Plans...); err != nil {
+	if err := s.planCandidateRepository.AddPlan(ctx, input.PlanCandidateSetId, input.Plans...); err != nil {
 		return fmt.Errorf("error while adding plan to plan candidate: %v\n", err)
 	}
 
@@ -48,7 +48,7 @@ func (s Service) SavePlans(ctx context.Context, input SavePlansInput) (err error
 		categoriesDisliked = &categories
 	}
 
-	if err := s.planCandidateRepository.UpdatePlanCandidateMetaData(ctx, input.PlanCandidateId, models.PlanCandidateMetaData{
+	if err := s.planCandidateRepository.UpdatePlanCandidateMetaData(ctx, input.PlanCandidateSetId, models.PlanCandidateMetaData{
 		LocationStart:                 input.LocationStart,
 		CategoriesPreferred:           categoriesPreferred,
 		CategoriesRejected:            categoriesDisliked,

--- a/internal/domain/services/plangen/create_by_location.go
+++ b/internal/domain/services/plangen/create_by_location.go
@@ -19,7 +19,7 @@ const (
 // GooglePlaceId が指定された場合は、その場所を起点としてプランを作成する
 // MaxDistanceFromStart は、プランの起点となる場所を選択するときの LocationStart からの最大距離
 type CreatePlanByLocationInput struct {
-	PlanCandidateId              string
+	PlanCandidateSetId           string
 	LocationStart                models.GeoLocation
 	GooglePlaceId                *string
 	CategoryNamesPreferred       *[]string
@@ -39,7 +39,7 @@ func (s Service) CreatePlanByLocation(ctx context.Context, input CreatePlanByLoc
 	// 付近の場所を検索
 	placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
 		Location:           input.LocationStart,
-		PlanCandidateSetId: &input.PlanCandidateId,
+		PlanCandidateSetId: &input.PlanCandidateSetId,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching google Places: %v\n", err)
@@ -47,7 +47,7 @@ func (s Service) CreatePlanByLocation(ctx context.Context, input CreatePlanByLoc
 
 	s.logger.Debug(
 		"Places searched",
-		zap.String("PlanCandidateId", input.PlanCandidateId),
+		zap.String("PlanCandidateSetId", input.PlanCandidateSetId),
 		zap.Float64("lat", input.LocationStart.Latitude),
 		zap.Float64("lng", input.LocationStart.Longitude),
 		zap.Int("placesCount", len(placesNearby)),
@@ -114,7 +114,7 @@ func (s Service) CreatePlanByLocation(ctx context.Context, input CreatePlanByLoc
 		createPlanParams = append(createPlanParams, createPlanParamsInRange[0])
 	}
 
-	plans := s.createPlanData(ctx, input.PlanCandidateId, createPlanParams...)
+	plans := s.createPlanData(ctx, input.PlanCandidateSetId, createPlanParams...)
 
 	// 場所を指定してプランを作成した場合、その場所を起点としたプランを最初に表示する
 	if input.GooglePlaceId != nil {
@@ -163,7 +163,7 @@ func (s Service) CreatePlan(input CreatePlanByLocationInput, places []models.Pla
 	}
 
 	planPlaces, err := s.CreatePlanPlaces(CreatePlanPlacesInput{
-		PlanCandidateId:         input.PlanCandidateId,
+		PlanCandidateSetId:      input.PlanCandidateSetId,
 		LocationStart:           placeRecommend.Location,
 		PlaceStart:              placeRecommend,
 		Places:                  places,

--- a/internal/domain/services/plangen/create_from_place.go
+++ b/internal/domain/services/plangen/create_from_place.go
@@ -15,7 +15,7 @@ func (s Service) CreatePlanFromPlace(
 	createPlanSessionId string,
 	placeId string,
 ) (*models.Plan, error) {
-	planCandidate, err := s.planCandidateRepository.Find(ctx, createPlanSessionId, time.Now())
+	planCandidateSet, err := s.planCandidateRepository.Find(ctx, createPlanSessionId, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching plan candidate")
 	}
@@ -38,20 +38,20 @@ func (s Service) CreatePlanFromPlace(
 	}
 
 	var categoryNamesRejected []string
-	if planCandidate.MetaData.CategoriesRejected != nil {
-		for _, category := range *planCandidate.MetaData.CategoriesRejected {
+	if planCandidateSet.MetaData.CategoriesRejected != nil {
+		for _, category := range *planCandidateSet.MetaData.CategoriesRejected {
 			categoryNamesRejected = append(categoryNamesRejected, category.Name)
 		}
 	}
 
 	// TODO: ユーザーの興味等を保存しておいて、それを反映させる
 	planPlaces, err := s.CreatePlanPlaces(CreatePlanPlacesInput{
-		PlanCandidateId:       createPlanSessionId,
+		PlanCandidateSetId:    createPlanSessionId,
 		LocationStart:         placeStart.Location,
 		PlaceStart:            *placeStart,
 		Places:                placesNearby,
 		CategoryNamesDisliked: &categoryNamesRejected,
-		FreeTime:              planCandidate.MetaData.FreeTime,
+		FreeTime:              planCandidateSet.MetaData.FreeTime,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/domain/services/plangen/create_plan_data.go
+++ b/internal/domain/services/plangen/create_plan_data.go
@@ -16,13 +16,13 @@ type CreatePlanParams struct {
 }
 
 // createPlanData 写真やタイトルなどのプランに必要な情報を作成する
-func (s Service) createPlanData(ctx context.Context, planCandidateId string, params ...CreatePlanParams) []models.Plan {
+func (s Service) createPlanData(ctx context.Context, planCandidateSetId string, params ...CreatePlanParams) []models.Plan {
 	// レビュー・写真を取得する
 	performanceTimer := time.Now()
-	placeIdToPlaceWithPlaceDetail := s.fetchPlaceDetailData(ctx, planCandidateId, params...)
+	placeIdToPlaceWithPlaceDetail := s.fetchPlaceDetailData(ctx, params...)
 	s.logger.Info(
 		"fetching reviews and images",
-		zap.String("PlanCandidateId", planCandidateId),
+		zap.String("PlanCandidateSetId", planCandidateSetId),
 		zap.Duration("duration", time.Since(performanceTimer)),
 	)
 
@@ -41,14 +41,14 @@ func (s Service) createPlanData(ctx context.Context, planCandidateId string, par
 				if err != nil {
 					s.logger.Warn(
 						"error while generating plan title",
-						zap.String("PlanCandidateId", planCandidateId),
+						zap.String("PlanCandidateSetId", planCandidateSetId),
 						zap.Error(err),
 					)
 					title = &param.PlaceStart.Google.Name
 				}
 				s.logger.Info(
 					"generating plan title",
-					zap.String("PlanCandidateId", planCandidateId),
+					zap.String("PlanCandidateSetId", planCandidateSetId),
 					zap.Duration("duration", time.Since(performanceTimer)),
 				)
 				chPlanTitle <- *title
@@ -63,7 +63,7 @@ func (s Service) createPlanData(ctx context.Context, planCandidateId string, par
 			case <-chTitleTimeOut.C:
 				s.logger.Warn(
 					"timeout while generating plan title",
-					zap.String("PlanCandidateId", planCandidateId),
+					zap.String("PlanCandidateSetId", planCandidateSetId),
 				)
 				title = param.PlaceStart.Google.Name
 			}
@@ -98,7 +98,7 @@ func (s Service) createPlanData(ctx context.Context, planCandidateId string, par
 }
 
 // fetchPlaceDetailData は、指定された場所の写真・レビューを一括で取得し、保存する
-func (s Service) fetchPlaceDetailData(ctx context.Context, planCandidateId string, params ...CreatePlanParams) map[string]models.Place {
+func (s Service) fetchPlaceDetailData(ctx context.Context, params ...CreatePlanParams) map[string]models.Place {
 	// プラン間の場所の重複を無くすため、場所のIDをキーにして場所を保存する
 	placeIdToPlace := make(map[string]models.Place)
 	for _, param := range params {

--- a/internal/domain/services/plangen/create_plan_places.go
+++ b/internal/domain/services/plangen/create_plan_places.go
@@ -16,7 +16,7 @@ const (
 )
 
 type CreatePlanPlacesInput struct {
-	PlanCandidateId         string
+	PlanCandidateSetId      string
 	LocationStart           models.GeoLocation
 	PlaceStart              models.Place
 	Places                  []models.Place
@@ -28,8 +28,8 @@ type CreatePlanPlacesInput struct {
 
 // CreatePlanPlaces プランの候補地となる場所を作成する
 func (s Service) CreatePlanPlaces(input CreatePlanPlacesInput) ([]models.Place, error) {
-	if input.PlanCandidateId == "" {
-		panic("PlanCandidateId is required")
+	if input.PlanCandidateSetId == "" {
+		panic("PlanCandidateSetId is required")
 	}
 
 	if input.MaxPlace == 0 {

--- a/internal/infrastructure/mock/plan_candidate.go
+++ b/internal/infrastructure/mock/plan_candidate.go
@@ -8,10 +8,10 @@ import (
 )
 
 type PlanRepository struct {
-	Data map[string]models.PlanCandidate
+	Data map[string]models.PlanCandidateSet
 }
 
-func NewPlanCandidateRepository(data map[string]models.PlanCandidate) *PlanRepository {
+func NewPlanCandidateRepository(data map[string]models.PlanCandidateSet) *PlanRepository {
 	return &PlanRepository{
 		Data: data,
 	}
@@ -22,7 +22,7 @@ func (p PlanRepository) Create(ctx context.Context, planCandidateId string, expi
 	panic("implement me")
 }
 
-func (p PlanRepository) Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidate, error) {
+func (p PlanRepository) Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidateSet, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/internal/infrastructure/mock/plan_candidate.go
+++ b/internal/infrastructure/mock/plan_candidate.go
@@ -85,7 +85,7 @@ func (p PlanRepository) DeleteAll(ctx context.Context, planCandidateIds []string
 	return nil
 }
 
-func (p PlanRepository) UpdateLikeToPlaceInPlanCandidate(ctx context.Context, planCandidateId string, placeId string, like bool) error {
+func (p PlanRepository) UpdateLikeToPlaceInPlanCandidateSet(ctx context.Context, planCandidateId string, placeId string, like bool) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/internal/infrastructure/rdb/factory/plan_candidate_set.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate_set.go
@@ -17,7 +17,7 @@ func NewPlanCandidateSetFromEntity(
 	planCandidateSetLikePlaceSlice generated.PlanCandidateSetLikePlaceSlice,
 	places []models.Place,
 	author *models.User,
-) (*models.PlanCandidate, error) {
+) (*models.PlanCandidateSet, error) {
 	planCandidateSetMetaData, err := NewPlanCandidateMetaDataFromEntity(planCandidateSetMetaDataSlice, planCandidateSetCategorySlice, planCandidateSetEntity.ID)
 	if err != nil {
 		// PlanCandidateSetMetaDataがない場合はエラーにしない
@@ -52,7 +52,7 @@ func NewPlanCandidateSetFromEntity(
 		return planCandidateSetLikePlace.PlaceID, true
 	})
 
-	return &models.PlanCandidate{
+	return &models.PlanCandidateSet{
 		Id:              planCandidateSetEntity.ID,
 		Plans:           *plans,
 		MetaData:        *planCandidateSetMetaData,

--- a/internal/infrastructure/rdb/mock_test.go
+++ b/internal/infrastructure/rdb/mock_test.go
@@ -83,7 +83,7 @@ func savePlans(ctx context.Context, db *sql.DB, plans []models.Plan) error {
 	return nil
 }
 
-func savePlanCandidate(ctx context.Context, db *sql.DB, planCandidateSet models.PlanCandidateSet) error {
+func savePlanCandidateSet(ctx context.Context, db *sql.DB, planCandidateSet models.PlanCandidateSet) error {
 	// PlanCandidateSetを作成
 	planCandidateSetEntity := generated.PlanCandidateSet{
 		ID:        planCandidateSet.Id,

--- a/internal/infrastructure/rdb/mock_test.go
+++ b/internal/infrastructure/rdb/mock_test.go
@@ -83,7 +83,7 @@ func savePlans(ctx context.Context, db *sql.DB, plans []models.Plan) error {
 	return nil
 }
 
-func savePlanCandidate(ctx context.Context, db *sql.DB, planCandidateSet models.PlanCandidate) error {
+func savePlanCandidate(ctx context.Context, db *sql.DB, planCandidateSet models.PlanCandidateSet) error {
 	// PlanCandidateSetを作成
 	planCandidateSetEntity := generated.PlanCandidateSet{
 		ID:        planCandidateSet.Id,

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -1031,7 +1031,7 @@ func TestPlaceRepository_FindByGooglePlaceID_WithLikeCount(t *testing.T) {
 
 			// 事前にPlanCandidateSetを保存しておく
 			for _, planCandidateSet := range c.savedPlanCandidateSets {
-				if err := savePlanCandidate(testContext, testDB, planCandidateSet); err != nil {
+				if err := savePlanCandidateSet(testContext, testDB, planCandidateSet); err != nil {
 					t.Fatalf("error while saving plan candidate set: %v", err)
 				}
 			}

--- a/internal/infrastructure/rdb/place_test.go
+++ b/internal/infrastructure/rdb/place_test.go
@@ -980,7 +980,7 @@ func TestPlaceRepository_FindByGooglePlaceID_WithLikeCount(t *testing.T) {
 	cases := []struct {
 		name                            string
 		savedPlaces                     []models.Place
-		savedPlanCandidateSets          []models.PlanCandidate
+		savedPlanCandidateSets          []models.PlanCandidateSet
 		savedPlanCandidateSetLikePlaces []generated.PlanCandidateSetLikePlace
 		googlePlaceId                   string
 		expectedPlace                   *models.Place
@@ -990,7 +990,7 @@ func TestPlaceRepository_FindByGooglePlaceID_WithLikeCount(t *testing.T) {
 			savedPlaces: []models.Place{
 				{Id: "place_id_1", Google: models.GooglePlace{PlaceId: "google_place_id_1"}},
 			},
-			savedPlanCandidateSets: []models.PlanCandidate{
+			savedPlanCandidateSets: []models.PlanCandidateSet{
 				{Id: "plan_candidate_set_id_1", ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local)},
 			},
 			savedPlanCandidateSetLikePlaces: []generated.PlanCandidateSetLikePlace{

--- a/internal/infrastructure/rdb/plan_candidate.go
+++ b/internal/infrastructure/rdb/plan_candidate.go
@@ -54,7 +54,7 @@ func (p PlanCandidateRepository) Create(cxt context.Context, planCandidateId str
 	return nil
 }
 
-func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidate, error) {
+func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidateSet, error) {
 	planCandidateSetEntity, err := generated.PlanCandidateSets(concatQueryMod(
 		[]qm.QueryMod{
 			generated.PlanCandidateSetWhere.ID.EQ(planCandidateId),

--- a/internal/infrastructure/rdb/plan_candidate.go
+++ b/internal/infrastructure/rdb/plan_candidate.go
@@ -41,10 +41,10 @@ func (p PlanCandidateRepository) GetDB() *sql.DB {
 
 // Create プラン候補を作成する
 // TODO: PlanCandidateSet のすべての値を保存できるようにする
-func (p PlanCandidateRepository) Create(cxt context.Context, planCandidateId string, expiresAt time.Time) error {
+func (p PlanCandidateRepository) Create(cxt context.Context, planCandidateSetId string, expiresAt time.Time) error {
 	if err := runTransaction(cxt, p, func(ctx context.Context, tx *sql.Tx) error {
-		planCandidateEntity := generated.PlanCandidateSet{ID: planCandidateId, ExpiresAt: expiresAt}
-		if err := planCandidateEntity.Insert(ctx, tx, boil.Infer()); err != nil {
+		planCandidateSetEntity := generated.PlanCandidateSet{ID: planCandidateSetId, ExpiresAt: expiresAt}
+		if err := planCandidateSetEntity.Insert(ctx, tx, boil.Infer()); err != nil {
 			return fmt.Errorf("failed to insert plan candidate: %w", err)
 		}
 		return nil
@@ -54,10 +54,10 @@ func (p PlanCandidateRepository) Create(cxt context.Context, planCandidateId str
 	return nil
 }
 
-func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateId string, now time.Time) (*models.PlanCandidateSet, error) {
+func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateSetId string, now time.Time) (*models.PlanCandidateSet, error) {
 	planCandidateSetEntity, err := generated.PlanCandidateSets(concatQueryMod(
 		[]qm.QueryMod{
-			generated.PlanCandidateSetWhere.ID.EQ(planCandidateId),
+			generated.PlanCandidateSetWhere.ID.EQ(planCandidateSetId),
 			generated.PlanCandidateSetWhere.ExpiresAt.GT(now),
 			qm.Load(generated.PlanCandidateSetRels.PlanCandidates),
 			qm.Load(generated.PlanCandidateSetRels.PlanCandidateSetMetaData),
@@ -515,7 +515,7 @@ func (p PlanCandidateRepository) DeleteAll(ctx context.Context, planCandidateIds
 	return nil
 }
 
-func (p PlanCandidateRepository) UpdateLikeToPlaceInPlanCandidate(ctx context.Context, planCandidateId string, placeId string, like bool) error {
+func (p PlanCandidateRepository) UpdateLikeToPlaceInPlanCandidateSet(ctx context.Context, planCandidateId string, placeId string, like bool) error {
 	if err := runTransaction(ctx, p, func(ctx context.Context, tx *sql.Tx) error {
 		if like {
 			isPlanCandidateSetLikePlaceEntityExist, err := generated.PlanCandidateSetLikePlaces(

--- a/internal/infrastructure/rdb/plan_candidate_test.go
+++ b/internal/infrastructure/rdb/plan_candidate_test.go
@@ -65,20 +65,20 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 	cases := []struct {
 		name                  string
 		now                   time.Time
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 		planCandidateId       string
-		expected              models.PlanCandidate
+		expected              models.PlanCandidateSet
 	}{
 		{
 			name: "plan candidate set with only id",
 			now:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: true,
 			},
 			planCandidateId: "test",
-			expected: models.PlanCandidate{
+			expected: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: true,
@@ -87,7 +87,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 		{
 			name: "plan candidate set with plan candidate",
 			now:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: true,
@@ -110,7 +110,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 				},
 			},
 			planCandidateId: "test",
-			expected: models.PlanCandidate{
+			expected: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: true,
@@ -134,7 +134,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			name:            "plan candidate set without PlanCandidateSetMetaData",
 			now:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			planCandidateId: "test",
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: true,
@@ -147,7 +147,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 					},
 				},
 			},
-			expected: models.PlanCandidate{
+			expected: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: true,
@@ -165,12 +165,12 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			name:            "plan candidate set with IsPlaceSearched false",
 			now:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			planCandidateId: "test",
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: false,
 			},
-			expected: models.PlanCandidate{
+			expected: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: false,
@@ -276,13 +276,13 @@ func TestPlanCandidateRepository_Find_ShouldReturnNil(t *testing.T) {
 	cases := []struct {
 		name                  string
 		now                   time.Time
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 		planCandidateId       string
 	}{
 		{
 			name: "expired plan candidate set will not be returned",
 			now:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test",
 				ExpiresAt: time.Date(2019, 12, 1, 0, 0, 0, 0, time.Local),
 			},
@@ -335,11 +335,11 @@ func TestPlanCandidateRepository_Find_WithPlaceLikeCount(t *testing.T) {
 		now                                    time.Time
 		savedPlaces                            []models.Place
 		savedUsers                             generated.UserSlice
-		savedPlanCandidateSets                 []models.PlanCandidate
+		savedPlanCandidateSets                 []models.PlanCandidateSet
 		savedPlanCandidateSetLikePlaceEntities []generated.PlanCandidateSetLikePlace
 		savedUserLikePlaceEntities             generated.UserLikePlaceSlice
 		planCandidateId                        string
-		expected                               models.PlanCandidate
+		expected                               models.PlanCandidateSet
 	}{
 		{
 			name: "plan candidate set with place like count",
@@ -352,7 +352,7 @@ func TestPlanCandidateRepository_Find_WithPlaceLikeCount(t *testing.T) {
 				{ID: "test-user-1", FirebaseUID: uuid.New().String()},
 				{ID: "test-user-2", FirebaseUID: uuid.New().String()},
 			},
-			savedPlanCandidateSets: []models.PlanCandidate{
+			savedPlanCandidateSets: []models.PlanCandidateSet{
 				{
 					Id:        "plan-candidate-set-1",
 					ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
@@ -381,7 +381,7 @@ func TestPlanCandidateRepository_Find_WithPlaceLikeCount(t *testing.T) {
 				{ID: uuid.New().String(), UserID: "test-user-2", PlaceID: "test-place-2"},
 			},
 			planCandidateId: "plan-candidate-set-1",
-			expected: models.PlanCandidate{
+			expected: models.PlanCandidateSet{
 				Id:        "plan-candidate-set-1",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -460,7 +460,7 @@ func TestPlanCandidateRepository_FindPlan(t *testing.T) {
 		planCandidateSetId    string
 		planCandidateId       string
 		savedPlaces           []models.Place
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 		expected              models.Plan
 	}{
 		{
@@ -515,7 +515,7 @@ func TestPlanCandidateRepository_FindPlan(t *testing.T) {
 					},
 				},
 			},
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -656,13 +656,13 @@ func TestPlanCandidateRepository_FindExpiredBefore(t *testing.T) {
 	cases := []struct {
 		name                   string
 		expiresAt              time.Time
-		savedPlanCandidateSets []models.PlanCandidate
+		savedPlanCandidateSets []models.PlanCandidateSet
 		expected               []string
 	}{
 		{
 			name:      "success",
 			expiresAt: time.Date(2020, 12, 1, 12, 0, 0, 0, time.Local),
-			savedPlanCandidateSets: []models.PlanCandidate{
+			savedPlanCandidateSets: []models.PlanCandidateSet{
 				{
 					Id:        "test-plan-candidate-set-1",
 					ExpiresAt: time.Date(2020, 12, 1, 12, 0, 0, 0, time.Local),
@@ -692,7 +692,7 @@ func TestPlanCandidateRepository_FindExpiredBefore(t *testing.T) {
 			})
 
 			// 事前にPlaceを作成しておく
-			placesInPlans := array.Flatten(array.Flatten(array.Map(c.savedPlanCandidateSets, func(planCandidate models.PlanCandidate) [][]models.Place {
+			placesInPlans := array.Flatten(array.Flatten(array.Map(c.savedPlanCandidateSets, func(planCandidate models.PlanCandidateSet) [][]models.Place {
 				return array.Map(planCandidate.Plans, func(plan models.Plan) []models.Place { return plan.Places })
 			})))
 			if err := savePlaces(testContext, testDB, placesInPlans); err != nil {
@@ -774,7 +774,7 @@ func TestPlanCandidateRepository_AddPlan(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, models.PlanCandidate{Id: c.planCandidateId, ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+			if err := savePlanCandidate(testContext, testDB, models.PlanCandidateSet{Id: c.planCandidateId, ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
 				t.Fatalf("failed to create plan candidate: %v", err)
 			}
 
@@ -906,14 +906,14 @@ func TestPlanCandidateRepository_RemovePlaceFromPlan(t *testing.T) {
 		planCandidateSetId    string
 		planCandidateId       string
 		placeIdToDelete       string
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 	}{
 		{
 			name:               "success",
 			planCandidateSetId: "test-plan-candidate-set",
 			planCandidateId:    "test-plan-candidate",
 			placeIdToDelete:    "second-place",
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -933,7 +933,7 @@ func TestPlanCandidateRepository_RemovePlaceFromPlan(t *testing.T) {
 			planCandidateSetId: "test-plan-candidate-set",
 			planCandidateId:    "test-plan-candidate",
 			placeIdToDelete:    "not-existing-place",
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1001,14 +1001,14 @@ func TestPlanCandidateRepository_UpdatePlacesOrder(t *testing.T) {
 		planCandidateSetId    string
 		planCandidateId       string
 		placeIdsOrdered       []string
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 	}{
 		{
 			name:               "success",
 			planCandidateSetId: "test-plan-candidate-set",
 			planCandidateId:    "test-plan-candidate",
 			placeIdsOrdered:    []string{"third-place", "first-place", "second-place"},
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1079,14 +1079,14 @@ func TestPlanCandidateRepository_UpdatePlacesOrder_ShouldReturnError(t *testing.
 		planCandidateSetId    string
 		planCandidateId       string
 		placeIdsOrdered       []string
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 	}{
 		{
 			name:               "reorder with not existing place",
 			planCandidateSetId: "test-plan-candidate-set",
 			planCandidateId:    "test-plan-candidate",
 			placeIdsOrdered:    []string{"third-place", "first-place", "not-existing-place"},
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1141,13 +1141,13 @@ func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 	cases := []struct {
 		name                  string
 		planCandidateSetId    string
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 		metaData              models.PlanCandidateMetaData
 	}{
 		{
 			name:               "save plan candidate meta data",
 			planCandidateSetId: "test-plan-candidate-set",
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				MetaData:  models.PlanCandidateMetaData{},
@@ -1163,7 +1163,7 @@ func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 		{
 			name:               "update plan candidate meta data",
 			planCandidateSetId: "test-plan-candidate-set",
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				MetaData: models.PlanCandidateMetaData{
@@ -1330,7 +1330,7 @@ func TestPlanCandidateRepository_ReplacePlace(t *testing.T) {
 		planCandidateId       string
 		placeIdToReplace      string
 		placeToReplace        models.Place
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 	}{
 		{
 			name:               "success",
@@ -1338,7 +1338,7 @@ func TestPlanCandidateRepository_ReplacePlace(t *testing.T) {
 			planCandidateId:    "test-plan-candidate",
 			placeIdToReplace:   "second-place",
 			placeToReplace:     models.Place{Id: "replaced-place"},
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1411,7 +1411,7 @@ func TestPlanCandidateRepository_ReplacePlace_ShouldReturnError(t *testing.T) {
 		planCandidateId       string
 		placeIdToReplace      string
 		placeToReplace        models.Place
-		savedPlanCandidateSet models.PlanCandidate
+		savedPlanCandidateSet models.PlanCandidateSet
 	}{
 		{
 			name:               "replace with not existing place",
@@ -1419,7 +1419,7 @@ func TestPlanCandidateRepository_ReplacePlace_ShouldReturnError(t *testing.T) {
 			planCandidateId:    "test-plan-candidate",
 			placeIdToReplace:   "not-existing-place",
 			placeToReplace:     models.Place{Id: "place-to-replace"},
-			savedPlanCandidateSet: models.PlanCandidate{
+			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1476,13 +1476,13 @@ func TestPlanCandidateRepository_ReplacePlace_ShouldReturnError(t *testing.T) {
 func TestPlanCandidateRepository_DeleteAll(t *testing.T) {
 	cases := []struct {
 		name                        string
-		savedPlanCandidateSets      []models.PlanCandidate
+		savedPlanCandidateSets      []models.PlanCandidateSet
 		planCandidateIdsToDelete    []string
 		planCandidateIdsNotToDelete []string
 	}{
 		{
 			name: "success",
-			savedPlanCandidateSets: []models.PlanCandidate{
+			savedPlanCandidateSets: []models.PlanCandidateSet{
 				{
 					Id:        "test-plan-candidate-set-1",
 					ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
@@ -1615,7 +1615,7 @@ func TestPlanCandidateRepository_DeleteAll(t *testing.T) {
 					t.Fatalf("plan candidate set meta data category should not exist")
 				}
 
-				// PlanCandidate が削除されていることを確認
+				// PlanCandidateSet が削除されていることを確認
 				planCandidateEntityExist, err := generated.PlanCandidates(
 					generated.PlanCandidateWhere.ID.EQ(planCandidateId),
 				).Exists(testContext, testDB)
@@ -1647,7 +1647,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Like(t *testin
 		planCandidateSetId                     string
 		placeId                                string
 		savedPlaces                            []models.Place
-		savedPlanCandidate                     models.PlanCandidate
+		savedPlanCandidate                     models.PlanCandidateSet
 		savedPlanCandidateSetLikePlaceEntities []generated.PlanCandidateSetLikePlace
 	}{
 		{
@@ -1657,7 +1657,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Like(t *testin
 			savedPlaces: []models.Place{
 				{Id: "test-place"},
 			},
-			savedPlanCandidate: models.PlanCandidate{
+			savedPlanCandidate: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1676,7 +1676,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Like(t *testin
 			savedPlaces: []models.Place{
 				{Id: "test-place"},
 			},
-			savedPlanCandidate: models.PlanCandidate{
+			savedPlanCandidate: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1754,7 +1754,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Unlike(t *test
 		planCandidateSetId                     string
 		placeId                                string
 		savedPlaces                            []models.Place
-		savedPlanCandidate                     models.PlanCandidate
+		savedPlanCandidate                     models.PlanCandidateSet
 		savedPlanCandidateSetLikePlaceEntities []generated.PlanCandidateSetLikePlace
 	}{
 		{
@@ -1764,7 +1764,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Unlike(t *test
 			savedPlaces: []models.Place{
 				{Id: "test-place"},
 			},
-			savedPlanCandidate: models.PlanCandidate{
+			savedPlanCandidate: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{
@@ -1789,7 +1789,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Unlike(t *test
 			savedPlaces: []models.Place{
 				{Id: "test-place"},
 			},
-			savedPlanCandidate: models.PlanCandidate{
+			savedPlanCandidate: models.PlanCandidateSet{
 				Id:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				Plans: []models.Plan{

--- a/internal/infrastructure/rdb/plan_candidate_test.go
+++ b/internal/infrastructure/rdb/plan_candidate_test.go
@@ -17,14 +17,14 @@ import (
 
 func TestPlanCandidateRepository_Create(t *testing.T) {
 	cases := []struct {
-		name            string
-		planCandidateId string
-		expiresAt       time.Time
+		name               string
+		planCandidateSetId string
+		expiresAt          time.Time
 	}{
 		{
-			name:            "success",
-			planCandidateId: uuid.New().String(),
-			expiresAt:       time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			name:               "success",
+			planCandidateSetId: uuid.New().String(),
+			expiresAt:          time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 	}
 
@@ -44,11 +44,11 @@ func TestPlanCandidateRepository_Create(t *testing.T) {
 				}
 			})
 
-			if err := planCandidateRepository.Create(testContext, c.planCandidateId, c.expiresAt); err != nil {
+			if err := planCandidateRepository.Create(testContext, c.planCandidateSetId, c.expiresAt); err != nil {
 				t.Fatalf("failed to create plan candidate: %v", err)
 			}
 
-			exists, err := generated.PlanCandidateSetExists(testContext, testDB, c.planCandidateId)
+			exists, err := generated.PlanCandidateSetExists(testContext, testDB, c.planCandidateSetId)
 			if err != nil {
 				t.Fatalf("failed to check plan candidate existence: %v", err)
 			}
@@ -66,7 +66,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 		name                  string
 		now                   time.Time
 		savedPlanCandidateSet models.PlanCandidateSet
-		planCandidateId       string
+		planCandidateSetId    string
 		expected              models.PlanCandidateSet
 	}{
 		{
@@ -77,7 +77,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
 				IsPlaceSearched: true,
 			},
-			planCandidateId: "test",
+			planCandidateSetId: "test",
 			expected: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
@@ -109,7 +109,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 					},
 				},
 			},
-			planCandidateId: "test",
+			planCandidateSetId: "test",
 			expected: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
@@ -131,9 +131,9 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			},
 		},
 		{
-			name:            "plan candidate set without PlanCandidateSetMetaData",
-			now:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
-			planCandidateId: "test",
+			name:               "plan candidate set without PlanCandidateSetMetaData",
+			now:                time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
+			planCandidateSetId: "test",
 			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
@@ -162,9 +162,9 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			},
 		},
 		{
-			name:            "plan candidate set with IsPlaceSearched false",
-			now:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
-			planCandidateId: "test",
+			name:               "plan candidate set with IsPlaceSearched false",
+			now:                time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
+			planCandidateSetId: "test",
 			savedPlanCandidateSet: models.PlanCandidateSet{
 				Id:              "test",
 				ExpiresAt:       time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
@@ -201,11 +201,11 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
-			actual, err := planCandidateRepository.Find(testContext, c.planCandidateId, c.now)
+			actual, err := planCandidateRepository.Find(testContext, c.planCandidateSetId, c.now)
 			if err != nil {
 				t.Fatalf("failed to find plan candidate: %v", err)
 			}
@@ -313,7 +313,7 @@ func TestPlanCandidateRepository_Find_ShouldReturnNil(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -338,7 +338,7 @@ func TestPlanCandidateRepository_Find_WithPlaceLikeCount(t *testing.T) {
 		savedPlanCandidateSets                 []models.PlanCandidateSet
 		savedPlanCandidateSetLikePlaceEntities []generated.PlanCandidateSetLikePlace
 		savedUserLikePlaceEntities             generated.UserLikePlaceSlice
-		planCandidateId                        string
+		planCandidateSetId                     string
 		expected                               models.PlanCandidateSet
 	}{
 		{
@@ -380,7 +380,7 @@ func TestPlanCandidateRepository_Find_WithPlaceLikeCount(t *testing.T) {
 				{ID: uuid.New().String(), UserID: "test-user-1", PlaceID: "test-place-1"},
 				{ID: uuid.New().String(), UserID: "test-user-2", PlaceID: "test-place-2"},
 			},
-			planCandidateId: "plan-candidate-set-1",
+			planCandidateSetId: "plan-candidate-set-1",
 			expected: models.PlanCandidateSet{
 				Id:        "plan-candidate-set-1",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
@@ -423,7 +423,7 @@ func TestPlanCandidateRepository_Find_WithPlaceLikeCount(t *testing.T) {
 			}
 
 			for _, planCandidateSet := range c.savedPlanCandidateSets {
-				if err := savePlanCandidate(textContext, testDB, planCandidateSet); err != nil {
+				if err := savePlanCandidateSet(textContext, testDB, planCandidateSet); err != nil {
 					t.Fatalf("failed to save plan candidate: %v", err)
 				}
 			}
@@ -438,7 +438,7 @@ func TestPlanCandidateRepository_Find_WithPlaceLikeCount(t *testing.T) {
 				t.Fatalf("failed to save user like place: %v", err)
 			}
 
-			actual, err := planCandidateRepository.Find(textContext, c.planCandidateId, c.now)
+			actual, err := planCandidateRepository.Find(textContext, c.planCandidateSetId, c.now)
 			if err != nil {
 				t.Fatalf("failed to find plan candidate: %v", err)
 			}
@@ -611,7 +611,7 @@ func TestPlanCandidateRepository_FindPlan(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -701,7 +701,7 @@ func TestPlanCandidateRepository_FindExpiredBefore(t *testing.T) {
 
 			// 事前にPlanCandidateSetを作成しておく
 			for _, planCandidateSet := range c.savedPlanCandidateSets {
-				if err := savePlanCandidate(testContext, testDB, planCandidateSet); err != nil {
+				if err := savePlanCandidateSet(testContext, testDB, planCandidateSet); err != nil {
 					t.Fatalf("failed to save plan candidate: %v", err)
 				}
 			}
@@ -774,7 +774,7 @@ func TestPlanCandidateRepository_AddPlan(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, models.PlanCandidateSet{Id: c.planCandidateId, ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, models.PlanCandidateSet{Id: c.planCandidateId, ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
 				t.Fatalf("failed to create plan candidate: %v", err)
 			}
 
@@ -972,7 +972,7 @@ func TestPlanCandidateRepository_RemovePlaceFromPlan(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1047,7 +1047,7 @@ func TestPlanCandidateRepository_UpdatePlacesOrder(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1125,7 +1125,7 @@ func TestPlanCandidateRepository_UpdatePlacesOrder_ShouldReturnError(t *testing.
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1200,7 +1200,7 @@ func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 			})
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1380,7 +1380,7 @@ func TestPlanCandidateRepository_ReplacePlace(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1461,7 +1461,7 @@ func TestPlanCandidateRepository_ReplacePlace_ShouldReturnError(t *testing.T) {
 			}
 
 			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1557,7 +1557,7 @@ func TestPlanCandidateRepository_DeleteAll(t *testing.T) {
 
 			// 事前にPlanCandidateSetを作成しておく
 			for _, planCandidateSet := range c.savedPlanCandidateSets {
-				if err := savePlanCandidate(testContext, testDB, planCandidateSet); err != nil {
+				if err := savePlanCandidateSet(testContext, testDB, planCandidateSet); err != nil {
 					t.Fatalf("failed to save plan candidate: %v", err)
 				}
 			}
@@ -1717,7 +1717,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Like(t *testin
 			}
 
 			// 事前に PlanCandidateSet を作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidate); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidate); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1728,7 +1728,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Like(t *testin
 				}
 			}
 
-			err := planCandidateRepository.UpdateLikeToPlaceInPlanCandidate(testContext, c.planCandidateSetId, c.placeId, true)
+			err := planCandidateRepository.UpdateLikeToPlaceInPlanCandidateSet(testContext, c.planCandidateSetId, c.placeId, true)
 			if err != nil {
 				t.Fatalf("failed to update like to place in plan candidate: %v", err)
 			}
@@ -1824,7 +1824,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Unlike(t *test
 			}
 
 			// 事前に PlanCandidateSet を作成しておく
-			if err := savePlanCandidate(testContext, testDB, c.savedPlanCandidate); err != nil {
+			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidate); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
 			}
 
@@ -1835,7 +1835,7 @@ func TestPlanCandidateRepository_UpdateLikeToPlaceInPlanCandidate_Unlike(t *test
 				}
 			}
 
-			err := planCandidateRepository.UpdateLikeToPlaceInPlanCandidate(testContext, c.planCandidateSetId, c.placeId, false)
+			err := planCandidateRepository.UpdateLikeToPlaceInPlanCandidateSet(testContext, c.planCandidateSetId, c.placeId, false)
 			if err != nil {
 				t.Fatalf("failed to update like to place in plan candidate: %v", err)
 			}

--- a/internal/interface/cloudfunctions/delete_expired_plan_candidates.go
+++ b/internal/interface/cloudfunctions/delete_expired_plan_candidates.go
@@ -18,7 +18,7 @@ func DeleteExpiredPlanCandidates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := batch.DeleteExpiredPlanCandidate(r.Context(), db); err != nil {
+	if err := batch.DeleteExpiredPlanCandidateSet(r.Context(), db); err != nil {
 		log.Printf("error while deleting expired plan candidates: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/internal/interface/graphql/factory/plan_candidate.go
+++ b/internal/interface/graphql/factory/plan_candidate.go
@@ -5,7 +5,7 @@ import (
 	graphql "poroto.app/poroto/planner/internal/interface/graphql/model"
 )
 
-func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidate) *graphql.PlanCandidate {
+func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidateSet) *graphql.PlanCandidate {
 	if planCandidate == nil {
 		return nil
 	}

--- a/internal/interface/graphql/factory/plan_candidate.go
+++ b/internal/interface/graphql/factory/plan_candidate.go
@@ -5,15 +5,15 @@ import (
 	graphql "poroto.app/poroto/planner/internal/interface/graphql/model"
 )
 
-func PlanCandidateFromDomainModel(planCandidate *models.PlanCandidateSet) *graphql.PlanCandidate {
-	if planCandidate == nil {
+func PlanCandidateSetFromDomainModel(planCandidateSet *models.PlanCandidateSet) *graphql.PlanCandidate {
+	if planCandidateSet == nil {
 		return nil
 	}
 
 	return &graphql.PlanCandidate{
-		ID:                            planCandidate.Id,
-		Plans:                         PlansFromDomainModel(&planCandidate.Plans, planCandidate.MetaData.LocationStart),
-		LikedPlaceIds:                 planCandidate.LikedPlaceIds,
-		CreatedBasedOnCurrentLocation: planCandidate.MetaData.CreatedBasedOnCurrentLocation,
+		ID:                            planCandidateSet.Id,
+		Plans:                         PlansFromDomainModel(&planCandidateSet.Plans, planCandidateSet.MetaData.LocationStart),
+		LikedPlaceIds:                 planCandidateSet.LikedPlaceIds,
+		CreatedBasedOnCurrentLocation: planCandidateSet.MetaData.CreatedBasedOnCurrentLocation,
 	}
 }

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -25,16 +25,16 @@ func (r *queryResolver) PlanCandidate(ctx context.Context, input model.PlanCandi
 		zap.String("planCandidateId", input.PlanCandidateID),
 	)
 
-	planCandidate, err := r.PlanCandidateService.FindPlanCandidate(ctx, plancandidate.FindPlanCandidateInput{
-		PlanCandidateId:   input.PlanCandidateID,
-		UserId:            input.UserID,
-		FirebaseAuthToken: input.FirebaseAuthToken})
+	planCandidate, err := r.PlanCandidateService.Find(ctx, plancandidate.FindPlanCandidateSetInput{
+		PlanCandidateSetId: input.PlanCandidateID,
+		UserId:             input.UserID,
+		FirebaseAuthToken:  input.FirebaseAuthToken})
 	if err != nil {
 		r.Logger.Error("error while finding plan candidate", zap.Error(err))
 		return nil, err
 	}
 
-	graphqlPlanCandidate := factory.PlanCandidateFromDomainModel(planCandidate)
+	graphqlPlanCandidate := factory.PlanCandidateSetFromDomainModel(planCandidate)
 	return &model.PlanCandidateOutput{
 		PlanCandidate: graphqlPlanCandidate,
 	}, nil
@@ -89,7 +89,7 @@ func (r *queryResolver) NearbyPlaceCategories(ctx context.Context, input model.N
 // AvailablePlacesForPlan is the resolver for the availablePlacesForPlan field.
 func (r *queryResolver) AvailablePlacesForPlan(ctx context.Context, input model.AvailablePlacesForPlanInput) (*model.AvailablePlacesForPlan, error) {
 	availablePlaces, err := r.PlaceService.FetchCandidatePlaces(ctx, place.FetchCandidatePlacesInput{
-		PlanCandidateId: input.Session,
+		PlanCandidateSetId: input.Session,
 	})
 	if err != nil {
 		r.Logger.Error("error while fetching available places for plan", zap.Error(err))
@@ -110,10 +110,10 @@ func (r *queryResolver) AvailablePlacesForPlan(ctx context.Context, input model.
 func (r *queryResolver) PlacesToAddForPlanCandidate(ctx context.Context, input model.PlacesToAddForPlanCandidateInput) (*model.PlacesToAddForPlanCandidateOutput, error) {
 	// TODO: 指定されたプランIDが不正だった場合の対処をする
 	result, err := r.PlaceService.FetchPlacesToAdd(ctx, place.FetchPlacesToAddInput{
-		PlanCandidateId: input.PlanCandidateID,
-		PlanId:          input.PlanID,
-		PlaceId:         input.PlaceID,
-		NLimit:          4,
+		PlanCandidateSetId: input.PlanCandidateID,
+		PlanId:             input.PlanID,
+		PlaceId:            input.PlaceID,
+		NLimit:             4,
 	})
 	if err != nil {
 		r.Logger.Error("error while fetching places to add", zap.Error(err))

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -21,7 +21,7 @@ import (
 // PlanCandidate is the resolver for the planCandidate field.
 func (r *queryResolver) PlanCandidate(ctx context.Context, input model.PlanCandidateInput) (*model.PlanCandidateOutput, error) {
 	r.Logger.Info(
-		"PlanCandidate",
+		"PlanCandidateSet",
 		zap.String("planCandidateId", input.PlanCandidateID),
 	)
 

--- a/pkg/batch/delete_expired_plan_candidate.go
+++ b/pkg/batch/delete_expired_plan_candidate.go
@@ -13,7 +13,7 @@ import (
 	"context"
 )
 
-func DeleteExpiredPlanCandidate(ctx context.Context, db *sql.DB) error {
+func DeleteExpiredPlanCandidateSet(ctx context.Context, db *sql.DB) error {
 	log.Printf("=================== Start deleting expired plan candidates ===================\n")
 
 	service, err := plancandidate.NewService(ctx, db)


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- プラン候補モデルや、それに関連する変数名や関数名をPlanCandidateSetに統一した


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #543 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```