### PR TITLE
[既存データを反映] ユーザ投稿の画像を複数の画質で管理できるようにする

### DIFF
--- a/cmd/features/script_create_place_photo_references_entities/main.go
+++ b/cmd/features/script_create_place_photo_references_entities/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"poroto.app/poroto/planner/internal/env"
+	"poroto.app/poroto/planner/internal/infrastructure/rdb"
+	"poroto.app/poroto/planner/internal/infrastructure/rdb/generated"
+)
+
+func main() {
+	env.LoadEnv()
+
+	db, err := rdb.InitDB(false)
+	if err != nil {
+		log.Fatalf("error while initializing db: %v", err)
+	}
+
+	ctx := context.Background()
+	placePhotoSlice, err := generated.PlacePhotos().All(ctx, db)
+	if err != nil {
+		log.Fatalf("error while fetching place photos: %v", err)
+	}
+	placePhotoReferenceSlice := make(generated.PlacePhotoReferenceSlice, 0, len(placePhotoSlice))
+
+	for _, placePhoto := range placePhotoSlice {
+		placePhotoReference := &generated.PlacePhotoReference{
+			ID:      uuid.New().String(),
+			PlaceID: placePhoto.PlaceID,
+			UserID:  placePhoto.UserID,
+		}
+		placePhotoReferenceSlice = append(placePhotoReferenceSlice, placePhotoReference)
+	}
+
+	if _, err := placePhotoReferenceSlice.InsertAll(ctx, db, boil.Infer()); err != nil {
+		log.Fatalf("error while inserting place photo references: %v", err)
+	}
+}

--- a/cmd/features/script_create_place_photo_references_entities/main.go
+++ b/cmd/features/script_create_place_photo_references_entities/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/google/uuid"
+	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"poroto.app/poroto/planner/internal/env"
 	"poroto.app/poroto/planner/internal/infrastructure/rdb"
@@ -32,10 +33,18 @@ func main() {
 			PlaceID: placePhoto.PlaceID,
 			UserID:  placePhoto.UserID,
 		}
+
+		placePhoto.PlacePhotoReferenceID = null.StringFrom(placePhotoReference.ID)
 		placePhotoReferenceSlice = append(placePhotoReferenceSlice, placePhotoReference)
 	}
 
 	if _, err := placePhotoReferenceSlice.InsertAll(ctx, db, boil.Infer()); err != nil {
 		log.Fatalf("error while inserting place photo references: %v", err)
+	}
+
+	for _, placePhoto := range placePhotoSlice {
+		if _, err := placePhoto.Update(ctx, db, boil.Infer()); err != nil {
+			log.Fatalf("error while updating place photo: %v", err)
+		}
 	}
 }

--- a/cmd/features/script_create_place_photo_references_entities/main.go
+++ b/cmd/features/script_create_place_photo_references_entities/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/google/uuid"
@@ -22,7 +23,9 @@ func main() {
 	}
 
 	ctx := context.Background()
-	placePhotoSliceToUpdate, err := generated.PlacePhotos(qm.Where("place_photo_reference_id is null")).All(ctx, db)
+	placePhotoSliceToUpdate, err := generated.PlacePhotos(
+		qm.Where(fmt.Sprintf("%s is null", generated.PlacePhotoColumns.PlacePhotoReferenceID)),
+	).All(ctx, db)
 	if err != nil {
 		log.Fatalf("error while fetching place photos: %v", err)
 	}
@@ -44,6 +47,7 @@ func main() {
 
 		placePhoto.PlacePhotoReferenceID = null.StringFrom(placePhotoReferenceToSave.ID)
 		placePhotoReferenceSliceToSave = append(placePhotoReferenceSliceToSave, placePhotoReferenceToSave)
+		log.Printf("place photo reference to save: %+v", placePhotoReferenceToSave)
 	}
 
 	if _, err := placePhotoReferenceSliceToSave.InsertAll(ctx, db, boil.Infer()); err != nil {

--- a/cmd/features/script_create_place_photo_references_entities/main.go
+++ b/cmd/features/script_create_place_photo_references_entities/main.go
@@ -51,13 +51,14 @@ func main() {
 		log.Printf("place photo reference to save: %+v", placePhotoReferenceToSave)
 	}
 
-	if err := runTransaction(ctx, db, func(ctx context.Context, tx boil.Transactor) error {
-		if _, err := placePhotoReferenceSliceToSave.InsertAll(ctx, db, boil.Infer()); err != nil {
+	if err := runTransaction(ctx, db, func(ctx context.Context, tx *sql.Tx) error {
+
+		if _, err := placePhotoReferenceSliceToSave.InsertAll(ctx, tx, boil.Infer()); err != nil {
 			log.Fatalf("error while inserting place photo references: %v", err)
 		}
 
 		for _, placePhoto := range placePhotoSliceToUpdate {
-			if _, err := placePhoto.Update(ctx, db, boil.Infer()); err != nil {
+			if _, err := placePhoto.Update(ctx, tx, boil.Infer()); err != nil {
 				log.Fatalf("error while updating place photo: %v", err)
 			}
 		}
@@ -68,7 +69,7 @@ func main() {
 	}
 }
 
-func runTransaction(ctx context.Context, db *sql.DB, f func(ctx context.Context, tx boil.Transactor) error) error {
+func runTransaction(ctx context.Context, db *sql.DB, f func(ctx context.Context, tx *sql.Tx) error) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)


### PR DESCRIPTION
### 修正の概要
<!--　XXの機能を作成した -->
- 既存の`placePhotos`データをもとに、新規テーブル`placePhotoReferences`に相当データを生成

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #580 
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメント追加・修正

### 修正の目的・解決したこと
<!--　YYのパフォーマンスを改善するため -->
- 既存データに複数画質で管理する方法を適用するため

### どのようにテストされているか
- [x] プラン作成できることを確認
- [x] プランを保存できることを確認
- [x] porotoで問題なく動作できることを確認
- [x] スクリプトファイルを実行することでDBに以下が反映されることを確認
 - `placePhotoReferences`が`placePhotos`のデータをもとに生成されること
  ->`place_id`と`user_id`が同等であること
 - `placePhoto.placePhotoReferenceId`が対応する`placePhotoReference.Id`であること  
- [x] 複数回 go run させても`placePhotoReferences`レコードを重複して作成しないことを確認

```shell
# planner
export BRANCH_PLANNER=feature/feature/script_create_place_photo_references_entities
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````
```shell
# poroto
export BRANCH_POROTO=develop
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```