### PR TITLE
プランを追加したときに、追加されたプランが一覧の最後に追加されるようにする

### DIFF
--- a/internal/infrastructure/rdb/util_test.go
+++ b/internal/infrastructure/rdb/util_test.go
@@ -1,0 +1,9 @@
+package rdb
+
+func arrayFromPointerSlice[T any](values []*T) []T {
+	var array []T
+	for _, value := range values {
+		array = append(array, *value)
+	}
+	return array
+}


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- PlanCandidateSetに含まれるPlanCandidateの順番は`SortOrder`プロパティによって制御されている
- 作成済みのPlanCandidateSetにプランを追加するときに、このプロパティが正しく指定されていないため、デタラメな順番でプランが追加されてしまうバグを修正した


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->


### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] `createPlanByPlace` Mutationを行ったときに、プランが最後に追加されることを確認

```shell
# planner
export BRANCH_PLANNER=feature/XX
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```