### PR TITLE
カテゴリからプランを作成できるようにする

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
 GCP_PROJECT_ID=poroto-dev
 GCP_CREDENTIAL_FILE_PATH=secrets/google-credential.json
+CLOUD_STORAGE_IMAGE_BUCKET=poroto-photos-development
 
 DB_USER=root
 DB_PASSWORD=password

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,6 @@
 GCP_PROJECT_ID=poroto-379005
 GCP_CREDENTIAL_FILE_PATH=secrets/google-credential.json
+CLOUD_STORAGE_IMAGE_BUCKET=poroto-photos
 
 WEB_PROTOCOL=https
 WEB_HOST=komichi.app

--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,6 @@
 GCP_PROJECT_ID=poroto-staging
 GCP_CREDENTIAL_FILE_PATH=secrets/google-credential.json
+CLOUD_STORAGE_IMAGE_BUCKET=poroto-photos-staging
 
 WEB_PROTOCOL=https
 WEB_HOST=staging.komichi.app

--- a/internal/domain/models/category_create_plan.go
+++ b/internal/domain/models/category_create_plan.go
@@ -1,0 +1,166 @@
+package models
+
+import "googlemaps.github.io/maps"
+
+type LocationCategorySetCreatePlan struct {
+	Name             string
+	DisplayNameJa    string
+	DisplayNameEn    string
+	Categories       []LocationCategoryCreatePlan
+	GooglePlaceTypes []string
+}
+
+type LocationCategoryCreatePlan struct {
+	Name             string
+	DisplayNameJa    string
+	DisplayNameEn    string
+	GooglePlaceTypes []string
+	Image            string
+}
+
+var (
+	CreatePlanCategoryAmusements = LocationCategorySetCreatePlan{
+		Name:          "amusements",
+		DisplayNameJa: "遊び",
+		DisplayNameEn: "Amusements",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Name:             "amusement_park",
+				DisplayNameJa:    "遊園地",
+				DisplayNameEn:    "Amusement Park",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeAmusementPark)},
+			},
+			{
+				Name:             "bowling_alley",
+				DisplayNameJa:    "ボウリング場",
+				DisplayNameEn:    "Bowling Alley",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeBowlingAlley)},
+			},
+			{
+				Name:             "movie_theater",
+				DisplayNameJa:    "映画館",
+				DisplayNameEn:    "Movie Theater",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeMovieTheater)},
+			},
+		},
+		GooglePlaceTypes: CategoryAmusements.SubCategories,
+	}
+
+	CreatePlaceCategoryCulture = LocationCategorySetCreatePlan{
+		Name:          "cultural_facility",
+		DisplayNameJa: "芸術・動物",
+		DisplayNameEn: "Culture",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Name:             "art_gallery",
+				DisplayNameJa:    "美術館",
+				DisplayNameEn:    "Art Gallery",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeArtGallery)},
+			},
+			{
+				Name:             "museum",
+				DisplayNameJa:    "博物館",
+				DisplayNameEn:    "Museum",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeMuseum)},
+			},
+			{
+				Name:             "aquarium",
+				DisplayNameJa:    "水族館",
+				DisplayNameEn:    "Aquarium",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeAquarium)},
+			},
+			{
+				Name:             "zoo",
+				DisplayNameJa:    "動物園",
+				DisplayNameEn:    "Zoo",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeZoo)},
+			},
+		},
+	}
+
+	CreatePlanCategorySetRelaxation = LocationCategorySetCreatePlan{
+		Name:          "relaxation",
+		DisplayNameJa: "リラックス",
+		DisplayNameEn: "Relaxation",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Name:             "spa",
+				DisplayNameJa:    "温泉",
+				DisplayNameEn:    "Spa",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeSpa)},
+			},
+			{
+				Name:             "park",
+				DisplayNameJa:    "公園",
+				DisplayNameEn:    "Park",
+				GooglePlaceTypes: []string{string(maps.PlaceTypePark)},
+			},
+		},
+	}
+
+	CreatePlanCategorySetShopping = LocationCategorySetCreatePlan{
+		Name:          "shopping",
+		DisplayNameJa: "ショッピング",
+		DisplayNameEn: "Shopping",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Name:             "shopping_mall",
+				DisplayNameJa:    "ショッピングモール",
+				DisplayNameEn:    "Shopping Mall",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeShoppingMall)},
+			},
+			{
+				Name:             "本屋",
+				DisplayNameJa:    "本屋",
+				DisplayNameEn:    "Bookstore",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeBookStore)},
+			},
+		},
+	}
+
+	CreatePlanCategorySetEat = LocationCategorySetCreatePlan{
+		Name:          "eat",
+		DisplayNameJa: "食事",
+		DisplayNameEn: "Eat",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Name:             "restaurant",
+				DisplayNameJa:    "レストラン",
+				DisplayNameEn:    "Restaurant",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeRestaurant)},
+			},
+			{
+				Name:             "cafe",
+				DisplayNameJa:    "カフェ",
+				DisplayNameEn:    "Cafe",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeCafe)},
+			},
+			{
+				Name:             "bakery",
+				DisplayNameJa:    "パン屋",
+				DisplayNameEn:    "Bakery",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeBakery)},
+			},
+		},
+	}
+
+	CreatePlanCategorySetAttractions = LocationCategorySetCreatePlan{
+		Name:          "attractions",
+		DisplayNameJa: "観光",
+		DisplayNameEn: "Attractions",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Name:             "観光スポット",
+				DisplayNameJa:    "観光スポット",
+				DisplayNameEn:    "Sightseeing",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeTouristAttraction)},
+			},
+			{
+				Name:             "寺・神社",
+				DisplayNameJa:    "寺・神社",
+				DisplayNameEn:    "Temples & Shrines",
+				GooglePlaceTypes: []string{"place_of_worship"},
+			},
+		},
+	}
+)

--- a/internal/domain/models/category_create_plan.go
+++ b/internal/domain/models/category_create_plan.go
@@ -11,34 +11,34 @@ type LocationCategorySetCreatePlan struct {
 }
 
 type LocationCategoryCreatePlan struct {
-	Name                string
+	Id                  string
 	DisplayNameJa       string
 	DisplayNameEn       string
 	GooglePlaceTypes    []string
-	SearchRadiusMinInKm int // 検索半径（最小）
+	SearchRadiusMinInKm float64 // 検索半径（最小）
 	Image               string
 }
 
 var (
-	CreatePlanCategoryAmusements = LocationCategorySetCreatePlan{
+	LocationCategorySetCreatePlanAmusements = LocationCategorySetCreatePlan{
 		Name:          "amusements",
 		DisplayNameJa: "遊び",
 		DisplayNameEn: "Amusements",
 		Categories: []LocationCategoryCreatePlan{
 			{
-				Name:             "amusement_park",
+				Id:               "amusement_park",
 				DisplayNameJa:    "遊園地",
 				DisplayNameEn:    "Amusement Park",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeAmusementPark)},
 			},
 			{
-				Name:             "bowling_alley",
+				Id:               "bowling_alley",
 				DisplayNameJa:    "ボウリング場",
 				DisplayNameEn:    "Bowling Alley",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeBowlingAlley)},
 			},
 			{
-				Name:             "movie_theater",
+				Id:               "movie_theater",
 				DisplayNameJa:    "映画館",
 				DisplayNameEn:    "Movie Theater",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeMovieTheater)},
@@ -47,32 +47,32 @@ var (
 		GooglePlaceTypes: CategoryAmusements.SubCategories,
 	}
 
-	CreatePlaceCategoryCulture = LocationCategorySetCreatePlan{
+	LocationCategorySetCreatePlanCulture = LocationCategorySetCreatePlan{
 		Name:          "cultural_facility",
 		DisplayNameJa: "芸術・動物",
 		DisplayNameEn: "Culture",
 		Categories: []LocationCategoryCreatePlan{
 			{
-				Name:             "art_gallery",
+				Id:               "art_gallery",
 				DisplayNameJa:    "美術館",
 				DisplayNameEn:    "Art Gallery",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeArtGallery)},
 			},
 			{
-				Name:             "museum",
+				Id:               "museum",
 				DisplayNameJa:    "博物館",
 				DisplayNameEn:    "Museum",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeMuseum)},
 			},
 			{
-				Name:                "aquarium",
+				Id:                  "aquarium",
 				DisplayNameJa:       "水族館",
 				DisplayNameEn:       "Aquarium",
 				GooglePlaceTypes:    []string{string(maps.PlaceTypeAquarium)},
 				SearchRadiusMinInKm: 30,
 			},
 			{
-				Name:             "zoo",
+				Id:               "zoo",
 				DisplayNameJa:    "動物園",
 				DisplayNameEn:    "Zoo",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeZoo)},
@@ -80,19 +80,19 @@ var (
 		},
 	}
 
-	CreatePlanCategorySetRelaxation = LocationCategorySetCreatePlan{
+	LocationCategorySetCreatePlanRelaxation = LocationCategorySetCreatePlan{
 		Name:          "relaxation",
 		DisplayNameJa: "リラックス",
 		DisplayNameEn: "Relaxation",
 		Categories: []LocationCategoryCreatePlan{
 			{
-				Name:             "spa",
+				Id:               "spa",
 				DisplayNameJa:    "温泉",
 				DisplayNameEn:    "Spa",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeSpa)},
 			},
 			{
-				Name:             "park",
+				Id:               "park",
 				DisplayNameJa:    "公園",
 				DisplayNameEn:    "Park",
 				GooglePlaceTypes: []string{string(maps.PlaceTypePark)},
@@ -100,19 +100,19 @@ var (
 		},
 	}
 
-	CreatePlanCategorySetShopping = LocationCategorySetCreatePlan{
+	LocationCategorySetCreatePlanShopping = LocationCategorySetCreatePlan{
 		Name:          "shopping",
 		DisplayNameJa: "ショッピング",
 		DisplayNameEn: "Shopping",
 		Categories: []LocationCategoryCreatePlan{
 			{
-				Name:             "shopping_mall",
+				Id:               "shopping_mall",
 				DisplayNameJa:    "ショッピングモール",
 				DisplayNameEn:    "Shopping Mall",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeShoppingMall)},
 			},
 			{
-				Name:             "本屋",
+				Id:               "本屋",
 				DisplayNameJa:    "本屋",
 				DisplayNameEn:    "Bookstore",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeBookStore)},
@@ -120,25 +120,25 @@ var (
 		},
 	}
 
