### PR TITLE
カテゴリからプランを作成したときの情報を保存・取得できるようにする

### DIFF
--- a/internal/domain/models/plan_candidate_meta_data.go
+++ b/internal/domain/models/plan_candidate_meta_data.go
@@ -7,13 +7,21 @@ type PlanCandidateMetaData struct {
 	CategoriesRejected            *[]LocationCategory
 	LocationStart                 *GeoLocation
 	FreeTime                      *int
+	CreateByCategoryMetaData      *CreateByCategoryMetaData
+}
+
+type CreateByCategoryMetaData struct {
+	Category   LocationCategoryCreatePlan
+	Location   GeoLocation
+	RadiusInKm float64
 }
 
 func (p PlanCandidateMetaData) IsZero() bool {
 	return p.CategoriesPreferred == nil &&
 		p.CategoriesRejected == nil &&
 		p.LocationStart == nil &&
-		p.FreeTime == nil
+		p.FreeTime == nil &&
+		p.CreateByCategoryMetaData == nil
 }
 
 func (p PlanCandidateMetaData) GetLocationStart() *GeoLocation {

--- a/internal/domain/services/plancandidate/save_plans.go
+++ b/internal/domain/services/plancandidate/save_plans.go
@@ -14,6 +14,7 @@ type SavePlansInput struct {
 	CategoryNamesRejected        *[]string
 	FreeTime                     *int
 	CreateBasedOnCurrentLocation bool
+	CreateByCategoryMetaData     *models.CreateByCategoryMetaData
 }
 
 // SavePlans 作成されたプランとプラン候補のメタデータを保存する
@@ -54,6 +55,7 @@ func (s Service) SavePlans(ctx context.Context, input SavePlansInput) (err error
 		CategoriesRejected:            categoriesDisliked,
 		FreeTime:                      input.FreeTime,
 		CreatedBasedOnCurrentLocation: input.CreateBasedOnCurrentLocation,
+		CreateByCategoryMetaData:      input.CreateByCategoryMetaData,
 	}); err != nil {
 		return fmt.Errorf("error while updating plan candidate metadata: %v\n", err)
 	}

