### PR TITLE
MySQL 5.7に合わせてクエリを修正

### DIFF
--- a/db/migrations/20240608092636_add_parent_plan_id_to_plan_candidate.sql
+++ b/db/migrations/20240608092636_add_parent_plan_id_to_plan_candidate.sql
@@ -1,13 +1,21 @@
 -- +goose Up
--- +goose StatementBegin
+START TRANSACTION;
+
 ALTER TABLE plan_candidates
-    ADD COLUMN parent_plan_id CHAR(36) DEFAULT NULL,
+    ADD COLUMN parent_plan_id CHAR(36) DEFAULT NULL;
+
+ALTER TABLE plan_candidates
     ADD CONSTRAINT fk_plan_candidates_parent_plan_id FOREIGN KEY (parent_plan_id) REFERENCES plans(id);
--- +goose StatementEnd
+
+COMMIT;
 
 -- +goose Down
--- +goose StatementBegin
+START TRANSACTION;
+
 ALTER TABLE plan_candidates
-    DROP COLUMN parent_plan_id,
-    DROP CONSTRAINT fk_plan_candidates_parent_plan_id;
--- +goose StatementEnd
+    DROP FOREIGN KEY fk_plan_candidates_parent_plan_id;
+
+ALTER TABLE plan_candidates
+    DROP COLUMN parent_plan_id;
+
+COMMIT;


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- MySQLではALTER TABLEの処理の中で、カラムの追加とカラム制約の追加を同時に行うことができないため、わける変更を行った。


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] gooseでマイグレーションできることを確認
- [x]  gooseでロールバックできることを確認
- [x] TablePlusでTiDB（staging）に適用できることを確認 


```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```