-	CreatePlanCategorySetEat = LocationCategorySetCreatePlan{
+	LocationCategorySetCreatePlanEat = LocationCategorySetCreatePlan{
 		Name:          "eat",
 		DisplayNameJa: "食事",
 		DisplayNameEn: "Eat",
 		Categories: []LocationCategoryCreatePlan{
 			{
-				Name:             "restaurant",
+				Id:               "restaurant",
 				DisplayNameJa:    "レストラン",
 				DisplayNameEn:    "Restaurant",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeRestaurant)},
 			},
 			{
-				Name:             "cafe",
+				Id:               "cafe",
 				DisplayNameJa:    "カフェ",
 				DisplayNameEn:    "Cafe",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeCafe)},
 			},
 			{
-				Name:             "bakery",
+				Id:               "bakery",
 				DisplayNameJa:    "パン屋",
 				DisplayNameEn:    "Bakery",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeBakery)},
@@ -146,19 +146,19 @@ var (
 		},
 	}
 
-	CreatePlanCategorySetAttractions = LocationCategorySetCreatePlan{
+	LocationCategorySetCreatePlanAttractions = LocationCategorySetCreatePlan{
 		Name:          "attractions",
 		DisplayNameJa: "観光",
 		DisplayNameEn: "Attractions",
 		Categories: []LocationCategoryCreatePlan{
 			{
-				Name:             "観光スポット",
+				Id:               "観光スポット",
 				DisplayNameJa:    "観光スポット",
 				DisplayNameEn:    "Sightseeing",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeTouristAttraction)},
 			},
 			{
-				Name:             "寺・神社",
+				Id:               "寺・神社",
 				DisplayNameJa:    "寺・神社",
 				DisplayNameEn:    "Temples & Shrines",
 				GooglePlaceTypes: []string{"place_of_worship"},
@@ -166,3 +166,14 @@ var (
 		},
 	}
 )
+
+func GetAllLocationCategorySetCreatePlan() []LocationCategorySetCreatePlan {
+	return []LocationCategorySetCreatePlan{
+		LocationCategorySetCreatePlanAmusements,
+		LocationCategorySetCreatePlanCulture,
+		LocationCategorySetCreatePlanRelaxation,
+		LocationCategorySetCreatePlanShopping,
+		LocationCategorySetCreatePlanEat,
+		LocationCategorySetCreatePlanAttractions,
+	}
+}

--- a/internal/domain/models/category_create_plan.go
+++ b/internal/domain/models/category_create_plan.go
@@ -11,11 +11,12 @@ type LocationCategorySetCreatePlan struct {
 }
 
 type LocationCategoryCreatePlan struct {
-	Name             string
-	DisplayNameJa    string
-	DisplayNameEn    string
-	GooglePlaceTypes []string
-	Image            string
+	Name                string
+	DisplayNameJa       string
+	DisplayNameEn       string
+	GooglePlaceTypes    []string
+	SearchRadiusMinInKm int // 検索半径（最小）
+	Image               string
 }
 
 var (
@@ -64,10 +65,11 @@ var (
 				GooglePlaceTypes: []string{string(maps.PlaceTypeMuseum)},
 			},
 			{
-				Name:             "aquarium",
-				DisplayNameJa:    "水族館",
-				DisplayNameEn:    "Aquarium",
-				GooglePlaceTypes: []string{string(maps.PlaceTypeAquarium)},
+				Name:                "aquarium",
+				DisplayNameJa:       "水族館",
+				DisplayNameEn:       "Aquarium",
+				GooglePlaceTypes:    []string{string(maps.PlaceTypeAquarium)},
+				SearchRadiusMinInKm: 30,
 			},
 			{
 				Name:             "zoo",

--- a/internal/domain/models/category_create_plan.go
+++ b/internal/domain/models/category_create_plan.go
@@ -25,8 +25,7 @@ type LocationCategoryCreatePlan struct {
 }
 
 func getCloudStorageImageUrl(filename string) string {
-	// 変数の中で環境変数を利用するため必要
-	env.LoadEnv()
+	env.LoadEnv(env.WithSkipErrors())
 	return fmt.Sprintf("https://storage.googleapis.com/%s/public/images/create_plan_categories/%s", os.Getenv("CLOUD_STORAGE_IMAGE_BUCKET"), filename)
 }
 
@@ -59,6 +58,28 @@ var (
 			},
 		},
 		GooglePlaceTypes: CategoryAmusements.SubCategories,
+	}
+
+	LocationCategorySetCreatePlanAttractions = LocationCategorySetCreatePlan{
+		Name:          "attractions",
+		DisplayNameJa: "観光",
+		DisplayNameEn: "Attractions",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Id:               "観光スポット",
+				DisplayNameJa:    "観光スポット",
+				DisplayNameEn:    "Sightseeing",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeTouristAttraction)},
+				Image:            getCloudStorageImageUrl("tourist_attraction.jpg"),
+			},
+			{
+				Id:               "寺・神社",
+				DisplayNameJa:    "寺・神社",
+				DisplayNameEn:    "Temples & Shrines",
+				GooglePlaceTypes: []string{"place_of_worship"},
+				Image:            getCloudStorageImageUrl("temple.jpg"),
+			},
+		},
 	}
 
 	LocationCategorySetCreatePlanCulture = LocationCategorySetCreatePlan{
@@ -94,6 +115,35 @@ var (
 				DisplayNameEn:    "Zoo",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeZoo)},
 				Image:            getCloudStorageImageUrl("zoo.jpg"),
+			},
+		},
+	}
+
+	LocationCategorySetCreatePlanEat = LocationCategorySetCreatePlan{
+		Name:          "eat",
+		DisplayNameJa: "食事",
+		DisplayNameEn: "Eat",
+		Categories: []LocationCategoryCreatePlan{
+			{
+				Id:               "restaurant",
+				DisplayNameJa:    "レストラン",
+				DisplayNameEn:    "Restaurant",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeRestaurant)},
+				Image:            getCloudStorageImageUrl("restaurant.jpg"),
+			},
+			{
+				Id:               "cafe",
+				DisplayNameJa:    "カフェ",
+				DisplayNameEn:    "Cafe",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeCafe)},
+				Image:            getCloudStorageImageUrl("cafe.jpg"),
+			},
+			{
+				Id:               "bakery",
+				DisplayNameJa:    "パン屋",
+				DisplayNameEn:    "Bakery",
+				GooglePlaceTypes: []string{string(maps.PlaceTypeBakery)},
+				Image:            getCloudStorageImageUrl("bakery.jpg"),
 			},
 		},
 	}
@@ -138,57 +188,6 @@ var (
 				DisplayNameEn:    "Bookstore",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeBookStore)},
 				Image:            getCloudStorageImageUrl("bookstore.jpg"),
-			},
-		},
-	}
-
-	LocationCategorySetCreatePlanEat = LocationCategorySetCreatePlan{
-		Name:          "eat",
-		DisplayNameJa: "食事",
-		DisplayNameEn: "Eat",
-		Categories: []LocationCategoryCreatePlan{
-			{
-				Id:               "restaurant",
-				DisplayNameJa:    "レストラン",
-				DisplayNameEn:    "Restaurant",
-				GooglePlaceTypes: []string{string(maps.PlaceTypeRestaurant)},
-				Image:            getCloudStorageImageUrl("restaurant.jpg"),
-			},
-			{
-				Id:               "cafe",
-				DisplayNameJa:    "カフェ",
-				DisplayNameEn:    "Cafe",
-				GooglePlaceTypes: []string{string(maps.PlaceTypeCafe)},
-				Image:            getCloudStorageImageUrl("cafe.jpg"),
-			},
-			{
-				Id:               "bakery",
-				DisplayNameJa:    "パン屋",
-				DisplayNameEn:    "Bakery",
-				GooglePlaceTypes: []string{string(maps.PlaceTypeBakery)},
-				Image:            getCloudStorageImageUrl("bakery.jpg"),
-			},
-		},
-	}
-
-	LocationCategorySetCreatePlanAttractions = LocationCategorySetCreatePlan{
-		Name:          "attractions",
-		DisplayNameJa: "観光",
-		DisplayNameEn: "Attractions",
-		Categories: []LocationCategoryCreatePlan{
-			{
-				Id:               "観光スポット",
-				DisplayNameJa:    "観光スポット",
-				DisplayNameEn:    "Sightseeing",
-				GooglePlaceTypes: []string{string(maps.PlaceTypeTouristAttraction)},
-				Image:            getCloudStorageImageUrl("tourist_attraction.jpg"),
-			},
-			{
-				Id:               "寺・神社",
-				DisplayNameJa:    "寺・神社",
-				DisplayNameEn:    "Temples & Shrines",
-				GooglePlaceTypes: []string{"place_of_worship"},
-				Image:            getCloudStorageImageUrl("temple.jpg"),
 			},
 		},
 	}