--- a/internal/infrastructure/rdb/factory/plan_candidate_set.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate_set.go
@@ -13,12 +13,13 @@ func NewPlanCandidateSetFromEntity(
 	planCandidateSlice generated.PlanCandidateSlice,
 	planCandidateSetMetaDataSlice generated.PlanCandidateSetMetaDatumSlice,
 	planCandidateSetCategorySlice generated.PlanCandidateSetMetaDataCategorySlice,
+	planCandidateSetMetaDataCreateByCategory generated.PlanCandidateSetMetaDataCreateByCategorySlice,
 	planCandidatePlaces generated.PlanCandidatePlaceSlice,
 	planCandidateSetLikePlaceSlice generated.PlanCandidateSetLikePlaceSlice,
 	places []models.Place,
 	author *models.User,
 ) (*models.PlanCandidateSet, error) {
-	planCandidateSetMetaData, err := NewPlanCandidateMetaDataFromEntity(planCandidateSetMetaDataSlice, planCandidateSetCategorySlice, planCandidateSetEntity.ID)
+	planCandidateSetMetaData, err := NewPlanCandidateMetaDataFromEntity(planCandidateSetMetaDataSlice, planCandidateSetCategorySlice, planCandidateSetMetaDataCreateByCategory, planCandidateSetEntity.ID)
 	if err != nil {
 		// PlanCandidateSetMetaDataがない場合はエラーにしない
 		logger, err := utils.NewLogger(utils.LoggerOption{

--- a/internal/infrastructure/rdb/factory/plan_candidate_set_meta_data.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate_set_meta_data.go
@@ -23,6 +23,7 @@ func NewPlanCandidateMetaDataFromDomainModel(planCandidateSetMetaData models.Pla
 func NewPlanCandidateMetaDataFromEntity(
 	planCandidateSetMetaDataSlice generated.PlanCandidateSetMetaDatumSlice,
 	planCandidateSetCategorySlice generated.PlanCandidateSetMetaDataCategorySlice,
+	planCandidateSetMetaDataCreateByCategory generated.PlanCandidateSetMetaDataCreateByCategorySlice,
 	planCandidateSetId string,
 ) (*models.PlanCandidateMetaData, error) {
 	planCandidateSetMetaData, ok := array.Find(planCandidateSetMetaDataSlice, func(planCandidateSetMetaData *generated.PlanCandidateSetMetaDatum) bool {
@@ -43,6 +44,7 @@ func NewPlanCandidateMetaDataFromEntity(
 			Latitude:  planCandidateSetMetaData.LatitudeStart,
 			Longitude: planCandidateSetMetaData.LongitudeStart,
 		},
-		FreeTime: planCandidateSetMetaData.PlanDurationMinutes.Ptr(),
+		FreeTime:                 planCandidateSetMetaData.PlanDurationMinutes.Ptr(),
+		CreateByCategoryMetaData: newPlanCandidateSetMetaDataCreateByCategoryFromEntry(planCandidateSetMetaDataCreateByCategory),
 	}, nil
 }

--- a/internal/infrastructure/rdb/factory/plan_candidate_set_meta_data_create_by_category.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate_set_meta_data_create_by_category.go
@@ -1,0 +1,18 @@
+package factory
+
+import (
+	"github.com/google/uuid"
+	"poroto.app/poroto/planner/internal/domain/models"
+	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
+)
+
+func NewPlanCandidateMetaDataCreateByCategoryFromDomainModel(planCandidateSetId string, createByPlanMetaData models.CreateByCategoryMetaData) generated.PlanCandidateSetMetaDataCreateByCategory {
+	return generated.PlanCandidateSetMetaDataCreateByCategory{
+		ID:                 uuid.New().String(),
+		PlanCandidateSetID: planCandidateSetId,
+		CategoryID:         createByPlanMetaData.Category.Id,
+		Latitude:           createByPlanMetaData.Location.Latitude,
+		Longitude:          createByPlanMetaData.Location.Longitude,
+		RangeInMeters:      int(createByPlanMetaData.RadiusInKm * 1000),
+	}
+}

--- a/internal/infrastructure/rdb/factory/plan_candidate_set_meta_data_create_by_category.go
+++ b/internal/infrastructure/rdb/factory/plan_candidate_set_meta_data_create_by_category.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"github.com/google/uuid"
+	"poroto.app/poroto/planner/internal/domain/array"
 	"poroto.app/poroto/planner/internal/domain/models"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
 )
@@ -14,5 +15,35 @@ func NewPlanCandidateMetaDataCreateByCategoryFromDomainModel(planCandidateSetId 
 		Latitude:           createByPlanMetaData.Location.Latitude,
 		Longitude:          createByPlanMetaData.Location.Longitude,
 		RangeInMeters:      int(createByPlanMetaData.RadiusInKm * 1000),
+	}
+}
+
+func newPlanCandidateSetMetaDataCreateByCategoryFromEntry(planCandidateSetMetaDataCreateByCategorySlice generated.PlanCandidateSetMetaDataCreateByCategorySlice) *models.CreateByCategoryMetaData {
+	if len(planCandidateSetMetaDataCreateByCategorySlice) == 0 {
+		return nil
+	}
+
+	category, found := array.Find(
+		array.FlatMap(
+			models.GetAllLocationCategorySetCreatePlan(),
+			func(categorySetCreatePlan models.LocationCategorySetCreatePlan) []models.LocationCategoryCreatePlan {
+				return categorySetCreatePlan.Categories
+			},
+		),
+		func(category models.LocationCategoryCreatePlan) bool {
+			return category.Id == planCandidateSetMetaDataCreateByCategorySlice[0].CategoryID
+		},
+	)
+	if !found {
+		return nil
+	}
+
+	return &models.CreateByCategoryMetaData{
+		Category: category,
+		Location: models.GeoLocation{
+			Latitude:  planCandidateSetMetaDataCreateByCategorySlice[0].Latitude,
+			Longitude: planCandidateSetMetaDataCreateByCategorySlice[0].Longitude,
+		},
+		RadiusInKm: float64(planCandidateSetMetaDataCreateByCategorySlice[0].RangeInMeters) / 1000,
 	}
 }

--- a/internal/infrastructure/rdb/mock_test.go
+++ b/internal/infrastructure/rdb/mock_test.go
@@ -135,6 +135,13 @@ func savePlanCandidateSet(ctx context.Context, db *sql.DB, planCandidateSet mode
 				}
 			}
 		}
+
+		if planCandidateSet.MetaData.CreateByCategoryMetaData != nil {
+			planCandidateSetMetaDataCreateByCategoryEntity := factory.NewPlanCandidateMetaDataCreateByCategoryFromDomainModel(planCandidateSet.Id, *planCandidateSet.MetaData.CreateByCategoryMetaData)
+			if err := planCandidateSetMetaDataCreateByCategoryEntity.Insert(ctx, db, boil.Infer()); err != nil {
+				return fmt.Errorf("failed to insert plan candidate set meta data create by category: %v", err)
+			}
+		}
 	}
 
 	// PlanCandidateを作成

--- a/internal/infrastructure/rdb/plan_candidate.go
+++ b/internal/infrastructure/rdb/plan_candidate.go
@@ -63,6 +63,7 @@ func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateSetId st
 			qm.Load(generated.PlanCandidateSetRels.PlanCandidateSetMetaData),
 			qm.Load(generated.PlanCandidateSetRels.PlanCandidateSetMetaDataCategories),
 			qm.Load(generated.PlanCandidateSetRels.PlanCandidateSetLikePlaces),
+			qm.Load(generated.PlanCandidateSetRels.PlanCandidateSetMetaDataCreateByCategories),
 		},
 		placeQueryModes(generated.PlanCandidateSetRels.PlanCandidatePlaces, generated.PlanCandidatePlaceRels.Place),
 	)...).One(ctx, p.db)
