### PR TITLE
[Fix] ユーザ投稿の画像を複数の画質で管理できるようにする

### DIFF
--- a/db/migrations/20240703091106_create_place_photo_references_table.sql
+++ b/db/migrations/20240703091106_create_place_photo_references_table.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-START TRANSACTION;
+-- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS place_photo_references
 (
     id         CHAR(36) PRIMARY KEY,
@@ -10,26 +10,31 @@ CREATE TABLE IF NOT EXISTS place_photo_references
     FOREIGN KEY (place_id) REFERENCES places (id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 ALTER TABLE place_photos
     ADD COLUMN place_photo_reference_id CHAR(36) DEFAULT NULL;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 ALTER TABLE place_photos
-    ADD CONSTRAINT fk_place_photos_place_photo_reference_id FOREIGN KEY (place_photo_reference_id) REFERENCES place_photo_references (id);
-COMMIT;
-
+    ADD CONSTRAINT fk_place_photos_place_photo_reference_id FOREIGN KEY (place_photo_reference_id) REFERENCES place_photo_references(id);
+-- +goose StatementEnd
 
 
 
 -- +goose Down
-START TRANSACTION;
+-- +goose StatementBegin
 ALTER TABLE place_photos
     DROP FOREIGN KEY fk_place_photos_place_photo_reference_id;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 ALTER TABLE place_photos
     DROP COLUMN place_photo_reference_id;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 DROP TABLE IF EXISTS place_photo_references;
-COMMIT;
-
-
+-- +goose StatementEnd

--- a/db/migrations/20240703091106_create_place_photo_references_table.sql
+++ b/db/migrations/20240703091106_create_place_photo_references_table.sql
@@ -1,5 +1,5 @@
 -- +goose Up
--- +goose StatementBegin
+START TRANSACTION;
 CREATE TABLE IF NOT EXISTS place_photo_references
 (
     id         CHAR(36) PRIMARY KEY,
@@ -10,33 +10,26 @@ CREATE TABLE IF NOT EXISTS place_photo_references
     FOREIGN KEY (place_id) REFERENCES places (id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
--- +goose StatementEnd
 
--- +goose StatementBegin
 ALTER TABLE place_photos
     ADD COLUMN place_photo_reference_id CHAR(36) DEFAULT NULL;
--- +goose StatementEnd
 
--- +goose StatementBegin
 ALTER TABLE place_photos
     ADD CONSTRAINT fk_place_photos_place_photo_reference_id FOREIGN KEY (place_photo_reference_id) REFERENCES place_photo_references (id);
--- +goose StatementEnd
+COMMIT;
+
 
 
 
 -- +goose Down
--- +goose StatementBegin
+START TRANSACTION;
 ALTER TABLE place_photos
     DROP FOREIGN KEY fk_place_photos_place_photo_reference_id;
--- +goose StatementEnd
 
--- +goose StatementBegin
 ALTER TABLE place_photos
     DROP COLUMN place_photo_reference_id;
--- +goose StatementEnd
 
--- +goose StatementBegin
 DROP TABLE IF EXISTS place_photo_references;
--- +goose StatementEnd
+COMMIT;
 
 

--- a/internal/infrastructure/rdb/generated/users.go
+++ b/internal/infrastructure/rdb/generated/users.go
@@ -94,25 +94,35 @@ var UserWhere = struct {
 
 // UserRels is where relationship names are stored.
 var UserRels = struct {
-	PlacePhotos    string
-	Plans          string
-	UserLikePlaces string
+	PlacePhotoReferences string
+	PlacePhotos          string
+	Plans                string
+	UserLikePlaces       string
 }{
-	PlacePhotos:    "PlacePhotos",
-	Plans:          "Plans",
-	UserLikePlaces: "UserLikePlaces",
+	PlacePhotoReferences: "PlacePhotoReferences",
+	PlacePhotos:          "PlacePhotos",
+	Plans:                "Plans",
+	UserLikePlaces:       "UserLikePlaces",
 }
 
 // userR is where relationships are stored.
 type userR struct {
-	PlacePhotos    PlacePhotoSlice    `boil:"PlacePhotos" json:"PlacePhotos" toml:"PlacePhotos" yaml:"PlacePhotos"`
-	Plans          PlanSlice          `boil:"Plans" json:"Plans" toml:"Plans" yaml:"Plans"`
-	UserLikePlaces UserLikePlaceSlice `boil:"UserLikePlaces" json:"UserLikePlaces" toml:"UserLikePlaces" yaml:"UserLikePlaces"`
+	PlacePhotoReferences PlacePhotoReferenceSlice `boil:"PlacePhotoReferences" json:"PlacePhotoReferences" toml:"PlacePhotoReferences" yaml:"PlacePhotoReferences"`
+	PlacePhotos          PlacePhotoSlice          `boil:"PlacePhotos" json:"PlacePhotos" toml:"PlacePhotos" yaml:"PlacePhotos"`
+	Plans                PlanSlice                `boil:"Plans" json:"Plans" toml:"Plans" yaml:"Plans"`
+	UserLikePlaces       UserLikePlaceSlice       `boil:"UserLikePlaces" json:"UserLikePlaces" toml:"UserLikePlaces" yaml:"UserLikePlaces"`
 }
 
 // NewStruct creates a new relationship struct
 func (*userR) NewStruct() *userR {
 	return &userR{}
+}
+
+func (r *userR) GetPlacePhotoReferences() PlacePhotoReferenceSlice {
+	if r == nil {
+		return nil
+	}
+	return r.PlacePhotoReferences
 }
 
 func (r *userR) GetPlacePhotos() PlacePhotoSlice {
@@ -452,6 +462,20 @@ func (q userQuery) Exists(ctx context.Context, exec boil.ContextExecutor) (bool,
 	return count > 0, nil
 }
 
+// PlacePhotoReferences retrieves all the place_photo_reference's PlacePhotoReferences with an executor.
+func (o *User) PlacePhotoReferences(mods ...qm.QueryMod) placePhotoReferenceQuery {
+	var queryMods []qm.QueryMod
+	if len(mods) != 0 {
+		queryMods = append(queryMods, mods...)
+	}
+
+	queryMods = append(queryMods,
+		qm.Where("`place_photo_references`.`user_id`=?", o.ID),
+	)
+
+	return PlacePhotoReferences(queryMods...)
+}
+
 // PlacePhotos retrieves all the place_photo's PlacePhotos with an executor.
 func (o *User) PlacePhotos(mods ...qm.QueryMod) placePhotoQuery {
 	var queryMods []qm.QueryMod
@@ -492,6 +516,119 @@ func (o *User) UserLikePlaces(mods ...qm.QueryMod) userLikePlaceQuery {
 	)
 
 	return UserLikePlaces(queryMods...)
+}
+
+// LoadPlacePhotoReferences allows an eager lookup of values, cached into the
+// loaded structs of the objects. This is for a 1-M or N-M relationship.
+func (userL) LoadPlacePhotoReferences(ctx context.Context, e boil.ContextExecutor, singular bool, maybeUser interface{}, mods queries.Applicator) error {
+	var slice []*User
+	var object *User
+
+	if singular {
+		var ok bool
+		object, ok = maybeUser.(*User)
+		if !ok {
+			object = new(User)
+			ok = queries.SetFromEmbeddedStruct(&object, &maybeUser)
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", object, maybeUser))
+			}
+		}
+	} else {
+		s, ok := maybeUser.(*[]*User)
+		if ok {
+			slice = *s
+		} else {
+			ok = queries.SetFromEmbeddedStruct(&slice, maybeUser)
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", slice, maybeUser))
+			}
+		}
+	}
+
+	args := make(map[interface{}]struct{})
+	if singular {
+		if object.R == nil {
+			object.R = &userR{}
+		}
+		args[object.ID] = struct{}{}
+	} else {
+		for _, obj := range slice {
+			if obj.R == nil {
+				obj.R = &userR{}
+			}
+			args[obj.ID] = struct{}{}
+		}
+	}
+
+	if len(args) == 0 {
+		return nil
+	}
+
+	argsSlice := make([]interface{}, len(args))
+	i := 0
+	for arg := range args {
+		argsSlice[i] = arg
+		i++
+	}
+
+	query := NewQuery(
+		qm.From(`place_photo_references`),
+		qm.WhereIn(`place_photo_references.user_id in ?`, argsSlice...),
+	)
+	if mods != nil {
+		mods.Apply(query)
+	}
+
+	results, err := query.QueryContext(ctx, e)
+	if err != nil {
+		return errors.Wrap(err, "failed to eager load place_photo_references")
+	}
+
+	var resultSlice []*PlacePhotoReference
+	if err = queries.Bind(results, &resultSlice); err != nil {
+		return errors.Wrap(err, "failed to bind eager loaded slice place_photo_references")
+	}
+
+	if err = results.Close(); err != nil {
+		return errors.Wrap(err, "failed to close results in eager load on place_photo_references")
+	}
+	if err = results.Err(); err != nil {
+		return errors.Wrap(err, "error occurred during iteration of eager loaded relations for place_photo_references")
+	}
+
+	if len(placePhotoReferenceAfterSelectHooks) != 0 {
+		for _, obj := range resultSlice {
+			if err := obj.doAfterSelectHooks(ctx, e); err != nil {
+				return err
+			}
+		}
+	}
+	if singular {
+		object.R.PlacePhotoReferences = resultSlice
+		for _, foreign := range resultSlice {
+			if foreign.R == nil {
+				foreign.R = &placePhotoReferenceR{}
+			}
+			foreign.R.User = object
+		}
+		return nil
+	}
+
+	for _, foreign := range resultSlice {
+		for _, local := range slice {
+			if local.ID == foreign.UserID {
+				local.R.PlacePhotoReferences = append(local.R.PlacePhotoReferences, foreign)
+				if foreign.R == nil {
+					foreign.R = &placePhotoReferenceR{}
+				}
+				foreign.R.User = local
+				break
+			}
+		}
+	}
+
+	return nil
 }
 
 // LoadPlacePhotos allows an eager lookup of values, cached into the
@@ -830,6 +967,59 @@ func (userL) LoadUserLikePlaces(ctx context.Context, e boil.ContextExecutor, sin
 		}
 	}
 
+	return nil
+}
+
+// AddPlacePhotoReferences adds the given related objects to the existing relationships
+// of the user, optionally inserting them as new records.
+// Appends related to o.R.PlacePhotoReferences.
+// Sets related.R.User appropriately.
+func (o *User) AddPlacePhotoReferences(ctx context.Context, exec boil.ContextExecutor, insert bool, related ...*PlacePhotoReference) error {
+	var err error
+	for _, rel := range related {
+		if insert {
+			rel.UserID = o.ID
+			if err = rel.Insert(ctx, exec, boil.Infer()); err != nil {
+				return errors.Wrap(err, "failed to insert into foreign table")
+			}
+		} else {
+			updateQuery := fmt.Sprintf(
+				"UPDATE `place_photo_references` SET %s WHERE %s",
+				strmangle.SetParamNames("`", "`", 0, []string{"user_id"}),
+				strmangle.WhereClause("`", "`", 0, placePhotoReferencePrimaryKeyColumns),
+			)
+			values := []interface{}{o.ID, rel.ID}
+
+			if boil.IsDebug(ctx) {
+				writer := boil.DebugWriterFrom(ctx)
+				fmt.Fprintln(writer, updateQuery)
+				fmt.Fprintln(writer, values)
+			}
+			if _, err = exec.ExecContext(ctx, updateQuery, values...); err != nil {
+				return errors.Wrap(err, "failed to update foreign table")
+			}
+
+			rel.UserID = o.ID
+		}
+	}
+
+	if o.R == nil {
+		o.R = &userR{
+			PlacePhotoReferences: related,
+		}
+	} else {
+		o.R.PlacePhotoReferences = append(o.R.PlacePhotoReferences, related...)
+	}
+
+	for _, rel := range related {
+		if rel.R == nil {
+			rel.R = &placePhotoReferenceR{
+				User: o,
+			}
+		} else {
+			rel.R.User = o
+		}
+	}
 	return nil
 }
 
@@ -2084,6 +2274,33 @@ func (s UserSlice) UpsertAllByPage(ctx context.Context, exec boil.ContextExecuto
 		}
 	}
 	return rowsAffected, nil
+}
+
+// LoadPlacePhotoReferencesByPage performs eager loading of values by page. This is for a 1-M or N-M relationship.
+func (s UserSlice) LoadPlacePhotoReferencesByPage(ctx context.Context, e boil.ContextExecutor, mods ...qm.QueryMod) error {
+	return s.LoadPlacePhotoReferencesByPageEx(ctx, e, DefaultPageSize, mods...)
+}
+func (s UserSlice) LoadPlacePhotoReferencesByPageEx(ctx context.Context, e boil.ContextExecutor, pageSize int, mods ...qm.QueryMod) error {
+	if len(s) == 0 {
+		return nil
+	}
+	for _, chunk := range chunkSlice[*User](s, pageSize) {
+		if err := chunk[0].L.LoadPlacePhotoReferences(ctx, e, false, &chunk, queryMods(mods)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s UserSlice) GetLoadedPlacePhotoReferences() PlacePhotoReferenceSlice {
+	result := make(PlacePhotoReferenceSlice, 0, len(s)*2)
+	for _, item := range s {
+		if item.R == nil || item.R.PlacePhotoReferences == nil {
+			continue
+		}
+		result = append(result, item.R.PlacePhotoReferences...)
+	}
+	return result
 }
 
 // LoadPlacePhotosByPage performs eager loading of values by page. This is for a 1-M or N-M relationship.


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
複数画像を管理するマイグレーションの修正

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
マイグレーションファイルの構文修正

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] マイグレーションの実行・ロールバック

```shell
# planner
export BRANCH_PLANNER=fix/db_place_photo_references
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```