--- a/internal/domain/models/category_create_plan.go
+++ b/internal/domain/models/category_create_plan.go
@@ -1,6 +1,11 @@
 package models
 
-import "googlemaps.github.io/maps"
+import (
+	"fmt"
+	"googlemaps.github.io/maps"
+	"os"
+	"poroto.app/poroto/planner/internal/env"
+)
 
 type LocationCategorySetCreatePlan struct {
 	Name             string
@@ -19,6 +24,12 @@ type LocationCategoryCreatePlan struct {
 	Image               string
 }
 
+func getCloudStorageImageUrl(filename string) string {
+	// 変数の中で環境変数を利用するため必要
+	env.LoadEnv()
+	return fmt.Sprintf("https://storage.googleapis.com/%s/public/images/create_plan_categories/%s", os.Getenv("CLOUD_STORAGE_IMAGE_BUCKET"), filename)
+}
+
 var (
 	LocationCategorySetCreatePlanAmusements = LocationCategorySetCreatePlan{
 		Name:          "amusements",
@@ -30,18 +41,21 @@ var (
 				DisplayNameJa:    "遊園地",
 				DisplayNameEn:    "Amusement Park",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeAmusementPark)},
+				Image:            getCloudStorageImageUrl("amusement_park.jpg"),
 			},
 			{
 				Id:               "bowling_alley",
 				DisplayNameJa:    "ボウリング場",
 				DisplayNameEn:    "Bowling Alley",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeBowlingAlley)},
+				Image:            getCloudStorageImageUrl("bowling.jpg"),
 			},
 			{
 				Id:               "movie_theater",
 				DisplayNameJa:    "映画館",
 				DisplayNameEn:    "Movie Theater",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeMovieTheater)},
+				Image:            getCloudStorageImageUrl("movie.jpg"),
 			},
 		},
 		GooglePlaceTypes: CategoryAmusements.SubCategories,
@@ -57,12 +71,14 @@ var (
 				DisplayNameJa:    "美術館",
 				DisplayNameEn:    "Art Gallery",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeArtGallery)},
+				Image:            getCloudStorageImageUrl("art_gallery.jpg"),
 			},
 			{
 				Id:               "museum",
 				DisplayNameJa:    "博物館",
 				DisplayNameEn:    "Museum",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeMuseum)},
+				Image:            getCloudStorageImageUrl("museum.jpg"),
 			},
 			{
 				Id:                  "aquarium",
@@ -70,12 +86,14 @@ var (
 				DisplayNameEn:       "Aquarium",
 				GooglePlaceTypes:    []string{string(maps.PlaceTypeAquarium)},
 				SearchRadiusMinInKm: 30,
+				Image:               getCloudStorageImageUrl("aquarium.jpg"),
 			},
 			{
 				Id:               "zoo",
 				DisplayNameJa:    "動物園",
 				DisplayNameEn:    "Zoo",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeZoo)},
+				Image:            getCloudStorageImageUrl("zoo.jpg"),
 			},
 		},
 	}
@@ -90,12 +108,14 @@ var (
 				DisplayNameJa:    "温泉",
 				DisplayNameEn:    "Spa",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeSpa)},
+				Image:            getCloudStorageImageUrl("spa.jpg"),
 			},
 			{
 				Id:               "park",
 				DisplayNameJa:    "公園",
 				DisplayNameEn:    "Park",
 				GooglePlaceTypes: []string{string(maps.PlaceTypePark)},
+				Image:            getCloudStorageImageUrl("park.jpg"),
 			},
 		},
 	}
@@ -110,12 +130,14 @@ var (
 				DisplayNameJa:    "ショッピングモール",
 				DisplayNameEn:    "Shopping Mall",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeShoppingMall)},
+				Image:            getCloudStorageImageUrl("shopping_mall.jpg"),
 			},
 			{
 				Id:               "本屋",
 				DisplayNameJa:    "本屋",
 				DisplayNameEn:    "Bookstore",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeBookStore)},
+				Image:            getCloudStorageImageUrl("bookstore.jpg"),
 			},
 		},
 	}
@@ -130,18 +152,21 @@ var (
 				DisplayNameJa:    "レストラン",
 				DisplayNameEn:    "Restaurant",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeRestaurant)},
+				Image:            getCloudStorageImageUrl("restaurant.jpg"),
 			},
 			{
 				Id:               "cafe",
 				DisplayNameJa:    "カフェ",
 				DisplayNameEn:    "Cafe",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeCafe)},
+				Image:            getCloudStorageImageUrl("cafe.jpg"),
 			},
 			{
 				Id:               "bakery",
 				DisplayNameJa:    "パン屋",
 				DisplayNameEn:    "Bakery",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeBakery)},
+				Image:            getCloudStorageImageUrl("bakery.jpg"),
 			},
 		},
 	}
@@ -156,12 +181,14 @@ var (
 				DisplayNameJa:    "観光スポット",
 				DisplayNameEn:    "Sightseeing",
 				GooglePlaceTypes: []string{string(maps.PlaceTypeTouristAttraction)},
+				Image:            getCloudStorageImageUrl("tourist_attraction.jpg"),
 			},
 			{
 				Id:               "寺・神社",
 				DisplayNameJa:    "寺・神社",
 				DisplayNameEn:    "Temples & Shrines",
 				GooglePlaceTypes: []string{"place_of_worship"},
+				Image:            getCloudStorageImageUrl("temple.jpg"),
 			},
 		},
 	}