@@ -126,6 +127,7 @@ func (p PlanCandidateRepository) Find(ctx context.Context, planCandidateSetId st
 		planCandidateSetEntity.R.PlanCandidates,
 		planCandidateSetEntity.R.PlanCandidateSetMetaData,
 		planCandidateSetEntity.R.PlanCandidateSetMetaDataCategories,
+		planCandidateSetEntity.R.PlanCandidateSetMetaDataCreateByCategories,
 		planCandidateSetEntity.R.PlanCandidatePlaces,
 		planCandidateSetEntity.R.PlanCandidateSetLikePlaces,
 		places,

--- a/internal/infrastructure/rdb/plan_candidate.go
+++ b/internal/infrastructure/rdb/plan_candidate.go
@@ -389,7 +389,6 @@ func (p PlanCandidateRepository) UpdatePlanCandidateMetaData(ctx context.Context
 			if err := planCandidateSetMetaDataEntity.Insert(ctx, tx, boil.Infer()); err != nil {
 				return fmt.Errorf("failed to insert plan candidate set meta data: %w", err)
 			}
-
 		} else {
 			// 保存されている場合は更新
 			planCandidateMetaDataEntity := factory.NewPlanCandidateMetaDataFromDomainModel(meta, planCandidateId)
@@ -410,6 +409,19 @@ func (p PlanCandidateRepository) UpdatePlanCandidateMetaData(ctx context.Context
 			planCandidateSetMetaDataCategorySlice := factory.NewPlanCandidateSetMetaDataCategorySliceFromDomainModel(meta.CategoriesPreferred, meta.CategoriesRejected, planCandidateId)
 			if _, err := planCandidateSetMetaDataCategorySlice.InsertAll(ctx, tx, boil.Infer()); err != nil {
 				return fmt.Errorf("failed to insert plan candidate set meta data category: %w", err)
+			}
+		}
+
+		// カテゴリからプランを作成した場合の情報を更新
+		if meta.CreateByCategoryMetaData != nil {
+			// すでに保存されている場合は削除
+			if _, err := generated.PlanCandidateSetMetaDataCreateByCategories(generated.PlanCandidateSetMetaDataCreateByCategoryWhere.PlanCandidateSetID.EQ(planCandidateId)).DeleteAll(ctx, tx); err != nil {
+				return fmt.Errorf("failed to get create by category meta data: %w", err)
+			}
+
+			planCandidateSetMetaDataCreateByCategoryEntity := factory.NewPlanCandidateMetaDataCreateByCategoryFromDomainModel(planCandidateId, *meta.CreateByCategoryMetaData)
+			if err := planCandidateSetMetaDataCreateByCategoryEntity.Insert(ctx, tx, boil.Infer()); err != nil {
+				return fmt.Errorf("failed to insert plan candidate set meta data create by category: %w", err)
 			}
 		}
 

--- a/internal/infrastructure/rdb/plan_candidate_test.go
+++ b/internal/infrastructure/rdb/plan_candidate_test.go
@@ -2,6 +2,9 @@ package rdb
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -1067,18 +1070,22 @@ func TestPlanCandidateRepository_UpdatePlacesOrder_ShouldReturnError(t *testing.
 
 func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 	cases := []struct {
-		name                  string
-		planCandidateSetId    string
-		savedPlanCandidateSet models.PlanCandidateSet
-		metaData              models.PlanCandidateMetaData
+		name                                             string
+		planCandidateSetId                               string
+		savedPlanCandidateSet                            generated.PlanCandidateSet
+		savedPlanCandidateSetMetaData                    *generated.PlanCandidateSetMetaDatum
+		savedPlanCandidateSetMetaDataCategorySlice       generated.PlanCandidateSetMetaDataCategorySlice
+		metaData                                         models.PlanCandidateMetaData
+		expectedPlanCandidateSetMetaData                 *generated.PlanCandidateSetMetaDatum
+		expectedPlanCandidateSetMetaDataCategorySlice    generated.PlanCandidateSetMetaDataCategorySlice
+		expectedPlanCandidateSetMetaDataCreateByCategory *generated.PlanCandidateSetMetaDataCreateByCategory
 	}{
 		{
 			name:               "save plan candidate meta data",
 			planCandidateSetId: "test-plan-candidate-set",
-			savedPlanCandidateSet: models.PlanCandidateSet{
-				Id:        "test-plan-candidate-set",
+			savedPlanCandidateSet: generated.PlanCandidateSet{
+				ID:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
-				MetaData:  models.PlanCandidateMetaData{},
 			},
 			metaData: models.PlanCandidateMetaData{
 				CreatedBasedOnCurrentLocation: true,
@@ -1087,19 +1094,52 @@ func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 				LocationStart:                 &models.GeoLocation{Latitude: 35.681236, Longitude: 139.767125},
 				FreeTime:                      utils.ToPointer(60),
 			},
+			expectedPlanCandidateSetMetaData: &generated.PlanCandidateSetMetaDatum{
+				PlanCandidateSetID:           "test-plan-candidate-set",
+				LatitudeStart:                35.681236,
+				LongitudeStart:               139.767125,
+				IsCreatedFromCurrentLocation: true,
+				PlanDurationMinutes:          null.IntFrom(60),
+			},
+			expectedPlanCandidateSetMetaDataCategorySlice: generated.PlanCandidateSetMetaDataCategorySlice{
+				{
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategoryRestaurant.Name,
+					IsSelected:         true,
+				},
+				{
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategorySpa.Name,
+					IsSelected:         false,
+				},
+			},
 		},
 		{
 			name:               "update plan candidate meta data",
 			planCandidateSetId: "test-plan-candidate-set",
-			savedPlanCandidateSet: models.PlanCandidateSet{
-				Id:        "test-plan-candidate-set",
+			savedPlanCandidateSet: generated.PlanCandidateSet{
+				ID:        "test-plan-candidate-set",
 				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
-				MetaData: models.PlanCandidateMetaData{
-					CreatedBasedOnCurrentLocation: false,
-					CategoriesPreferred:           &[]models.LocationCategory{models.CategoryRestaurant},
-					CategoriesRejected:            &[]models.LocationCategory{models.CategorySpa},
-					LocationStart:                 &models.GeoLocation{Latitude: 35.681236, Longitude: 139.767125},
-					FreeTime:                      utils.ToPointer(60),
+			},
+			savedPlanCandidateSetMetaData: &generated.PlanCandidateSetMetaDatum{
+				PlanCandidateSetID:           "test-plan-candidate-set",
+				LatitudeStart:                35.681236,
+				LongitudeStart:               139.767125,
+				IsCreatedFromCurrentLocation: false,
+				PlanDurationMinutes:          null.IntFrom(60),
+			},
+			savedPlanCandidateSetMetaDataCategorySlice: generated.PlanCandidateSetMetaDataCategorySlice{
+				{
+					ID:                 uuid.New().String(),
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategoryRestaurant.Name,
+					IsSelected:         true,
+				},
+				{
+					ID:                 uuid.New().String(),
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategorySpa.Name,
+					IsSelected:         false,
 				},
 			},
 			metaData: models.PlanCandidateMetaData{
@@ -1108,6 +1148,66 @@ func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 				CategoriesRejected:            &[]models.LocationCategory{models.CategoryShopping, models.CategoryAmusements},
 				LocationStart:                 &models.GeoLocation{Latitude: 36.681236, Longitude: 140.767125},
 				FreeTime:                      utils.ToPointer(120),
+			},
+			expectedPlanCandidateSetMetaData: &generated.PlanCandidateSetMetaDatum{
+				PlanCandidateSetID:           "test-plan-candidate-set",
+				LatitudeStart:                36.681236,
+				LongitudeStart:               140.767125,
+				IsCreatedFromCurrentLocation: true,
+				PlanDurationMinutes:          null.IntFrom(120),
+			},
+			expectedPlanCandidateSetMetaDataCategorySlice: generated.PlanCandidateSetMetaDataCategorySlice{
+				{
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategoryRestaurant.Name,
+					IsSelected:         true,
+				},
+				{
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategoryBakery.Name,
+					IsSelected:         true,
+				},
+				{
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategoryAmusements.Name,
+					IsSelected:         false,
+				},
+				{
+					PlanCandidateSetID: "test-plan-candidate-set",
+					Category:           models.CategoryShopping.Name,
+					IsSelected:         false,
+				},
+			},
+		},
+		{
+			name:               "create plan by category",
+			planCandidateSetId: "test-plan-candidate-set",
+			savedPlanCandidateSet: generated.PlanCandidateSet{
+				ID:        "test-plan-candidate-set",
+				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+			},
+			metaData: models.PlanCandidateMetaData{
+				CreatedBasedOnCurrentLocation: true,
+				LocationStart:                 &models.GeoLocation{Latitude: 36.681236, Longitude: 140.767125},
+				CreateByCategoryMetaData: &models.CreateByCategoryMetaData{
+					Category:   models.LocationCategorySetCreatePlanAmusements.Categories[0],
+					Location:   models.GeoLocation{Latitude: 36.681236, Longitude: 140.767125},
+					RadiusInKm: 1,
+				},
+			},
+			expectedPlanCandidateSetMetaData: &generated.PlanCandidateSetMetaDatum{
+				PlanCandidateSetID:           "test-plan-candidate-set",
+				LatitudeStart:                36.681236,
+				LongitudeStart:               140.767125,
+				IsCreatedFromCurrentLocation: true,
+				PlanDurationMinutes:          null.IntFromPtr(nil),
+			},
+			expectedPlanCandidateSetMetaDataCreateByCategory: &generated.PlanCandidateSetMetaDataCreateByCategory{
+				PlanCandidateSetID: "test-plan-candidate-set",
+				CategoryID:         models.LocationCategorySetCreatePlanAmusements.Categories[0].Id,
+				Latitude:           36.681236,
+				Longitude:          140.767125,
+				RangeInMeters:      1000,
 			},
 		},
 	}
@@ -1127,9 +1227,13 @@ func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 				}
 			})
 
-			// 事前にPlanCandidateSetを作成しておく
-			if err := savePlanCandidateSet(testContext, testDB, c.savedPlanCandidateSet); err != nil {
+			// データ準備
+			if err := c.savedPlanCandidateSet.Insert(testContext, testDB, boil.Infer()); err != nil {
 				t.Fatalf("failed to save plan candidate: %v", err)
+			}
+
+			if _, err := c.savedPlanCandidateSetMetaDataCategorySlice.InsertAll(testContext, testDB, boil.Infer()); err != nil {
+				t.Fatalf("failed to save plan candidate set meta data category: %v", err)
 			}
 
 			err := planCandidateRepository.UpdatePlanCandidateMetaData(testContext, c.planCandidateSetId, c.metaData)
@@ -1144,46 +1248,43 @@ func TestPlanCandidateRepository_UpdatePlanCandidateMetaData(t *testing.T) {
 				t.Fatalf("failed to get plan candidate set meta data: %v", err)
 			}
 
-			if planCandidateSetMetaDataEntity.IsCreatedFromCurrentLocation != c.metaData.CreatedBasedOnCurrentLocation {
-				t.Fatalf("wrong is created from current location expected: %v, actual: %v", c.metaData.CreatedBasedOnCurrentLocation, planCandidateSetMetaDataEntity.IsCreatedFromCurrentLocation)
+			if diff := cmp.Diff(
+				c.expectedPlanCandidateSetMetaData,
+				planCandidateSetMetaDataEntity,
+				cmpopts.IgnoreFields(generated.PlanCandidateSetMetaDatum{}, "ID", "CreatedAt", "UpdatedAt"),
+			); diff != "" {
+				t.Fatalf("wrong plan candidate set meta data (-expected, +actual): %v", diff)
 			}
 
-			if planCandidateSetMetaDataEntity.LatitudeStart != c.metaData.LocationStart.Latitude {
-				t.Fatalf("wrong latitude start expected: %v, actual: %v", c.metaData.LocationStart.Latitude, planCandidateSetMetaDataEntity.LatitudeStart)
-			}
-
-			if planCandidateSetMetaDataEntity.LongitudeStart != c.metaData.LocationStart.Longitude {
-				t.Fatalf("wrong longitude start expected: %v, actual: %v", c.metaData.LocationStart.Longitude, planCandidateSetMetaDataEntity.LongitudeStart)
-			}
-
-			if planCandidateSetMetaDataEntity.PlanDurationMinutes.Int != *c.metaData.FreeTime {
-				t.Fatalf("wrong plan duration minutes expected: %v, actual: %v", c.metaData.FreeTime, planCandidateSetMetaDataEntity.PlanDurationMinutes.Int)
-			}
-
-			// CategoriesPreferred が一致する
-			numCategoriesPreferred, err := generated.
-				PlanCandidateSetMetaDataCategories(
-					generated.PlanCandidateSetMetaDataCategoryWhere.PlanCandidateSetID.EQ(c.planCandidateSetId),
-					generated.PlanCandidateSetMetaDataCategoryWhere.IsSelected.EQ(true),
-				).Count(testContext, testDB)
+			// Category が保存されている
+			categories, err := generated.PlanCandidateSetMetaDataCategories(generated.PlanCandidateSetMetaDataCategoryWhere.PlanCandidateSetID.EQ(c.planCandidateSetId)).All(testContext, testDB)
 			if err != nil {
 				t.Fatalf("failed to get plan candidate set meta data categories: %v", err)
 			}
-			if int(numCategoriesPreferred) != len(*c.metaData.CategoriesPreferred) {
-				t.Fatalf("wrong number of plan candidate set meta data categories expected: %v, actual: %v", len(*c.metaData.CategoriesPreferred), numCategoriesPreferred)
+
+			if diff := cmp.Diff(
+				c.expectedPlanCandidateSetMetaDataCategorySlice,
+				categories,
+				cmpopts.SortSlices(func(a, b *generated.PlanCandidateSetMetaDataCategory) bool {
+					return strings.Compare(a.Category, b.Category) < 0
+				}),
+				cmpopts.IgnoreFields(generated.PlanCandidateSetMetaDataCategory{}, "ID", "CreatedAt", "UpdatedAt"),
+			); diff != "" {
+				t.Fatalf("wrong plan candidate set meta data categories (-expected, +actual): %v", diff)
 			}
 
-			// CategoriesRejected が一致する
-			numCategoriesRejected, err := generated.
-				PlanCandidateSetMetaDataCategories(
-					generated.PlanCandidateSetMetaDataCategoryWhere.PlanCandidateSetID.EQ(c.planCandidateSetId),
-					generated.PlanCandidateSetMetaDataCategoryWhere.IsSelected.EQ(false),
-				).Count(testContext, testDB)
-			if err != nil {
-				t.Fatalf("failed to get plan candidate set meta data categories: %v", err)
+			// CreateByCategory が保存されている
+			createByCategoryMetaData, err := generated.PlanCandidateSetMetaDataCreateByCategories(generated.PlanCandidateSetMetaDataCreateByCategoryWhere.PlanCandidateSetID.EQ(c.planCandidateSetId)).One(testContext, testDB)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				t.Fatalf("failed to get plan candidate set meta data create by category: %v", err)
 			}
-			if int(numCategoriesRejected) != len(*c.metaData.CategoriesRejected) {
-				t.Fatalf("wrong number of plan candidate set meta data categories expected: %v, actual: %v", len(*c.metaData.CategoriesRejected), numCategoriesRejected)
+
+			if diff := cmp.Diff(
+				c.expectedPlanCandidateSetMetaDataCreateByCategory,
+				createByCategoryMetaData,
+				cmpopts.IgnoreFields(generated.PlanCandidateSetMetaDataCreateByCategory{}, "ID", "CreatedAt", "UpdatedAt"),
+			); diff != "" {
+				t.Fatalf("wrong plan candidate set meta data create by category (-expected, +actual): %v", diff)
 			}
 		})
 	}

--- a/internal/infrastructure/rdb/plan_candidate_test.go
+++ b/internal/infrastructure/rdb/plan_candidate_test.go
@@ -195,6 +195,38 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 				Plans:           []models.Plan{},
 			},
 		},
+		{
+			name:               "create by category",
+			now:                time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
+			planCandidateSetId: "test",
+			savedPlanCandidateSet: models.PlanCandidateSet{
+				Id:        "test",
+				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				MetaData: models.PlanCandidateMetaData{
+					CreatedBasedOnCurrentLocation: false,
+					LocationStart:                 &models.GeoLocation{Latitude: 139.767125, Longitude: 35.681236},
+					CreateByCategoryMetaData: &models.CreateByCategoryMetaData{
+						Category:   models.LocationCategorySetCreatePlanAmusements.Categories[0],
+						Location:   models.GeoLocation{Latitude: 139.767125, Longitude: 35.681236},
+						RadiusInKm: 1.0,
+					},
+				},
+			},
+			expected: &models.PlanCandidateSet{
+				Id:        "test",
+				ExpiresAt: time.Date(2020, 12, 1, 0, 0, 0, 0, time.Local),
+				Plans:     []models.Plan{},
+				MetaData: models.PlanCandidateMetaData{
+					CreatedBasedOnCurrentLocation: false,
+					LocationStart:                 &models.GeoLocation{Latitude: 139.767125, Longitude: 35.681236},
+					CreateByCategoryMetaData: &models.CreateByCategoryMetaData{
+						Category:   models.LocationCategorySetCreatePlanAmusements.Categories[0],
+						Location:   models.GeoLocation{Latitude: 139.767125, Longitude: 35.681236},
+						RadiusInKm: 1.0,
+					},
+				},
+			},
+		},
 	}
 
 	planCandidateRepository, err := NewPlanCandidateRepository(testDB)
@@ -213,7 +245,7 @@ func TestPlanCandidateRepository_Find(t *testing.T) {
 				}
 			})
 
