### PR TITLE
[スキーマ変更] ユーザーのプロフィールを更新できるようにする

### DIFF
--- a/internal/domain/services/user/update_profile.go
+++ b/internal/domain/services/user/update_profile.go
@@ -1,1 +1,0 @@
-package user

--- a/internal/domain/services/user/update_profile.go
+++ b/internal/domain/services/user/update_profile.go
@@ -1,0 +1,1 @@
+package user

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -2119,7 +2119,6 @@ type BindPlanCandidateSetToUserOutput {
 
 input UpdateUserProfileInput {
     userId: ID!
-    firebaseAuthToken: String!
     name: String
     profileImageUrl: String
 }
@@ -13291,7 +13290,7 @@ func (ec *executionContext) unmarshalInputUpdateUserProfileInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "name", "profileImageUrl"}
+	fieldsInOrder := [...]string{"userId", "name", "profileImageUrl"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -13307,15 +13306,6 @@ func (ec *executionContext) unmarshalInputUpdateUserProfileInput(ctx context.Con
 				return it, err
 			}
 			it.UserID = data
-		case "firebaseAuthToken":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("firebaseAuthToken"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.FirebaseAuthToken = data
 		case "name":
 			var err error
 

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -158,6 +158,7 @@ type ComplexityRoot struct {
 		ReplacePlaceOfPlanCandidate         func(childComplexity int, input model.ReplacePlaceOfPlanCandidateInput) int
 		SavePlanFromCandidate               func(childComplexity int, input model.SavePlanFromCandidateInput) int
 		UpdatePlanCollageImage              func(childComplexity int, input model.UpdatePlanCollageImageInput) int
+		UpdateUserProfile                   func(childComplexity int, input model.UpdateUserProfileInput) int
 		UploadPlacePhotoInPlan              func(childComplexity int, planID string, userID string, firebaseAuthToken string, inputs []*model.UploadPlacePhotoInPlanInput) int
 	}
 
@@ -303,6 +304,10 @@ type ComplexityRoot struct {
 		Plan func(childComplexity int) int
 	}
 
+	UpdateUserProfileOutput struct {
+		User func(childComplexity int) int
+	}
+
 	UploadPlacePhotoInPlanOutput struct {
 		Plan func(childComplexity int) int
 	}
@@ -333,6 +338,7 @@ type MutationResolver interface {
 	LikeToPlaceInPlan(ctx context.Context, input model.LikeToPlaceInPlanInput) (*model.LikeToPlaceInPlanOutput, error)
 	UpdatePlanCollageImage(ctx context.Context, input model.UpdatePlanCollageImageInput) (*model.UpdatePlanCollageImageOutput, error)
 	BindPlanCandidateSetToUser(ctx context.Context, input model.BindPlanCandidateSetToUserInput) (*model.BindPlanCandidateSetToUserOutput, error)
+	UpdateUserProfile(ctx context.Context, input model.UpdateUserProfileInput) (*model.UpdateUserProfileOutput, error)
 }
 type PlanResolver interface {
 	Collage(ctx context.Context, obj *model.Plan) (*model.PlanCollage, error)
@@ -847,6 +853,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.UpdatePlanCollageImage(childComplexity, args["input"].(model.UpdatePlanCollageImageInput)), true
+
+	case "Mutation.updateUserProfile":
+		if e.complexity.Mutation.UpdateUserProfile == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateUserProfile_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateUserProfile(childComplexity, args["input"].(model.UpdateUserProfileInput)), true
 
 	case "Mutation.uploadPlacePhotoInPlan":
 		if e.complexity.Mutation.UploadPlacePhotoInPlan == nil {
@@ -1431,6 +1449,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.UpdatePlanCollageImageOutput.Plan(childComplexity), true
 
+	case "UpdateUserProfileOutput.user":
+		if e.complexity.UpdateUserProfileOutput.User == nil {
+			break
+		}
+
+		return e.complexity.UpdateUserProfileOutput.User(childComplexity), true
+
 	case "UploadPlacePhotoInPlanOutput.plan":
 		if e.complexity.UploadPlacePhotoInPlanOutput.Plan == nil {
 			break
@@ -1508,6 +1533,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputReplacePlaceOfPlanCandidateInput,
 		ec.unmarshalInputSavePlanFromCandidateInput,
 		ec.unmarshalInputUpdatePlanCollageImageInput,
+		ec.unmarshalInputUpdateUserProfileInput,
 		ec.unmarshalInputUploadPlacePhotoInPlanInput,
 	)
 	first := true
@@ -2077,6 +2103,8 @@ type Mutation {
 }`, BuiltIn: false},
 	{Name: "../schema/user_mutation.graphqls", Input: `extend type Mutation {
     bindPlanCandidateSetToUser(input: BindPlanCandidateSetToUserInput!): BindPlanCandidateSetToUserOutput!
+
+    updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfileOutput!
 }
 
 input BindPlanCandidateSetToUserInput {
@@ -2087,7 +2115,19 @@ input BindPlanCandidateSetToUserInput {
 
 type BindPlanCandidateSetToUserOutput {
     user: User!
-}`, BuiltIn: false},
+}
+
+input UpdateUserProfileInput {
+    userId: ID!
+    firebaseAuthToken: String!
+    name: String
+    profileImageUrl: String
+}
+
+type UpdateUserProfileOutput {
+    user: User!
+}
+`, BuiltIn: false},
 	{Name: "../schema/user_query.graphqls", Input: `extend type Query {
     firebaseUser(input: FirebaseUserInput): User!
 
@@ -2334,6 +2374,21 @@ func (ec *executionContext) field_Mutation_updatePlanCollageImage_args(ctx conte
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNUpdatePlanCollageImageInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUpdatePlanCollageImageInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateUserProfile_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.UpdateUserProfileInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNUpdateUserProfileInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUpdateUserProfileInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -5656,6 +5711,65 @@ func (ec *executionContext) fieldContext_Mutation_bindPlanCandidateSetToUser(ctx
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_bindPlanCandidateSetToUser_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateUserProfile(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateUserProfile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateUserProfile(rctx, fc.Args["input"].(model.UpdateUserProfileInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.UpdateUserProfileOutput)
+	fc.Result = res
+	return ec.marshalNUpdateUserProfileOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUpdateUserProfileOutput(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateUserProfile(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "user":
+				return ec.fieldContext_UpdateUserProfileOutput_user(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateUserProfileOutput", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateUserProfile_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9711,6 +9825,62 @@ func (ec *executionContext) fieldContext_UpdatePlanCollageImageOutput_plan(ctx c
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateUserProfileOutput_user(ctx context.Context, field graphql.CollectedField, obj *model.UpdateUserProfileOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateUserProfileOutput_user(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.User, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.User)
+	fc.Result = res
+	return ec.marshalNUser2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateUserProfileOutput_user(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateUserProfileOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "photoUrl":
+				return ec.fieldContext_User_photoUrl(ctx, field)
+			case "plans":
+				return ec.fieldContext_User_plans(ctx, field)
+			case "likedPlaces":
+				return ec.fieldContext_User_likedPlaces(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UploadPlacePhotoInPlanOutput_plan(ctx context.Context, field graphql.CollectedField, obj *model.UploadPlacePhotoInPlanOutput) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UploadPlacePhotoInPlanOutput_plan(ctx, field)
 	if err != nil {
@@ -13114,6 +13284,62 @@ func (ec *executionContext) unmarshalInputUpdatePlanCollageImageInput(ctx contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateUserProfileInput(ctx context.Context, obj interface{}) (model.UpdateUserProfileInput, error) {
+	var it model.UpdateUserProfileInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"userId", "firebaseAuthToken", "name", "profileImageUrl"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "userId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserID = data
+		case "firebaseAuthToken":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("firebaseAuthToken"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FirebaseAuthToken = data
+		case "name":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "profileImageUrl":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("profileImageUrl"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ProfileImageURL = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUploadPlacePhotoInPlanInput(ctx context.Context, obj interface{}) (model.UploadPlacePhotoInPlanInput, error) {
 	var it model.UploadPlacePhotoInPlanInput
 	asMap := map[string]interface{}{}
@@ -14100,6 +14326,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "bindPlanCandidateSetToUser":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_bindPlanCandidateSetToUser(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateUserProfile":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateUserProfile(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -15534,6 +15767,45 @@ func (ec *executionContext) _UpdatePlanCollageImageOutput(ctx context.Context, s
 			out.Values[i] = graphql.MarshalString("UpdatePlanCollageImageOutput")
 		case "plan":
 			out.Values[i] = ec._UpdatePlanCollageImageOutput_plan(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateUserProfileOutputImplementors = []string{"UpdateUserProfileOutput"}
+
+func (ec *executionContext) _UpdateUserProfileOutput(ctx context.Context, sel ast.SelectionSet, obj *model.UpdateUserProfileOutput) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateUserProfileOutputImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateUserProfileOutput")
+		case "user":
+			out.Values[i] = ec._UpdateUserProfileOutput_user(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -17128,6 +17400,25 @@ func (ec *executionContext) marshalNUpdatePlanCollageImageOutput2ᚖporotoᚗapp
 		return graphql.Null
 	}
 	return ec._UpdatePlanCollageImageOutput(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateUserProfileInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUpdateUserProfileInput(ctx context.Context, v interface{}) (model.UpdateUserProfileInput, error) {
+	res, err := ec.unmarshalInputUpdateUserProfileInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateUserProfileOutput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUpdateUserProfileOutput(ctx context.Context, sel ast.SelectionSet, v model.UpdateUserProfileOutput) graphql.Marshaler {
+	return ec._UpdateUserProfileOutput(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateUserProfileOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUpdateUserProfileOutput(ctx context.Context, sel ast.SelectionSet, v *model.UpdateUserProfileOutput) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateUserProfileOutput(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUploadPlacePhotoInPlanInput2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐUploadPlacePhotoInPlanInputᚄ(ctx context.Context, v interface{}) ([]*model.UploadPlacePhotoInPlanInput, error) {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -395,6 +395,17 @@ type UpdatePlanCollageImageOutput struct {
 	Plan *Plan `json:"plan"`
 }
 
+type UpdateUserProfileInput struct {
+	UserID            string  `json:"userId"`
+	FirebaseAuthToken string  `json:"firebaseAuthToken"`
+	Name              *string `json:"name,omitempty"`
+	ProfileImageURL   *string `json:"profileImageUrl,omitempty"`
+}
+
+type UpdateUserProfileOutput struct {
+	User *User `json:"user"`
+}
+
 type UploadPlacePhotoInPlanInput struct {
 	PlaceID  string `json:"placeId"`
 	PhotoURL string `json:"photoUrl"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -396,10 +396,9 @@ type UpdatePlanCollageImageOutput struct {
 }
 
 type UpdateUserProfileInput struct {
-	UserID            string  `json:"userId"`
-	FirebaseAuthToken string  `json:"firebaseAuthToken"`
-	Name              *string `json:"name,omitempty"`
-	ProfileImageURL   *string `json:"profileImageUrl,omitempty"`
+	UserID          string  `json:"userId"`
+	Name            *string `json:"name,omitempty"`
+	ProfileImageURL *string `json:"profileImageUrl,omitempty"`
 }
 
 type UpdateUserProfileOutput struct {

--- a/internal/interface/graphql/resolver/plan_type.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_type.resolvers.go
@@ -7,11 +7,11 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"poroto.app/poroto/planner/internal/domain/services/plan"
-	"poroto.app/poroto/planner/internal/domain/utils"
 
 	"go.uber.org/zap"
 	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/services/plan"
+	"poroto.app/poroto/planner/internal/domain/utils"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 	"poroto.app/poroto/planner/internal/interface/graphql/generated"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"

--- a/internal/interface/graphql/resolver/user_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/user_mutation.resolvers.go
@@ -32,3 +32,8 @@ func (r *mutationResolver) BindPlanCandidateSetToUser(ctx context.Context, input
 		User: graphqlUser,
 	}, nil
 }
+
+// UpdateUserProfile is the resolver for the updateUserProfile field.
+func (r *mutationResolver) UpdateUserProfile(ctx context.Context, input model.UpdateUserProfileInput) (*model.UpdateUserProfileOutput, error) {
+	panic(fmt.Errorf("not implemented: UpdateUserProfile - updateUserProfile"))
+}

--- a/internal/interface/graphql/schema/user_mutation.graphqls
+++ b/internal/interface/graphql/schema/user_mutation.graphqls
@@ -16,7 +16,6 @@ type BindPlanCandidateSetToUserOutput {
 
 input UpdateUserProfileInput {
     userId: ID!
-    firebaseAuthToken: String!
     name: String
     profileImageUrl: String
 }

--- a/internal/interface/graphql/schema/user_mutation.graphqls
+++ b/internal/interface/graphql/schema/user_mutation.graphqls
@@ -1,5 +1,7 @@
 extend type Mutation {
     bindPlanCandidateSetToUser(input: BindPlanCandidateSetToUserInput!): BindPlanCandidateSetToUserOutput!
+
+    updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfileOutput!
 }
 
 input BindPlanCandidateSetToUserInput {
@@ -9,5 +11,16 @@ input BindPlanCandidateSetToUserInput {
 }
 
 type BindPlanCandidateSetToUserOutput {
+    user: User!
+}
+
+input UpdateUserProfileInput {
+    userId: ID!
+    firebaseAuthToken: String!
+    name: String
+    profileImageUrl: String
+}
+
+type UpdateUserProfileOutput {
     user: User!
 }


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- ユーザー名・プロフィール画像を更新するためのMutationを作成

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #556 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- ユーザー情報を更新できるようにするため。

### どのようにテストされているか


```shell
# planner
export BRANCH_PLANNER=feature/graphql_update_user_profile
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```