### PR TITLE
新規ユーザー登録ができなくなってしまうバグを修正

### DIFF
--- a/db/migrations/20240608041046_increase_users_photo_url_length.sql
+++ b/db/migrations/20240608041046_increase_users_photo_url_length.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE users
+    MODIFY photo_url VARCHAR(2048);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE users
+    MODIFY photo_url VARCHAR(255);
+-- +goose StatementEnd

--- a/internal/interface/rest/graphql.go
+++ b/internal/interface/rest/graphql.go
@@ -124,6 +124,15 @@ func (s Server) GraphqlAuthMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		if user == nil {
+			s.logger.Debug(
+				"user not found",
+				zap.String("firebaseUid", *firebaseUid),
+			)
+			c.Next()
+			return
+		}
+
 		s.logger.Debug(
 			"set auth user to context",
 			zap.String("userId", user.Id),


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 以下の２つの原因で新規ユーザー登録ができなくなってしまっていた。
  1. Graphqlの認証状態を確認するミドルウェア内で、初回ログイン時に認証ヘッダに登録されたユーザー情報と一致するものがDB上に存在せずエラーとなってしまう
  2. 登録されたユーザーのアイコン画像のURLが256文字を超え、DBに登録できない。

これに伴い以下の修正を行った。
- [x] DB上にユーザー情報が存在しないときに、エラーにならないようにする
- [x] アイコン画像のURLの最大長を2048文字まで増やす 

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- ユーザー登録を行えるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] 今まで登録されていないユーザー情報でログインできることを確認
- [x] xxx@poroto.app アカウントでログインできることを客員 

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```