-			// 事前にデータを準備
+			// データ準備
 			placesInPlanCandidates := array.Flatten(array.Map(c.savedPlanCandidateSet.Plans, func(plan models.Plan) []models.Place { return plan.Places }))
 			if err := savePlaces(testContext, testDB, placesInPlanCandidates); err != nil {
 				t.Fatalf("failed to save places: %v", err)

--- a/internal/infrastructure/rdb/rdb_main_test.go
+++ b/internal/infrastructure/rdb/rdb_main_test.go
@@ -78,6 +78,7 @@ func cleanup(ctx context.Context, db *sql.DB) error {
 		// PlanCandidate
 		generated.PlanCandidateSetLikePlaces(),
 		generated.PlanCandidatePlaces(),
+		generated.PlanCandidateSetMetaDataCreateByCategories(),
 		generated.PlanCandidateSetMetaDataCategories(),
 		generated.PlanCandidateSetMetaData(),
 		generated.PlanCandidates(),

--- a/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_mutation.resolvers.go
@@ -158,7 +158,14 @@ func (r *mutationResolver) CreatePlanByCategory(ctx context.Context, input model
 			Latitude:  input.Latitude,
 			Longitude: input.Longitude,
 		},
-		CategoryNamesPreferred: &[]string{category.Id},
+		CreateByCategoryMetaData: &models.CreateByCategoryMetaData{
+			Category:   category,
+			RadiusInKm: input.RadiusInKm,
+			Location: models.GeoLocation{
+				Latitude:  input.Latitude,
+				Longitude: input.Longitude,
+			},
+		},
 	}); err != nil {
 		r.Logger.Error("error while saving plans", zap.Error(err))
 	}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- カテゴリからプランを作成したときのカテゴリ、範囲等の情報をRDBに保存・取得できるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #571 
- close #572
- #565

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- プラン作成後に、最初に指定した条件にマッチする他の場所を提示できるようにするため

### どのようにテストされているか
- [x] 単体テストを作成
- [x] カテゴリからプランを作成したときの情報が保存されることを確認 
<img width="1466" alt="image" src="https://github.com/poroto-app/planner/assets/55840281/a65ed28c-6656-4398-92e2-44748ae1b367">

```shell
# planner
export BRANCH_PLANNER=feature/plan_candidate_set_from_category
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```