@@ -169,11 +196,11 @@ var (
 
 func GetAllLocationCategorySetCreatePlan() []LocationCategorySetCreatePlan {
 	return []LocationCategorySetCreatePlan{
+		LocationCategorySetCreatePlanEat,
+		LocationCategorySetCreatePlanRelaxation,
+		LocationCategorySetCreatePlanAttractions,
+		LocationCategorySetCreatePlanShopping,
 		LocationCategorySetCreatePlanAmusements,
 		LocationCategorySetCreatePlanCulture,
-		LocationCategorySetCreatePlanRelaxation,
-		LocationCategorySetCreatePlanShopping,
-		LocationCategorySetCreatePlanEat,
-		LocationCategorySetCreatePlanAttractions,
 	}
 }

--- a/internal/domain/services/plangen/create_by_category.go
+++ b/internal/domain/services/plangen/create_by_category.go
@@ -34,6 +34,11 @@ func (s Service) CreatePlanByCategory(ctx context.Context, input CreatePlanByCat
 		return nil, fmt.Errorf("error while fetching google Places: %v\n", err)
 	}
 
+	// 検索が大量に行われないようにするため、対象とする場所の数を20件に制限する
+	if len(*placesOfCategory) > 20 {
+		*placesOfCategory = (*placesOfCategory)[:20]
+	}
+
 	var createPlanParams []CreatePlanParams
 	for _, placeOfCategory := range *placesOfCategory {
 		if len(createPlanParams) >= 3 {

--- a/internal/domain/services/plangen/create_by_category.go
+++ b/internal/domain/services/plangen/create_by_category.go
@@ -1,0 +1,73 @@
+package plangen
+
+import (
+	"context"
+	"fmt"
+	"poroto.app/poroto/planner/internal/domain/array"
+	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/domain/services/placesearch"
+)
+
+type CreatePlanByCategoryInput struct {
+	PlanCandidateSetId string
+	Category           models.LocationCategoryCreatePlan
+	Location           models.GeoLocation
+	RadiusInKm         int
+}
+
+func (s Service) CreatePlanByCategory(ctx context.Context, input CreatePlanByCategoryInput) (*[]models.Plan, error) {
+	searchRadiusInKm := input.RadiusInKm
+	if searchRadiusInKm < input.Category.SearchRadiusMinInKm {
+		searchRadiusInKm = input.Category.SearchRadiusMinInKm
+	} else if searchRadiusInKm < 5 {
+		// 検索範囲が狭い場合は広めに検索する
+		searchRadiusInKm += 5
+	}
+
+	placesOfCategory, err := s.placeRepository.FindByGooglePlaceType(
+		ctx,
+		input.Category.GooglePlaceTypes[0],
+		input.Location,
+		float64(searchRadiusInKm)*1000,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while fetching google Places: %v\n", err)
+	}
+
+	var createPlanParams []CreatePlanParams
+	for _, placeOfCategory := range *placesOfCategory {
+		if len(createPlanParams) >= 3 {
+			break
+		}
+
+		placesNearby, err := s.placeSearchService.SearchNearbyPlaces(ctx, placesearch.SearchNearbyPlacesInput{
+			Location: placeOfCategory.Location,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error while fetching nearby places: %v\n", err)
+		}
+
+		planPlaces, err := s.CreatePlanPlaces(CreatePlanPlacesInput{
+			PlanCandidateSetId: input.PlanCandidateSetId,
+			LocationStart:      placeOfCategory.Location,
+			PlaceStart:         placeOfCategory,
+			Places:             placesNearby,
+			PlacesOtherPlansContain: array.FlatMap(createPlanParams, func(p CreatePlanParams) []models.Place {
+				return p.Places
+			}),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error while creating plan places: %v\n", err)
+		}
+
+		createPlanParams = append(createPlanParams, CreatePlanParams{
+			LocationStart: placeOfCategory.Location,
+			PlaceStart:    placeOfCategory,
+			Places:        planPlaces,
+		})
+	}
+
+	plans := s.createPlanData(ctx, input.PlanCandidateSetId, createPlanParams...)
+
+	return &plans, nil
+}

--- a/internal/domain/services/plangen/create_by_category.go
+++ b/internal/domain/services/plangen/create_by_category.go
@@ -12,7 +12,7 @@ type CreatePlanByCategoryInput struct {
 	PlanCandidateSetId string
 	Category           models.LocationCategoryCreatePlan
 	Location           models.GeoLocation
-	RadiusInKm         int
+	RadiusInKm         float64
 }
 
 func (s Service) CreatePlanByCategory(ctx context.Context, input CreatePlanByCategoryInput) (*[]models.Plan, error) {
@@ -28,7 +28,7 @@ func (s Service) CreatePlanByCategory(ctx context.Context, input CreatePlanByCat
 		ctx,
 		input.Category.GooglePlaceTypes[0],
 		input.Location,
-		float64(searchRadiusInKm)*1000,
+		searchRadiusInKm*1000,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching google Places: %v\n", err)

--- a/internal/infrastructure/rdb/place.go
+++ b/internal/infrastructure/rdb/place.go
@@ -305,6 +305,8 @@ func (p PlaceRepository) FindByGooglePlaceType(ctx context.Context, googlePlaceT
 		generated.GooglePlaceWhere.Latitude.LT(maxLocation.Latitude),
 		generated.GooglePlaceWhere.Longitude.GT(minLocation.Longitude),
 		generated.GooglePlaceWhere.Longitude.LT(maxLocation.Longitude),
+		qm.OrderBy(generated.GooglePlaceColumns.UserRatingsTotal+" desc"),
+		qm.Limit(100),
 		qm.Load(generated.GooglePlaceRels.Place),
 		qm.Load(generated.GooglePlaceRels.Place+"."+generated.PlaceRels.PlacePhotos),
 		qm.Load(generated.GooglePlaceRels.GooglePlaceTypes),

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1893,7 +1893,6 @@ type CreatePlanByPlaceOutput {
 }
 
 input CreatePlanByCategoryInput {
-    session: String!
     categoryId: String!
     latitude: Float!
     longitude: Float!
@@ -12909,22 +12908,13 @@ func (ec *executionContext) unmarshalInputCreatePlanByCategoryInput(ctx context.
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"session", "categoryId", "latitude", "longitude", "radiusInKm"}
+	fieldsInOrder := [...]string{"categoryId", "latitude", "longitude", "radiusInKm"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "session":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Session = data
 		case "categoryId":
 			var err error
 

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -96,6 +96,13 @@ type ComplexityRoot struct {
 		PlanCandidate func(childComplexity int) int
 	}
 
+	CreatePlanPlaceCategory struct {
+		DisplayNameEn func(childComplexity int) int
+		DisplayNameJa func(childComplexity int) int
+		ID            func(childComplexity int) int
+		ImageURL      func(childComplexity int) int
+	}
+
 	DeletePlaceFromPlanCandidateOutput struct {
 		Plan            func(childComplexity int) int
 		PlanCandidateID func(childComplexity int) int
@@ -279,6 +286,7 @@ type ComplexityRoot struct {
 		FirebaseUser                    func(childComplexity int, input *model.FirebaseUserInput) int
 		LikePlaces                      func(childComplexity int, input *model.LikePlacesInput) int
 		NearbyPlaceCategories           func(childComplexity int, input model.NearbyPlaceCategoriesInput) int
+		PlaceCategories                 func(childComplexity int) int
 		PlacesNearPlan                  func(childComplexity int, input model.PlacesNearPlanInput) int
 		PlacesRecommendation            func(childComplexity int) int
 		PlacesToAddForPlanCandidate     func(childComplexity int, input model.PlacesToAddForPlanCandidateInput) int
@@ -358,6 +366,7 @@ type QueryResolver interface {
 	PlanCandidate(ctx context.Context, input model.PlanCandidateInput) (*model.PlanCandidateOutput, error)
 	NearbyPlaceCategories(ctx context.Context, input model.NearbyPlaceCategoriesInput) (*model.NearbyPlaceCategoryOutput, error)
 	AvailablePlacesForPlan(ctx context.Context, input model.AvailablePlacesForPlanInput) (*model.AvailablePlacesForPlan, error)
+	PlaceCategories(ctx context.Context) ([]*model.CreatePlanPlaceCategory, error)
 	PlacesToAddForPlanCandidate(ctx context.Context, input model.PlacesToAddForPlanCandidateInput) (*model.PlacesToAddForPlanCandidateOutput, error)
 	PlacesToReplaceForPlanCandidate(ctx context.Context, input model.PlacesToReplaceForPlanCandidateInput) (*model.PlacesToReplaceForPlanCandidateOutput, error)
 	Plan(ctx context.Context, input model.PlanInput) (*model.PlanOutput, error)
@@ -505,6 +514,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CreatePlanCandidateSetFromSavedPlanOutput.PlanCandidate(childComplexity), true
+
+	case "CreatePlanPlaceCategory.displayNameEn":
+		if e.complexity.CreatePlanPlaceCategory.DisplayNameEn == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanPlaceCategory.DisplayNameEn(childComplexity), true
+
+	case "CreatePlanPlaceCategory.displayNameJa":
+		if e.complexity.CreatePlanPlaceCategory.DisplayNameJa == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanPlaceCategory.DisplayNameJa(childComplexity), true
+
+	case "CreatePlanPlaceCategory.id":
+		if e.complexity.CreatePlanPlaceCategory.ID == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanPlaceCategory.ID(childComplexity), true
+
+	case "CreatePlanPlaceCategory.imageUrl":
+		if e.complexity.CreatePlanPlaceCategory.ImageURL == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanPlaceCategory.ImageURL(childComplexity), true
 
 	case "DeletePlaceFromPlanCandidateOutput.plan":
 		if e.complexity.DeletePlaceFromPlanCandidateOutput.Plan == nil {
@@ -1323,6 +1360,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.NearbyPlaceCategories(childComplexity, args["input"].(model.NearbyPlaceCategoriesInput)), true
 
+	case "Query.placeCategories":
+		if e.complexity.Query.PlaceCategories == nil {
+			break
+		}
+
+		return e.complexity.Query.PlaceCategories(childComplexity), true
+
 	case "Query.placesNearPlan":
 		if e.complexity.Query.PlacesNearPlan == nil {
 			break
@@ -1741,6 +1785,13 @@ type PlaceCategory {
     name: String!
 }
 
+type CreatePlanPlaceCategory {
+    id: String!
+    displayNameJa: String!
+    displayNameEn: String!
+    imageUrl: String!
+}
+
 type CategoryGroupedPlaces {
     category: PlaceCategory!
     places: [Place!]!
@@ -1939,6 +1990,8 @@ type LikeToPlaceInPlanCandidateOutput {
 
     # プランを作成可能な他の場所を取得する
     availablePlacesForPlan(input: AvailablePlacesForPlanInput!): AvailablePlacesForPlan!
+
+    placeCategories: [CreatePlanPlaceCategory!]!
 
     # ===========================================================
     # Edit
@@ -3684,6 +3737,182 @@ func (ec *executionContext) fieldContext_CreatePlanCandidateSetFromSavedPlanOutp
 				return ec.fieldContext_PlanCandidate_createdBasedOnCurrentLocation(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PlanCandidate", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanPlaceCategory_id(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanPlaceCategory) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanPlaceCategory_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanPlaceCategory_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanPlaceCategory",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanPlaceCategory_displayNameJa(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanPlaceCategory) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanPlaceCategory_displayNameJa(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayNameJa, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanPlaceCategory_displayNameJa(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanPlaceCategory",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanPlaceCategory_displayNameEn(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanPlaceCategory) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanPlaceCategory_displayNameEn(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayNameEn, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanPlaceCategory_displayNameEn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanPlaceCategory",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanPlaceCategory_imageUrl(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanPlaceCategory) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanPlaceCategory_imageUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ImageURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanPlaceCategory_imageUrl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanPlaceCategory",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -9005,6 +9234,60 @@ func (ec *executionContext) fieldContext_Query_availablePlacesForPlan(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_placeCategories(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_placeCategories(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().PlaceCategories(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CreatePlanPlaceCategory)
+	fc.Result = res
+	return ec.marshalNCreatePlanPlaceCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategoryᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_placeCategories(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_CreatePlanPlaceCategory_id(ctx, field)
+			case "displayNameJa":
+				return ec.fieldContext_CreatePlanPlaceCategory_displayNameJa(ctx, field)
+			case "displayNameEn":
+				return ec.fieldContext_CreatePlanPlaceCategory_displayNameEn(ctx, field)
+			case "imageUrl":
+				return ec.fieldContext_CreatePlanPlaceCategory_imageUrl(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreatePlanPlaceCategory", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_placesToAddForPlanCandidate(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_placesToAddForPlanCandidate(ctx, field)
 	if err != nil {
@@ -14151,6 +14434,60 @@ func (ec *executionContext) _CreatePlanCandidateSetFromSavedPlanOutput(ctx conte
 	return out
 }
 
+var createPlanPlaceCategoryImplementors = []string{"CreatePlanPlaceCategory"}
+
+func (ec *executionContext) _CreatePlanPlaceCategory(ctx context.Context, sel ast.SelectionSet, obj *model.CreatePlanPlaceCategory) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createPlanPlaceCategoryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreatePlanPlaceCategory")
+		case "id":
+			out.Values[i] = ec._CreatePlanPlaceCategory_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "displayNameJa":
+			out.Values[i] = ec._CreatePlanPlaceCategory_displayNameJa(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "displayNameEn":
+			out.Values[i] = ec._CreatePlanPlaceCategory_displayNameEn(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "imageUrl":
+			out.Values[i] = ec._CreatePlanPlaceCategory_imageUrl(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var deletePlaceFromPlanCandidateOutputImplementors = []string{"DeletePlaceFromPlanCandidateOutput"}
 
 func (ec *executionContext) _DeletePlaceFromPlanCandidateOutput(ctx context.Context, sel ast.SelectionSet, obj *model.DeletePlaceFromPlanCandidateOutput) graphql.Marshaler {
@@ -15757,6 +16094,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "placeCategories":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_placeCategories(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "placesToAddForPlanCandidate":
 			field := field
 
@@ -16887,6 +17246,60 @@ func (ec *executionContext) marshalNCreatePlanCandidateSetFromSavedPlanOutput2�
 		return graphql.Null
 	}
 	return ec._CreatePlanCandidateSetFromSavedPlanOutput(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCreatePlanPlaceCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategoryᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CreatePlanPlaceCategory) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNCreatePlanPlaceCategory2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategory(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNCreatePlanPlaceCategory2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategory(ctx context.Context, sel ast.SelectionSet, v *model.CreatePlanPlaceCategory) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreatePlanPlaceCategory(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeletePlaceFromPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐDeletePlaceFromPlanCandidateInput(ctx context.Context, v interface{}) (model.DeletePlaceFromPlanCandidateInput, error) {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1895,9 +1895,9 @@ type CreatePlanByPlaceOutput {
 input CreatePlanByCategoryInput {
     session: String!
     categoryId: String!
-    latitude: Float
-    longitude: Float
-    radiusInKm: Float
+    latitude: Float!
+    longitude: Float!
+    radiusInKm: Float!
 }
 
 type CreatePlanByCategoryOutput {
@@ -12938,7 +12938,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByCategoryInput(ctx context.
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("latitude"))
-			data, err := ec.unmarshalOFloat2ᚖfloat64(ctx, v)
+			data, err := ec.unmarshalNFloat2float64(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12947,7 +12947,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByCategoryInput(ctx context.
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("longitude"))
-			data, err := ec.unmarshalOFloat2ᚖfloat64(ctx, v)
+			data, err := ec.unmarshalNFloat2float64(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12956,7 +12956,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByCategoryInput(ctx context.
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("radiusInKm"))
-			data, err := ec.unmarshalOFloat2ᚖfloat64(ctx, v)
+			data, err := ec.unmarshalNFloat2float64(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -1894,7 +1894,7 @@ type CreatePlanByPlaceOutput {
 
 input CreatePlanByCategoryInput {
     session: String!
-    category: String!
+    categoryId: String!
     latitude: Float
     longitude: Float
     radiusInKm: Float
@@ -12909,7 +12909,7 @@ func (ec *executionContext) unmarshalInputCreatePlanByCategoryInput(ctx context.
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"session", "category", "latitude", "longitude", "radiusInKm"}
+	fieldsInOrder := [...]string{"session", "categoryId", "latitude", "longitude", "radiusInKm"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -12925,15 +12925,15 @@ func (ec *executionContext) unmarshalInputCreatePlanByCategoryInput(ctx context.
 				return it, err
 			}
 			it.Session = data
-		case "category":
+		case "categoryId":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoryId"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Category = data
+			it.CategoryID = data
 		case "latitude":
 			var err error
 

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -73,6 +73,11 @@ type ComplexityRoot struct {
 		Plan func(childComplexity int) int
 	}
 
+	CreatePlanByCategoryOutput struct {
+		PlanCandidateSetID func(childComplexity int) int
+		Plans              func(childComplexity int) int
+	}
+
 	CreatePlanByGooglePlaceIdOutput struct {
 		PlanCandidate func(childComplexity int) int
 	}
@@ -147,6 +152,7 @@ type ComplexityRoot struct {
 		AutoReorderPlacesInPlanCandidate    func(childComplexity int, input model.AutoReorderPlacesInPlanCandidateInput) int
 		BindPlanCandidateSetToUser          func(childComplexity int, input model.BindPlanCandidateSetToUserInput) int
 		ChangePlacesOrderInPlanCandidate    func(childComplexity int, input model.ChangePlacesOrderInPlanCandidateInput) int
+		CreatePlanByCategory                func(childComplexity int, input model.CreatePlanByCategoryInput) int
 		CreatePlanByLocation                func(childComplexity int, input model.CreatePlanByLocationInput) int
 		CreatePlanByPlace                   func(childComplexity int, input model.CreatePlanByPlaceInput) int
 		CreatePlanCandidateSetFromSavedPlan func(childComplexity int, input model.CreatePlanCandidateSetFromSavedPlanInput) int
@@ -325,6 +331,7 @@ type MutationResolver interface {
 	Ping(ctx context.Context, message string) (string, error)
 	CreatePlanByLocation(ctx context.Context, input model.CreatePlanByLocationInput) (*model.CreatePlanByLocationOutput, error)
 	CreatePlanByPlace(ctx context.Context, input model.CreatePlanByPlaceInput) (*model.CreatePlanByPlaceOutput, error)
+	CreatePlanByCategory(ctx context.Context, input model.CreatePlanByCategoryInput) (*model.CreatePlanByCategoryOutput, error)
 	CreatePlanCandidateSetFromSavedPlan(ctx context.Context, input model.CreatePlanCandidateSetFromSavedPlanInput) (*model.CreatePlanCandidateSetFromSavedPlanOutput, error)
 	ChangePlacesOrderInPlanCandidate(ctx context.Context, input model.ChangePlacesOrderInPlanCandidateInput) (*model.ChangePlacesOrderInPlanCandidateOutput, error)
 	SavePlanFromCandidate(ctx context.Context, input model.SavePlanFromCandidateInput) (*model.SavePlanFromCandidateOutput, error)
@@ -442,6 +449,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ChangePlacesOrderInPlanCandidateOutput.Plan(childComplexity), true
+
+	case "CreatePlanByCategoryOutput.planCandidateSetId":
+		if e.complexity.CreatePlanByCategoryOutput.PlanCandidateSetID == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanByCategoryOutput.PlanCandidateSetID(childComplexity), true
+
+	case "CreatePlanByCategoryOutput.plans":
+		if e.complexity.CreatePlanByCategoryOutput.Plans == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanByCategoryOutput.Plans(childComplexity), true
 
 	case "CreatePlanByGooglePlaceIdOutput.planCandidate":
 		if e.complexity.CreatePlanByGooglePlaceIdOutput.PlanCandidate == nil {
@@ -721,6 +742,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.ChangePlacesOrderInPlanCandidate(childComplexity, args["input"].(model.ChangePlacesOrderInPlanCandidateInput)), true
+
+	case "Mutation.createPlanByCategory":
+		if e.complexity.Mutation.CreatePlanByCategory == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createPlanByCategory_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreatePlanByCategory(childComplexity, args["input"].(model.CreatePlanByCategoryInput)), true
 
 	case "Mutation.createPlanByLocation":
 		if e.complexity.Mutation.CreatePlanByLocation == nil {
@@ -1511,6 +1544,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAvailablePlacesForPlanInput,
 		ec.unmarshalInputBindPlanCandidateSetToUserInput,
 		ec.unmarshalInputChangePlacesOrderInPlanCandidateInput,
+		ec.unmarshalInputCreatePlanByCategoryInput,
 		ec.unmarshalInputCreatePlanByGooglePlaceIdInput,
 		ec.unmarshalInputCreatePlanByLocationInput,
 		ec.unmarshalInputCreatePlanByPlaceInput,
@@ -1719,6 +1753,8 @@ type CategoryGroupedPlaces {
 
     createPlanByPlace(input: CreatePlanByPlaceInput!): CreatePlanByPlaceOutput!
 
+    createPlanByCategory(input: CreatePlanByCategoryInput!): CreatePlanByCategoryOutput!
+
     # 保存されたプランをベースに新しいプランを作成する
     createPlanCandidateSetFromSavedPlan(input: CreatePlanCandidateSetFromSavedPlanInput!): CreatePlanCandidateSetFromSavedPlanOutput!
 
@@ -1770,6 +1806,19 @@ input CreatePlanByPlaceInput {
 type CreatePlanByPlaceOutput {
     session: String!
     plan: Plan!
+}
+
+input CreatePlanByCategoryInput {
+    session: String!
+    category: String!
+    latitude: Float
+    longitude: Float
+    radiusInKm: Float
+}
+
+type CreatePlanByCategoryOutput {
+    planCandidateSetId: String!
+    plans: [Plan!]!
 }
 
 input CreatePlanByGooglePlaceIdInput {
@@ -2208,6 +2257,21 @@ func (ec *executionContext) field_Mutation_changePlacesOrderInPlanCandidate_args
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNChangePlacesOrderInPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐChangePlacesOrderInPlanCandidateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_createPlanByCategory_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.CreatePlanByCategoryInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNCreatePlanByCategoryInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByCategoryInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -3163,6 +3227,114 @@ func (ec *executionContext) _ChangePlacesOrderInPlanCandidateOutput_plan(ctx con
 func (ec *executionContext) fieldContext_ChangePlacesOrderInPlanCandidateOutput_plan(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ChangePlacesOrderInPlanCandidateOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Plan_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Plan_name(ctx, field)
+			case "places":
+				return ec.fieldContext_Plan_places(ctx, field)
+			case "timeInMinutes":
+				return ec.fieldContext_Plan_timeInMinutes(ctx, field)
+			case "description":
+				return ec.fieldContext_Plan_description(ctx, field)
+			case "transitions":
+				return ec.fieldContext_Plan_transitions(ctx, field)
+			case "author":
+				return ec.fieldContext_Plan_author(ctx, field)
+			case "collage":
+				return ec.fieldContext_Plan_collage(ctx, field)
+			case "nearbyPlans":
+				return ec.fieldContext_Plan_nearbyPlans(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Plan", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanByCategoryOutput_planCandidateSetId(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanByCategoryOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanByCategoryOutput_planCandidateSetId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PlanCandidateSetID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanByCategoryOutput_planCandidateSetId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanByCategoryOutput",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanByCategoryOutput_plans(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanByCategoryOutput) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanByCategoryOutput_plans(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Plans, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Plan)
+	fc.Result = res
+	return ec.marshalNPlan2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐPlanᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanByCategoryOutput_plans(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanByCategoryOutput",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -4931,6 +5103,67 @@ func (ec *executionContext) fieldContext_Mutation_createPlanByPlace(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createPlanByPlace_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createPlanByCategory(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createPlanByCategory(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreatePlanByCategory(rctx, fc.Args["input"].(model.CreatePlanByCategoryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.CreatePlanByCategoryOutput)
+	fc.Result = res
+	return ec.marshalNCreatePlanByCategoryOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByCategoryOutput(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createPlanByCategory(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "planCandidateSetId":
+				return ec.fieldContext_CreatePlanByCategoryOutput_planCandidateSetId(ctx, field)
+			case "plans":
+				return ec.fieldContext_CreatePlanByCategoryOutput_plans(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreatePlanByCategoryOutput", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createPlanByCategory_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -12213,6 +12446,71 @@ func (ec *executionContext) unmarshalInputChangePlacesOrderInPlanCandidateInput(
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreatePlanByCategoryInput(ctx context.Context, obj interface{}) (model.CreatePlanByCategoryInput, error) {
+	var it model.CreatePlanByCategoryInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"session", "category", "latitude", "longitude", "radiusInKm"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "session":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Session = data
+		case "category":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Category = data
+		case "latitude":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("latitude"))
+			data, err := ec.unmarshalOFloat2ᚖfloat64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Latitude = data
+		case "longitude":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("longitude"))
+			data, err := ec.unmarshalOFloat2ᚖfloat64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Longitude = data
+		case "radiusInKm":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("radiusInKm"))
+			data, err := ec.unmarshalOFloat2ᚖfloat64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RadiusInKm = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreatePlanByGooglePlaceIdInput(ctx context.Context, obj interface{}) (model.CreatePlanByGooglePlaceIDInput, error) {
 	var it model.CreatePlanByGooglePlaceIDInput
 	asMap := map[string]interface{}{}
@@ -13643,6 +13941,50 @@ func (ec *executionContext) _ChangePlacesOrderInPlanCandidateOutput(ctx context.
 	return out
 }
 
+var createPlanByCategoryOutputImplementors = []string{"CreatePlanByCategoryOutput"}
+
+func (ec *executionContext) _CreatePlanByCategoryOutput(ctx context.Context, sel ast.SelectionSet, obj *model.CreatePlanByCategoryOutput) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createPlanByCategoryOutputImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreatePlanByCategoryOutput")
+		case "planCandidateSetId":
+			out.Values[i] = ec._CreatePlanByCategoryOutput_planCandidateSetId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "plans":
+			out.Values[i] = ec._CreatePlanByCategoryOutput_plans(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createPlanByGooglePlaceIdOutputImplementors = []string{"CreatePlanByGooglePlaceIdOutput"}
 
 func (ec *executionContext) _CreatePlanByGooglePlaceIdOutput(ctx context.Context, sel ast.SelectionSet, obj *model.CreatePlanByGooglePlaceIDOutput) graphql.Marshaler {
@@ -14225,6 +14567,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "createPlanByPlace":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createPlanByPlace(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createPlanByCategory":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createPlanByCategory(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -16462,6 +16811,25 @@ func (ec *executionContext) marshalNChangePlacesOrderInPlanCandidateOutput2ᚖpo
 		return graphql.Null
 	}
 	return ec._ChangePlacesOrderInPlanCandidateOutput(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNCreatePlanByCategoryInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByCategoryInput(ctx context.Context, v interface{}) (model.CreatePlanByCategoryInput, error) {
+	res, err := ec.unmarshalInputCreatePlanByCategoryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreatePlanByCategoryOutput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByCategoryOutput(ctx context.Context, sel ast.SelectionSet, v model.CreatePlanByCategoryOutput) graphql.Marshaler {
+	return ec._CreatePlanByCategoryOutput(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreatePlanByCategoryOutput2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByCategoryOutput(ctx context.Context, sel ast.SelectionSet, v *model.CreatePlanByCategoryOutput) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreatePlanByCategoryOutput(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCreatePlanByLocationInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanByLocationInput(ctx context.Context, v interface{}) (model.CreatePlanByLocationInput, error) {

--- a/internal/interface/graphql/generated/generated.go
+++ b/internal/interface/graphql/generated/generated.go
@@ -103,6 +103,12 @@ type ComplexityRoot struct {
 		ImageURL      func(childComplexity int) int
 	}
 
+	CreatePlanPlaceCategorySet struct {
+		Categories    func(childComplexity int) int
+		DisplayNameEn func(childComplexity int) int
+		DisplayNameJa func(childComplexity int) int
+	}
+
 	DeletePlaceFromPlanCandidateOutput struct {
 		Plan            func(childComplexity int) int
 		PlanCandidateID func(childComplexity int) int
@@ -366,7 +372,7 @@ type QueryResolver interface {
 	PlanCandidate(ctx context.Context, input model.PlanCandidateInput) (*model.PlanCandidateOutput, error)
 	NearbyPlaceCategories(ctx context.Context, input model.NearbyPlaceCategoriesInput) (*model.NearbyPlaceCategoryOutput, error)
 	AvailablePlacesForPlan(ctx context.Context, input model.AvailablePlacesForPlanInput) (*model.AvailablePlacesForPlan, error)
-	PlaceCategories(ctx context.Context) ([]*model.CreatePlanPlaceCategory, error)
+	PlaceCategories(ctx context.Context) ([]*model.CreatePlanPlaceCategorySet, error)
 	PlacesToAddForPlanCandidate(ctx context.Context, input model.PlacesToAddForPlanCandidateInput) (*model.PlacesToAddForPlanCandidateOutput, error)
 	PlacesToReplaceForPlanCandidate(ctx context.Context, input model.PlacesToReplaceForPlanCandidateInput) (*model.PlacesToReplaceForPlanCandidateOutput, error)
 	Plan(ctx context.Context, input model.PlanInput) (*model.PlanOutput, error)
@@ -542,6 +548,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CreatePlanPlaceCategory.ImageURL(childComplexity), true
+
+	case "CreatePlanPlaceCategorySet.categories":
+		if e.complexity.CreatePlanPlaceCategorySet.Categories == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanPlaceCategorySet.Categories(childComplexity), true
+
+	case "CreatePlanPlaceCategorySet.displayNameEn":
+		if e.complexity.CreatePlanPlaceCategorySet.DisplayNameEn == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanPlaceCategorySet.DisplayNameEn(childComplexity), true
+
+	case "CreatePlanPlaceCategorySet.displayNameJa":
+		if e.complexity.CreatePlanPlaceCategorySet.DisplayNameJa == nil {
+			break
+		}
+
+		return e.complexity.CreatePlanPlaceCategorySet.DisplayNameJa(childComplexity), true
 
 	case "DeletePlaceFromPlanCandidateOutput.plan":
 		if e.complexity.DeletePlaceFromPlanCandidateOutput.Plan == nil {
@@ -1785,6 +1812,12 @@ type PlaceCategory {
     name: String!
 }
 
+type CreatePlanPlaceCategorySet {
+    displayNameJa: String!
+    displayNameEn: String!
+    categories: [CreatePlanPlaceCategory!]!
+}
+
 type CreatePlanPlaceCategory {
     id: String!
     displayNameJa: String!
@@ -1991,7 +2024,7 @@ type LikeToPlaceInPlanCandidateOutput {
     # プランを作成可能な他の場所を取得する
     availablePlacesForPlan(input: AvailablePlacesForPlanInput!): AvailablePlacesForPlan!
 
-    placeCategories: [CreatePlanPlaceCategory!]!
+    placeCategories: [CreatePlanPlaceCategorySet!]!
 
     # ===========================================================
     # Edit
@@ -3913,6 +3946,148 @@ func (ec *executionContext) fieldContext_CreatePlanPlaceCategory_imageUrl(ctx co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanPlaceCategorySet_displayNameJa(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanPlaceCategorySet) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanPlaceCategorySet_displayNameJa(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayNameJa, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanPlaceCategorySet_displayNameJa(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanPlaceCategorySet",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanPlaceCategorySet_displayNameEn(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanPlaceCategorySet) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanPlaceCategorySet_displayNameEn(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayNameEn, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanPlaceCategorySet_displayNameEn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanPlaceCategorySet",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreatePlanPlaceCategorySet_categories(ctx context.Context, field graphql.CollectedField, obj *model.CreatePlanPlaceCategorySet) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreatePlanPlaceCategorySet_categories(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Categories, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CreatePlanPlaceCategory)
+	fc.Result = res
+	return ec.marshalNCreatePlanPlaceCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategoryᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreatePlanPlaceCategorySet_categories(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreatePlanPlaceCategorySet",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_CreatePlanPlaceCategory_id(ctx, field)
+			case "displayNameJa":
+				return ec.fieldContext_CreatePlanPlaceCategory_displayNameJa(ctx, field)
+			case "displayNameEn":
+				return ec.fieldContext_CreatePlanPlaceCategory_displayNameEn(ctx, field)
+			case "imageUrl":
+				return ec.fieldContext_CreatePlanPlaceCategory_imageUrl(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreatePlanPlaceCategory", field.Name)
 		},
 	}
 	return fc, nil
@@ -9260,9 +9435,9 @@ func (ec *executionContext) _Query_placeCategories(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.CreatePlanPlaceCategory)
+	res := resTmp.([]*model.CreatePlanPlaceCategorySet)
 	fc.Result = res
-	return ec.marshalNCreatePlanPlaceCategory2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategoryᚄ(ctx, field.Selections, res)
+	return ec.marshalNCreatePlanPlaceCategorySet2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategorySetᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_placeCategories(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9273,16 +9448,14 @@ func (ec *executionContext) fieldContext_Query_placeCategories(ctx context.Conte
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "id":
-				return ec.fieldContext_CreatePlanPlaceCategory_id(ctx, field)
 			case "displayNameJa":
-				return ec.fieldContext_CreatePlanPlaceCategory_displayNameJa(ctx, field)
+				return ec.fieldContext_CreatePlanPlaceCategorySet_displayNameJa(ctx, field)
 			case "displayNameEn":
-				return ec.fieldContext_CreatePlanPlaceCategory_displayNameEn(ctx, field)
-			case "imageUrl":
-				return ec.fieldContext_CreatePlanPlaceCategory_imageUrl(ctx, field)
+				return ec.fieldContext_CreatePlanPlaceCategorySet_displayNameEn(ctx, field)
+			case "categories":
+				return ec.fieldContext_CreatePlanPlaceCategorySet_categories(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type CreatePlanPlaceCategory", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type CreatePlanPlaceCategorySet", field.Name)
 		},
 	}
 	return fc, nil
@@ -14488,6 +14661,55 @@ func (ec *executionContext) _CreatePlanPlaceCategory(ctx context.Context, sel as
 	return out
 }
 
+var createPlanPlaceCategorySetImplementors = []string{"CreatePlanPlaceCategorySet"}
+
+func (ec *executionContext) _CreatePlanPlaceCategorySet(ctx context.Context, sel ast.SelectionSet, obj *model.CreatePlanPlaceCategorySet) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createPlanPlaceCategorySetImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreatePlanPlaceCategorySet")
+		case "displayNameJa":
+			out.Values[i] = ec._CreatePlanPlaceCategorySet_displayNameJa(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "displayNameEn":
+			out.Values[i] = ec._CreatePlanPlaceCategorySet_displayNameEn(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "categories":
+			out.Values[i] = ec._CreatePlanPlaceCategorySet_categories(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var deletePlaceFromPlanCandidateOutputImplementors = []string{"DeletePlaceFromPlanCandidateOutput"}
 
 func (ec *executionContext) _DeletePlaceFromPlanCandidateOutput(ctx context.Context, sel ast.SelectionSet, obj *model.DeletePlaceFromPlanCandidateOutput) graphql.Marshaler {
@@ -17300,6 +17522,60 @@ func (ec *executionContext) marshalNCreatePlanPlaceCategory2ᚖporotoᚗappᚋpo
 		return graphql.Null
 	}
 	return ec._CreatePlanPlaceCategory(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCreatePlanPlaceCategorySet2ᚕᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategorySetᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CreatePlanPlaceCategorySet) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNCreatePlanPlaceCategorySet2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategorySet(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNCreatePlanPlaceCategorySet2ᚖporotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐCreatePlanPlaceCategorySet(ctx context.Context, sel ast.SelectionSet, v *model.CreatePlanPlaceCategorySet) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreatePlanPlaceCategorySet(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeletePlaceFromPlanCandidateInput2porotoᚗappᚋporotoᚋplannerᚋinternalᚋinterfaceᚋgraphqlᚋmodelᚐDeletePlaceFromPlanCandidateInput(ctx context.Context, v interface{}) (model.DeletePlaceFromPlanCandidateInput, error) {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -133,6 +133,12 @@ type CreatePlanPlaceCategory struct {
 	ImageURL      string `json:"imageUrl"`
 }
 
+type CreatePlanPlaceCategorySet struct {
+	DisplayNameJa string                     `json:"displayNameJa"`
+	DisplayNameEn string                     `json:"displayNameEn"`
+	Categories    []*CreatePlanPlaceCategory `json:"categories"`
+}
+
 type DeletePlaceFromPlanCandidateInput struct {
 	PlanCandidateID string `json:"planCandidateId"`
 	PlanID          string `json:"planId"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -67,7 +67,7 @@ type ChangePlacesOrderInPlanCandidateOutput struct {
 
 type CreatePlanByCategoryInput struct {
 	Session    string   `json:"session"`
-	Category   string   `json:"category"`
+	CategoryID string   `json:"categoryId"`
 	Latitude   *float64 `json:"latitude,omitempty"`
 	Longitude  *float64 `json:"longitude,omitempty"`
 	RadiusInKm *float64 `json:"radiusInKm,omitempty"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -66,11 +66,11 @@ type ChangePlacesOrderInPlanCandidateOutput struct {
 }
 
 type CreatePlanByCategoryInput struct {
-	Session    string   `json:"session"`
-	CategoryID string   `json:"categoryId"`
-	Latitude   *float64 `json:"latitude,omitempty"`
-	Longitude  *float64 `json:"longitude,omitempty"`
-	RadiusInKm *float64 `json:"radiusInKm,omitempty"`
+	Session    string  `json:"session"`
+	CategoryID string  `json:"categoryId"`
+	Latitude   float64 `json:"latitude"`
+	Longitude  float64 `json:"longitude"`
+	RadiusInKm float64 `json:"radiusInKm"`
 }
 
 type CreatePlanByCategoryOutput struct {

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -66,7 +66,6 @@ type ChangePlacesOrderInPlanCandidateOutput struct {
 }
 
 type CreatePlanByCategoryInput struct {
-	Session    string  `json:"session"`
 	CategoryID string  `json:"categoryId"`
 	Latitude   float64 `json:"latitude"`
 	Longitude  float64 `json:"longitude"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -65,6 +65,19 @@ type ChangePlacesOrderInPlanCandidateOutput struct {
 	Plan *Plan `json:"plan"`
 }
 
+type CreatePlanByCategoryInput struct {
+	Session    string   `json:"session"`
+	Category   string   `json:"category"`
+	Latitude   *float64 `json:"latitude,omitempty"`
+	Longitude  *float64 `json:"longitude,omitempty"`
+	RadiusInKm *float64 `json:"radiusInKm,omitempty"`
+}
+
+type CreatePlanByCategoryOutput struct {
+	PlanCandidateSetID string  `json:"planCandidateSetId"`
+	Plans              []*Plan `json:"plans"`
+}
+
 type CreatePlanByGooglePlaceIDInput struct {
 	PlanCandidateID     *string  `json:"planCandidateId,omitempty"`
 	GooglePlaceID       string   `json:"googlePlaceId"`

--- a/internal/interface/graphql/model/models_gen.go
+++ b/internal/interface/graphql/model/models_gen.go
@@ -126,6 +126,13 @@ type CreatePlanCandidateSetFromSavedPlanOutput struct {
 	PlanCandidate *PlanCandidate `json:"planCandidate"`
 }
 
+type CreatePlanPlaceCategory struct {
+	ID            string `json:"id"`
+	DisplayNameJa string `json:"displayNameJa"`
+	DisplayNameEn string `json:"displayNameEn"`
+	ImageURL      string `json:"imageUrl"`
+}
+
 type DeletePlaceFromPlanCandidateInput struct {
 	PlanCandidateID string `json:"planCandidateId"`
 	PlanID          string `json:"planId"`

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -7,6 +7,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"poroto.app/poroto/planner/internal/domain/array"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -106,7 +107,66 @@ func (r *mutationResolver) CreatePlanByPlace(ctx context.Context, input model.Cr
 
 // CreatePlanByCategory is the resolver for the createPlanByCategory field.
 func (r *mutationResolver) CreatePlanByCategory(ctx context.Context, input model.CreatePlanByCategoryInput) (*model.CreatePlanByCategoryOutput, error) {
-	panic(fmt.Errorf("not implemented: CreatePlanByCategory - createPlanByCategory"))
+	r.Logger.Info(
+		"CreatePlanByCategory",
+		zap.String("category", input.CategoryID),
+		zap.Float64("latitude", input.Latitude),
+		zap.Float64("longitude", input.Longitude),
+		zap.Float64("radius", input.RadiusInKm),
+	)
+
+	planCandidateSetId := uuid.New().String()
+	if err := r.PlanCandidateService.CreatePlanCandidateSet(ctx, planCandidateSetId); err != nil {
+		r.Logger.Error("error while creating plan candidate", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	category, ok := array.Find(
+		array.FlatMap(models.GetAllLocationCategorySetCreatePlan(), func(s models.LocationCategorySetCreatePlan) []models.LocationCategoryCreatePlan {
+			return s.Categories
+		}),
+		func(c models.LocationCategoryCreatePlan) bool {
+			return c.Id == input.CategoryID
+		},
+	)
+	if !ok {
+		r.Logger.Error("invalid category id", zap.String("category", input.CategoryID))
+		return nil, fmt.Errorf("invalid category id")
+	}
+
+	plans, err := r.PlanGenService.CreatePlanByCategory(
+		ctx,
+		plangen.CreatePlanByCategoryInput{
+			PlanCandidateSetId: planCandidateSetId,
+			Category:           category,
+			Location: models.GeoLocation{
+				Latitude:  input.Latitude,
+				Longitude: input.Longitude,
+			},
+			RadiusInKm: input.RadiusInKm,
+		},
+	)
+	if err != nil {
+		r.Logger.Error("error while creating plan by category", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	if err := r.PlanCandidateService.SavePlans(ctx, plancandidate.SavePlansInput{
+		PlanCandidateSetId: planCandidateSetId,
+		Plans:              *plans,
+		LocationStart: &models.GeoLocation{
+			Latitude:  input.Latitude,
+			Longitude: input.Longitude,
+		},
+		CategoryNamesPreferred: &[]string{category.Id},
+	}); err != nil {
+		r.Logger.Error("error while saving plans", zap.Error(err))
+	}
+
+	return &model.CreatePlanByCategoryOutput{
+		PlanCandidateSetID: planCandidateSetId,
+		Plans:              factory.PlansFromDomainModel(plans, nil),
+	}, nil
 }
 
 // CreatePlanCandidateSetFromSavedPlan is the resolver for the createPlanCandidateSetFromSavedPlan field.

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -104,6 +104,11 @@ func (r *mutationResolver) CreatePlanByPlace(ctx context.Context, input model.Cr
 	}, nil
 }
 
+// CreatePlanByCategory is the resolver for the createPlanByCategory field.
+func (r *mutationResolver) CreatePlanByCategory(ctx context.Context, input model.CreatePlanByCategoryInput) (*model.CreatePlanByCategoryOutput, error) {
+	panic(fmt.Errorf("not implemented: CreatePlanByCategory - createPlanByCategory"))
+}
+
 // CreatePlanCandidateSetFromSavedPlan is the resolver for the createPlanCandidateSetFromSavedPlan field.
 func (r *mutationResolver) CreatePlanCandidateSetFromSavedPlan(ctx context.Context, input model.CreatePlanCandidateSetFromSavedPlanInput) (*model.CreatePlanCandidateSetFromSavedPlanOutput, error) {
 	r.Logger.Info(

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -106,6 +106,11 @@ func (r *queryResolver) AvailablePlacesForPlan(ctx context.Context, input model.
 	}, nil
 }
 
+// PlaceCategories is the resolver for the placeCategories field.
+func (r *queryResolver) PlaceCategories(ctx context.Context) ([]*model.CreatePlanPlaceCategory, error) {
+	panic(fmt.Errorf("not implemented: PlaceCategories - placeCategories"))
+}
+
 // PlacesToAddForPlanCandidate is the resolver for the placesToAddForPlanCandidate field.
 func (r *queryResolver) PlacesToAddForPlanCandidate(ctx context.Context, input model.PlacesToAddForPlanCandidateInput) (*model.PlacesToAddForPlanCandidateOutput, error) {
 	// TODO: 指定されたプランIDが不正だった場合の対処をする

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -107,7 +107,7 @@ func (r *queryResolver) AvailablePlacesForPlan(ctx context.Context, input model.
 }
 
 // PlaceCategories is the resolver for the placeCategories field.
-func (r *queryResolver) PlaceCategories(ctx context.Context) ([]*model.CreatePlanPlaceCategory, error) {
+func (r *queryResolver) PlaceCategories(ctx context.Context) ([]*model.CreatePlanPlaceCategorySet, error) {
 	panic(fmt.Errorf("not implemented: PlaceCategories - placeCategories"))
 }
 

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -108,7 +108,25 @@ func (r *queryResolver) AvailablePlacesForPlan(ctx context.Context, input model.
 
 // PlaceCategories is the resolver for the placeCategories field.
 func (r *queryResolver) PlaceCategories(ctx context.Context) ([]*model.CreatePlanPlaceCategorySet, error) {
-	panic(fmt.Errorf("not implemented: PlaceCategories - placeCategories"))
+	r.Logger.Info("PlaceCategories")
+	graphqlCreatePlanPlaceCategorySet := array.Map(
+		models.GetAllLocationCategorySetCreatePlan(),
+		func(categorySet models.LocationCategorySetCreatePlan) *model.CreatePlanPlaceCategorySet {
+			return &model.CreatePlanPlaceCategorySet{
+				DisplayNameJa: categorySet.DisplayNameJa,
+				DisplayNameEn: categorySet.DisplayNameEn,
+				Categories: array.Map(categorySet.Categories, func(category models.LocationCategoryCreatePlan) *model.CreatePlanPlaceCategory {
+					return &model.CreatePlanPlaceCategory{
+						ID:            category.Id,
+						DisplayNameJa: category.DisplayNameJa,
+						DisplayNameEn: category.DisplayNameEn,
+						ImageURL:      category.Image,
+					}
+				}),
+			}
+		},
+	)
+	return graphqlCreatePlanPlaceCategorySet, nil
 }
 
 // PlacesToAddForPlanCandidate is the resolver for the placesToAddForPlanCandidate field.

--- a/internal/interface/graphql/resolver/user_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/user_mutation.resolvers.go
@@ -6,14 +6,14 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/friendsofgo/errors"
-	"poroto.app/poroto/planner/internal/apperrors"
-	"poroto.app/poroto/planner/internal/domain/utils"
-	gcontext "poroto.app/poroto/planner/internal/interface/graphql/context"
 
 	"go.uber.org/zap"
+	"poroto.app/poroto/planner/internal/apperrors"
 	"poroto.app/poroto/planner/internal/domain/services/user"
+	"poroto.app/poroto/planner/internal/domain/utils"
+	gcontext "poroto.app/poroto/planner/internal/interface/graphql/context"
 	"poroto.app/poroto/planner/internal/interface/graphql/factory"
 	"poroto.app/poroto/planner/internal/interface/graphql/model"
 )

--- a/internal/interface/graphql/schema/place_type.graphqls
+++ b/internal/interface/graphql/schema/place_type.graphqls
@@ -39,6 +39,12 @@ type PlaceCategory {
     name: String!
 }
 
+type CreatePlanPlaceCategorySet {
+    displayNameJa: String!
+    displayNameEn: String!
+    categories: [CreatePlanPlaceCategory!]!
+}
+
 type CreatePlanPlaceCategory {
     id: String!
     displayNameJa: String!

--- a/internal/interface/graphql/schema/place_type.graphqls
+++ b/internal/interface/graphql/schema/place_type.graphqls
@@ -39,6 +39,13 @@ type PlaceCategory {
     name: String!
 }
 
+type CreatePlanPlaceCategory {
+    id: String!
+    displayNameJa: String!
+    displayNameEn: String!
+    imageUrl: String!
+}
+
 type CategoryGroupedPlaces {
     category: PlaceCategory!
     places: [Place!]!

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -6,6 +6,8 @@ extend type Mutation {
 
     createPlanByPlace(input: CreatePlanByPlaceInput!): CreatePlanByPlaceOutput!
 
+    createPlanByCategory(input: CreatePlanByCategoryInput!): CreatePlanByCategoryOutput!
+
     # 保存されたプランをベースに新しいプランを作成する
     createPlanCandidateSetFromSavedPlan(input: CreatePlanCandidateSetFromSavedPlanInput!): CreatePlanCandidateSetFromSavedPlanOutput!
 
@@ -57,6 +59,19 @@ input CreatePlanByPlaceInput {
 type CreatePlanByPlaceOutput {
     session: String!
     plan: Plan!
+}
+
+input CreatePlanByCategoryInput {
+    session: String!
+    category: String!
+    latitude: Float
+    longitude: Float
+    radiusInKm: Float
+}
+
+type CreatePlanByCategoryOutput {
+    planCandidateSetId: String!
+    plans: [Plan!]!
 }
 
 input CreatePlanByGooglePlaceIdInput {

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -62,7 +62,6 @@ type CreatePlanByPlaceOutput {
 }
 
 input CreatePlanByCategoryInput {
-    session: String!
     categoryId: String!
     latitude: Float!
     longitude: Float!

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -63,7 +63,7 @@ type CreatePlanByPlaceOutput {
 
 input CreatePlanByCategoryInput {
     session: String!
-    category: String!
+    categoryId: String!
     latitude: Float
     longitude: Float
     radiusInKm: Float

--- a/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_mutation.graphqls
@@ -64,9 +64,9 @@ type CreatePlanByPlaceOutput {
 input CreatePlanByCategoryInput {
     session: String!
     categoryId: String!
-    latitude: Float
-    longitude: Float
-    radiusInKm: Float
+    latitude: Float!
+    longitude: Float!
+    radiusInKm: Float!
 }
 
 type CreatePlanByCategoryOutput {

--- a/internal/interface/graphql/schema/plan_candidate_query.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_query.graphqls
@@ -6,7 +6,7 @@ extend type Query {
     # プランを作成可能な他の場所を取得する
     availablePlacesForPlan(input: AvailablePlacesForPlanInput!): AvailablePlacesForPlan!
 
-    placeCategories: [CreatePlanPlaceCategory!]!
+    placeCategories: [CreatePlanPlaceCategorySet!]!
 
     # ===========================================================
     # Edit

--- a/internal/interface/graphql/schema/plan_candidate_query.graphqls
+++ b/internal/interface/graphql/schema/plan_candidate_query.graphqls
@@ -6,6 +6,8 @@ extend type Query {
     # プランを作成可能な他の場所を取得する
     availablePlacesForPlan(input: AvailablePlacesForPlanInput!): AvailablePlacesForPlan!
 
+    placeCategories: [CreatePlanPlaceCategory!]!
+
     # ===========================================================
     # Edit
     # ===========================================================


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 場所を指定せずにカテゴリからプランを作成できるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #564 
### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- トップページからカテゴリに基づいてプランを作成できるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] カテゴリを指定してプランを作成できることを確認(Postman)

```shell
# planner
export BRANCH_PLANNER=feature/create_plan_from_category
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```