### PR TITLE
他の目的地を取得できるようにする

### DIFF
--- a/internal/domain/services/place/places_destination_for_plan_candidate.go
+++ b/internal/domain/services/place/places_destination_for_plan_candidate.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	desfaultFetchDestinationPlacesForPlanCandidateLimit = 10
+	defaultFetchDestinationPlacesForPlanCandidateLimit = 10
 )
 
 type FetchDestinationPlacesForPlanCandidateInput struct {
@@ -28,7 +28,7 @@ type PlacesForPlanCandidate struct {
 // FetchDestinationPlacesForPlanCandidate カテゴリからプランを作成したときに、その条件をもとに他の目的地を提示する
 func (s Service) FetchDestinationPlacesForPlanCandidate(ctx context.Context, input FetchDestinationPlacesForPlanCandidateInput) (*FetchDestinationPlacesForPlanCandidateOutput, error) {
 	if input.Limit == 0 {
-		input.Limit = desfaultFetchDestinationPlacesForPlanCandidateLimit
+		input.Limit = defaultFetchDestinationPlacesForPlanCandidateLimit
 	}
 
 	planCandidate, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateSetId, time.Now())

--- a/internal/domain/services/place/places_destination_for_plan_candidate.go
+++ b/internal/domain/services/place/places_destination_for_plan_candidate.go
@@ -1,0 +1,68 @@
+package place
+
+import (
+	"context"
+	"poroto.app/poroto/planner/internal/domain/array"
+	"poroto.app/poroto/planner/internal/domain/models"
+	"time"
+)
+
+const (
+	desfaultFetchDestinationPlacesForPlanCandidateLimit = 10
+)
+
+type FetchDestinationPlacesForPlanCandidateInput struct {
+	PlanCandidateSetId string
+	PlanCandidateId    string
+	Limit              int
+}
+
+// FetchDestinationPlacesForPlanCandidate カテゴリからプランを作成したときに、その条件をもとに他の目的地を提示する
+func (s Service) FetchDestinationPlacesForPlanCandidate(ctx context.Context, input FetchDestinationPlacesForPlanCandidateInput) (*[]models.Place, error) {
+	if input.Limit == 0 {
+		input.Limit = desfaultFetchDestinationPlacesForPlanCandidateLimit
+	}
+
+	planCandidate, err := s.planCandidateRepository.Find(ctx, input.PlanCandidateSetId, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	// カテゴリからプランを作成したときのみ取得できるようにする
+	if planCandidate.MetaData.CreateByCategoryMetaData == nil {
+		return &[]models.Place{}, nil
+	}
+
+	googleCategoryTypes := planCandidate.MetaData.CreateByCategoryMetaData.Category.GooglePlaceTypes
+	if len(googleCategoryTypes) == 0 {
+		return &[]models.Place{}, nil
+	}
+
+	placesInPlans := array.FlatMap(planCandidate.Plans, func(plan models.Plan) []models.Place {
+		return plan.Places
+	})
+
+	placesOfCategory, err := s.placeRepository.FindByGooglePlaceType(
+		ctx,
+		googleCategoryTypes[0],
+		planCandidate.MetaData.CreateByCategoryMetaData.Location,
+		planCandidate.MetaData.CreateByCategoryMetaData.RadiusInKm*1000,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// すでにプランに含まれている場所を提示しない
+	placesDestination := array.Filter(*placesOfCategory, func(place models.Place) bool {
+		_, found := array.Find(placesInPlans, func(p models.Place) bool {
+			return p.Id == place.Id
+		})
+		return !found
+	})
+
+	if len(placesDestination) > input.Limit {
+		placesDestination = placesDestination[:input.Limit]
+	}
+
+	return &placesDestination, nil
+}

--- a/internal/domain/services/place/places_destination_for_plan_candidate.go
+++ b/internal/domain/services/place/places_destination_for_plan_candidate.go
@@ -86,6 +86,9 @@ func (s Service) FetchDestinationPlacesForPlanCandidate(ctx context.Context, inp
 		placesDestination = placesDestination[:input.Limit]
 	}
 
+	// 画像を取得
+	placesDestination = s.placeSearchService.FetchPlacesPhotosAndSave(ctx, placesDestination...)
+
 	return &FetchDestinationPlacesForPlanCandidateOutput{
 		PlacesForPlanCandidates: array.Map(planCandidate.Plans, func(plan models.Plan) PlacesForPlanCandidate {
 			return PlacesForPlanCandidate{

--- a/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
+++ b/internal/interface/graphql/resolver/plan_candidate_query.resolvers.go
@@ -214,5 +214,26 @@ func (r *queryResolver) PlacesToReplaceForPlanCandidate(ctx context.Context, inp
 
 // DestinationCandidatePlacesForPlanCandidate is the resolver for the destinationCandidatePlacesForPlanCandidate field.
 func (r *queryResolver) DestinationCandidatePlacesForPlanCandidate(ctx context.Context, input model.DestinationCandidatePlacesForPlanCandidateInput) (*model.DestinationCandidatePlacesForPlanCandidateOutput, error) {
-	panic(fmt.Errorf("not implemented: DestinationCandidatePlacesForPlanCandidate - destinationCandidatePlacesForPlanCandidate"))
+	r.Logger.Info(
+		"DestinationCandidatePlacesForPlanCandidate",
+		zap.String("planCandidateSetId", input.PlanCandidateSetID),
+		zap.String("planId", input.PlanID),
+	)
+
+	places, err := r.PlaceService.FetchDestinationPlacesForPlanCandidate(ctx, place.FetchDestinationPlacesForPlanCandidateInput{
+		PlanCandidateSetId: input.PlanCandidateSetID,
+		PlanCandidateId:    input.PlanID,
+	})
+	if err != nil {
+		r.Logger.Error("error while fetching destination places for plan candidate", zap.Error(err))
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	graphqlPlaces := array.Map(*places, func(place models.Place) *model.Place {
+		return factory.PlaceFromDomainModel(&place)
+	})
+
+	return &model.DestinationCandidatePlacesForPlanCandidateOutput{
+		Places: graphqlPlaces,
+	}, nil
 }


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- カテゴリからプランを作成したときに、その条件をもとに他の目的地を取得する機能を実装した


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #574 
- close #573 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- カテゴリからプランを作成したときに、その他の場所から簡単にプランを作成できるようにするため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] Postmanで他の目的地を取得できることを確認

```shell
# planner
export BRANCH_PLANNER=feature/plan_candate_by_category_places
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```