### PR TITLE
ユーザーのプロフィールを更新できるようにする

### DIFF
--- a/internal/apperrors/errors.go
+++ b/internal/apperrors/errors.go
@@ -1,0 +1,7 @@
+package apperrors
+
+import "errors"
+
+var (
+	ErrUnauthorized = errors.New("permission denied")
+)

--- a/internal/domain/repository/user.go
+++ b/internal/domain/repository/user.go
@@ -11,4 +11,6 @@ type UserRepository interface {
 	Find(ctx context.Context, id string) (*models.User, error)
 
 	FindByFirebaseUID(ctx context.Context, firebaseUID string) (*models.User, error)
+
+	UpdateProfile(ctx context.Context, userId string, name *string, photoUrl *string) error
 }

--- a/internal/domain/services/user/update_profile.go
+++ b/internal/domain/services/user/update_profile.go
@@ -1,0 +1,42 @@
+package user
+
+import (
+	"context"
+	"fmt"
+	"poroto.app/poroto/planner/internal/apperrors"
+	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/utils"
+)
+
+type UpdateUserProfileInput struct {
+	AuthorizedUser  models.User
+	UserId          string
+	Name            string
+	ProfileImageUrl string
+}
+
+// UpdateUserProfile ユーザーのプロフィールを更新する
+// 認証ユーザーと更新対象が一致しない場合は apperrors.ErrUnauthorized を返す
+// 更新対象が空白の場合は更新を行わない
+func (s Service) UpdateUserProfile(ctx context.Context, input UpdateUserProfileInput) (*models.User, error) {
+	if input.AuthorizedUser.Id != input.UserId {
+		return nil, apperrors.ErrUnauthorized
+	}
+
+	// 空白だけの場合は更新を行わない
+	if err := s.userRepository.UpdateProfile(
+		ctx,
+		input.UserId,
+		utils.StrOmitWhitespace(input.Name),
+		utils.StrOmitWhitespace(input.ProfileImageUrl),
+	); err != nil {
+		return nil, fmt.Errorf("failed to update user profile: %w", err)
+	}
+
+	user, err := s.userRepository.Find(ctx, input.UserId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	return user, nil
+}

--- a/internal/domain/utils/string.go
+++ b/internal/domain/utils/string.go
@@ -1,5 +1,7 @@
 package utils
 
+import "strings"
+
 // TODO: ToPointer 関数に置き換える
 func StrPointer(s string) *string {
 	return &s
@@ -9,6 +11,15 @@ func StrOmitEmpty(s string) *string {
 	if s == "" {
 		return nil
 	}
+	return &s
+}
+
+func StrOmitWhitespace(s string) *string {
+	// すべて空白の場合はnilを返す
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+
 	return &s
 }
 

--- a/internal/domain/utils/string_test.go
+++ b/internal/domain/utils/string_test.go
@@ -1,6 +1,9 @@
 package utils
 
-import "testing"
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
 
 func TestStrPinter(t *testing.T) {
 	object := struct {
@@ -29,6 +32,61 @@ func TestStrOmitEmpty(t *testing.T) {
 	result = StrOmitEmpty("")
 	if result != nil {
 		t.Errorf("StrOmitEmpty(%v) = %v, want %v", "", result, nil)
+	}
+}
+
+func TestStrOmitWhitespace(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected *string
+	}{
+		{
+			name:     "return original value if not empty",
+			input:    "test",
+			expected: StrOmitEmpty("test"),
+		},
+		{
+			name:     "return nil if empty",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "return nil if whitespace",
+			input:    "  ",
+			expected: nil,
+		},
+		{
+			name:     "return nil if tab",
+			input:    "\t",
+			expected: nil,
+		},
+		{
+			name:     "return nil if newline",
+			input:    "\n",
+			expected: nil,
+		},
+		{
+			name:     "return nil if carriage return",
+			input:    "\r",
+			expected: nil,
+		},
+		{
+			name:     "return nil if mixed whitespace",
+			input:    " \t\n\r",
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			result := StrOmitWhitespace(c.input)
+			if diff := cmp.Diff(c.expected, result); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/infrastructure/rdb/user_test.go
+++ b/internal/infrastructure/rdb/user_test.go
@@ -1,0 +1,99 @@
+package rdb
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"poroto.app/poroto/planner/internal/domain/utils"
+	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
+	"testing"
+)
+
+func TestUserRepository_UpdateProfile(t *testing.T) {
+	cases := []struct {
+		name       string
+		savedUsers generated.UserSlice
+		userId     string
+		userName   *string
+		photoUrl   *string
+		expected   generated.User
+	}{
+		{
+			name: "update user profile with empty values",
+			savedUsers: generated.UserSlice{
+				{
+					ID:       "user-1",
+					Name:     null.StringFrom("test-user"),
+					PhotoURL: null.StringFrom("https://example.com/test-user.jpg"),
+				},
+			},
+			userId:   "user-1",
+			userName: nil,
+			photoUrl: nil,
+			expected: generated.User{
+				ID:       "user-1",
+				Name:     null.StringFrom("test-user"),
+				PhotoURL: null.StringFrom("https://example.com/test-user.jpg"),
+			},
+		},
+		{
+			name: "update user profile with new values",
+			savedUsers: generated.UserSlice{
+				{
+					ID:       "user-1",
+					Name:     null.StringFrom("test-user"),
+					PhotoURL: null.StringFrom("https://example.com/test-user.jpg"),
+				},
+			},
+			userId:   "user-1",
+			userName: utils.ToPointer("new-user"),
+			photoUrl: utils.ToPointer("https://example.com/new-user.jpg"),
+			expected: generated.User{
+				ID:       "user-1",
+				Name:     null.StringFrom("new-user"),
+				PhotoURL: null.StringFrom("https://example.com/new-user.jpg"),
+			},
+		},
+	}
+
+	userRepository, err := NewUserRepository(testDB)
+	if err != nil {
+		t.Fatalf("failed to create user repository: %v", err)
+	}
+
+	for _, c := range cases {
+		testContext := context.Background()
+		t.Run(c.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				if err := cleanup(testContext, testDB); err != nil {
+					t.Errorf("error cleaning up: %v", err)
+				}
+			})
+
+			// データを準備
+			if _, err := c.savedUsers.InsertAll(testContext, testDB, boil.Infer()); err != nil {
+				t.Fatalf("failed to insert user: %v", err)
+			}
+
+			// テスト対象の関数を実行
+			if err := userRepository.UpdateProfile(testContext, c.userId, c.userName, c.photoUrl); err != nil {
+				t.Fatalf("failed to update user profile: %v", err)
+			}
+
+			updatedUser, err := generated.Users(generated.UserWhere.ID.EQ(c.userId)).One(testContext, testDB)
+			if err != nil {
+				t.Fatalf("failed to find user: %v", err)
+			}
+
+			if diff := cmp.Diff(
+				c.expected,
+				*updatedUser,
+				cmpopts.IgnoreFields(generated.User{}, "CreatedAt", "UpdatedAt"),
+			); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- ユーザー名やユーザーのアバター画像を更新できるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #557 
- close #556 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正


### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] DBの保存処理の単体テストを作成
- [x] 名前が更新できることを確認（Posman）
- [x] 画像が更新できることを確認（更新後、Nextjsの最適化の都合で閲覧できなくなることに注意）

**テスト時の注意**
Authenticationタブで、Firestoreから提供される認証トークンを設定する必要がある。
<img width="1295" alt="image" src="https://github.com/poroto-app/planner/assets/55840281/483ca199-9089-4875-bf9b-2683d6361402">

```shell
# planner
export BRANCH_PLANNER=feature/update_user_profile
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```